### PR TITLE
Add TEDAPI v1r Mode Support - v0.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,5 @@ sync.sh
 pypowerwall
 pwsimulator
 issues/
+r
+tedapi_rsa_private.pem

--- a/Dockerfile.beta
+++ b/Dockerfile.beta
@@ -1,0 +1,39 @@
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app
+
+# Install all requirements including pypowerwall (to pull in its transitive deps),
+# then install the local pypowerwall's own deps (may be ahead of the pinned release).
+# Copy the local pypowerwall source tree and shadow it via PYTHONPATH.
+COPY requirements.txt .
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        python3-dev \
+        libffi-dev \
+        make \
+        automake \
+        autoconf \
+        libtool && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir \
+        "protobuf>=3.20.0" python-dotenv pyroute2 \
+        python-dateutil requests-oauthlib websocket-client cryptography && \
+    apt-get purge -y gcc python3-dev libffi-dev make automake autoconf libtool && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy local pypowerwall source tree — shadows the pip-installed version via PYTHONPATH
+COPY pypowerwall/ ./pypowerwall/
+
+# Ensure /app is first on the Python path so local pypowerwall/ is imported
+ENV PYTHONPATH=/app
+
+# Copy application
+COPY app/ ./app/
+
+# Expose port
+EXPOSE 8675
+
+# Run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8675"]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ docker run -d \
   jasonacox/pypowerwall-server
 ```
 
+#### TEDAPI v1r Mode (RSA Key Auth)
+```bash
+# TEDAPI v1r uses an RSA-4096 private key instead of the gateway Wi-Fi password.
+# Generate a key pair with pypowerwall, then mount it into the container.
+docker run -d \
+  --name pypowerwall-server \
+  --network host \
+  -e PW_HOST=192.168.91.1 \
+  -e PW_RSA_KEY_PATH=/keys/tedapi_rsa_private.pem \
+  -v /path/to/keys:/keys \
+  jasonacox/pypowerwall-server
+```
+
 #### Cloud Mode (Remote Access)
 
 ```bash
@@ -124,6 +137,13 @@ PW_BIND_ADDRESS=0.0.0.0  # Listen on all interfaces
 PROXY_BASE_URL=/pypowerwall  # Optional: serve under a sub-path (see Reverse Proxy)
 ```
 
+**Single Gateway Mode (TEDAPI v1r — RSA Key Auth):**
+```bash
+PW_HOST=192.168.91.1
+PW_RSA_KEY_PATH=/path/to/tedapi_rsa_private.pem  # RSA-4096 private key (alternative to PW_GW_PWD)
+PW_TIMEZONE=America/Los_Angeles
+```
+
 **Single Gateway Mode (With Cloud Control):**
 ```bash
 PW_HOST=192.168.91.1
@@ -200,17 +220,29 @@ gateways:
     email: user@example.com
     authpath: /auth
     cloud_mode: true
+
+  - id: v1r-gateway
+    name: TEDAPI v1r Gateway
+    host: 192.168.91.1
+    rsa_key_path: /keys/tedapi_rsa_private.pem  # RSA-4096 private key (TEDAPI v1r mode)
+    timezone: America/Los_Angeles
 ```
 
 **Authentication:**
-- `gw_pwd`: For TEDAPI local gateway access
+- `gw_pwd`: For TEDAPI local gateway access (standard mode)
+- `rsa_key_path`: Path to RSA-4096 private key PEM file for TEDAPI v1r LAN access (alternative to `gw_pwd`)
 - `email` + `authpath`: For Tesla Cloud API (control operations)
   - Run `pypowerwall-server --setup` to authenticate and generate auth files
   - Specify directory containing `.pypowerwall.auth` and `.pypowerwall.site` files
 
+**TEDAPI connection modes:**
+- `host` + `gw_pwd` → TEDAPI (standard, uses gateway Wi-Fi password)
+- `host` + `rsa_key_path` → TEDAPI v1r (uses RSA-4096 private key; shown as "TEDAPI v1r" in console)
+
 **Optional fields:**
 - `port`: Non-standard HTTPS port (e.g. `8443`) — use when the gateway is behind a travel router that forwards a custom port to `192.168.91.1:443`
 - `type`: Gateway device type — `powerwall` (default, has batteries) or `inverter` (solar-only; suppresses battery panels in the console)
+- `rsa_key_path`: RSA-4096 private key PEM path for TEDAPI v1r LAN authentication
 
 ### Reverse Proxy / HTTPS Proxy
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ docker run -d \
   --network host \
   -e PW_HOST=192.168.91.1 \
   -e PW_RSA_KEY_PATH=/keys/tedapi_rsa_private.pem \
+  -e PW_WIFI_HOST=192.168.91.1 \
   -v /path/to/keys:/keys \
   jasonacox/pypowerwall-server
 ```
+
+> **Note:** `PW_WIFI_HOST` is the IP address pypowerwall uses for the WiFi fallback path in v1r mode. It defaults to `192.168.91.1`. Only set it if your gateway is on a different IP (e.g. behind a travel router).
 
 #### Cloud Mode (Remote Access)
 
@@ -141,6 +144,7 @@ PROXY_BASE_URL=/pypowerwall  # Optional: serve under a sub-path (see Reverse Pro
 ```bash
 PW_HOST=192.168.91.1
 PW_RSA_KEY_PATH=/path/to/tedapi_rsa_private.pem  # RSA-4096 private key (alternative to PW_GW_PWD)
+PW_WIFI_HOST=192.168.91.1                         # WiFi fallback IP for v1r mode (default: 192.168.91.1)
 PW_TIMEZONE=America/Los_Angeles
 ```
 
@@ -225,6 +229,7 @@ gateways:
     name: TEDAPI v1r Gateway
     host: 192.168.91.1
     rsa_key_path: /keys/tedapi_rsa_private.pem  # RSA-4096 private key (TEDAPI v1r mode)
+    wifi_host: 192.168.91.1                     # WiFi fallback IP (optional, defaults to 192.168.91.1)
     timezone: America/Los_Angeles
 ```
 
@@ -238,11 +243,13 @@ gateways:
 **TEDAPI connection modes:**
 - `host` + `gw_pwd` → TEDAPI (standard, uses gateway Wi-Fi password)
 - `host` + `rsa_key_path` → TEDAPI v1r (uses RSA-4096 private key; shown as "TEDAPI v1r" in console)
+- `wifi_host` → Optional WiFi fallback IP for v1r mode (default `192.168.91.1`; only needed when your gateway is on a non-standard IP)
 
 **Optional fields:**
 - `port`: Non-standard HTTPS port (e.g. `8443`) — use when the gateway is behind a travel router that forwards a custom port to `192.168.91.1:443`
 - `type`: Gateway device type — `powerwall` (default, has batteries) or `inverter` (solar-only; suppresses battery panels in the console)
 - `rsa_key_path`: RSA-4096 private key PEM path for TEDAPI v1r LAN authentication
+- `wifi_host`: WiFi host IP for TEDAPI v1r WiFi fallback (default `192.168.91.1`; set this when your gateway's WiFi AP is on a different subnet, e.g. behind a travel router)
 
 ### Reverse Proxy / HTTPS Proxy
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,18 @@
 
 ## Version History
 
+### [0.2.1] - 2026-03-01
+
+**Added:**
+- `PW_RSA_KEY_PATH` environment variable — path to an RSA-4096 private key PEM file for TEDAPI v1r LAN access (new pypowerwall authentication mode). Supported in single-gateway env-var config and `gateways.yaml` multi-gateway config.
+- Console **Connect Mode** and **Connected Gateways** panels now display `TEDAPI v1r` when `rsa_key_path` is configured, or `TEDAPI` otherwise (previously always showed `TEDAPI`).
+- `Dockerfile.beta` — alternative Dockerfile for beta builds that installs the production `requirements.txt` (for all transitive deps) then shadows the installed `pypowerwall` package with the local source tree via `PYTHONPATH=/app`. Used by `upload.sh` when building a beta release tag.
+
+**Fixed:**
+- **WebSocket disconnected under reverse proxy** — `strip_proxy_prefix` was implemented as `BaseHTTPMiddleware` which only intercepts `scope["type"] == "http"`. WebSocket upgrade connections (`scope["type"] == "websocket"`) bypassed it entirely, leaving the proxy prefix in the path and causing `/pypowerwall/ws/aggregate` to 404. Replaced with a pure ASGI middleware class (`_StripProxyPrefix`) that handles both `http` and `websocket` scope types.
+- Duplicate `favicon()` function names — renamed to `favicon_ico()` and `favicon_png()` to avoid the second definition silently shadowing the first.
+- PR #16 reviewer feedback: removed unused `inject_js` import, fixed `raw_path` byte-slice to preserve percent-encoding, removed dead unreachable `serve_static_prefixed` route, made `openapi_url` proxy-base aware so Swagger/ReDoc work under a sub-path, updated router comment, fixed hardcoded links in root/console fallback HTML, added README nginx CORS wildcard note.
+
 ### [0.2.0] - 2026-02-22
 
 **Added:**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,9 +10,9 @@
 - `Dockerfile.beta` — alternative Dockerfile for beta builds that installs the production `requirements.txt` (for all transitive deps) then shadows the installed `pypowerwall` package with the local source tree via `PYTHONPATH=/app`. Used by `upload.sh` when building a beta release tag.
 
 **Fixed:**
-- **WebSocket disconnected under reverse proxy** — `strip_proxy_prefix` was implemented as `BaseHTTPMiddleware` which only intercepts `scope["type"] == "http"`. WebSocket upgrade connections (`scope["type"] == "websocket"`) bypassed it entirely, leaving the proxy prefix in the path and causing `/pypowerwall/ws/aggregate` to 404. Replaced with a pure ASGI middleware class (`_StripProxyPrefix`) that handles both `http` and `websocket` scope types.
-- Duplicate `favicon()` function names — renamed to `favicon_ico()` and `favicon_png()` to avoid the second definition silently shadowing the first.
-- PR #16 reviewer feedback: removed unused `inject_js` import, fixed `raw_path` byte-slice to preserve percent-encoding, removed dead unreachable `serve_static_prefixed` route, made `openapi_url` proxy-base aware so Swagger/ReDoc work under a sub-path, updated router comment, fixed hardcoded links in root/console fallback HTML, added README nginx CORS wildcard note.
+- `rsa_key_path` excluded from API responses to prevent path disclosure; a safe boolean `rsa_key_configured` is exposed instead (#17).
+- `upload.sh` trap used `-d` to test for the `pypowerwall_symlink` cleanup target — changed to `-L` so it correctly detects a symlink even if its target is temporarily missing (#17).
+- `upload.sh` now checks that the `pypowerwall/` source tree exists before attempting a beta build, exiting with a clear error message if it is absent (#17).
 
 ### [0.2.0] - 2026-02-22
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## Version History
 
-### [0.2.1] - 2026-03-01
+### [0.2.2] - 2026-03-04
 
 **Added:**
 - `PW_RSA_KEY_PATH` environment variable — path to an RSA-4096 private key PEM file for TEDAPI v1r LAN access (new pypowerwall authentication mode). Supported in single-gateway env-var config and `gateways.yaml` multi-gateway config.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,8 +8,11 @@
 - `PW_RSA_KEY_PATH` environment variable — path to an RSA-4096 private key PEM file for TEDAPI v1r LAN access (new pypowerwall authentication mode). Supported in single-gateway env-var config and `gateways.yaml` multi-gateway config.
 - Console **Connect Mode** and **Connected Gateways** panels now display `TEDAPI v1r` when `rsa_key_path` is configured, or `TEDAPI` otherwise (previously always showed `TEDAPI`).
 - `Dockerfile.beta` — alternative Dockerfile for beta builds that installs the production `requirements.txt` (for all transitive deps) then shadows the installed `pypowerwall` package with the local source tree via `PYTHONPATH=/app`. Used by `upload.sh` when building a beta release tag.
+- Hybrid TEDAPI + cloud control for write operations — when TEDAPI is available, control commands (charge limit, operation mode) fall back to cloud if the TEDAPI write fails, ensuring reliable control across LAN and cloud paths (#19). Thanks @lemassykoi!
 
 **Fixed:**
+- Poll operation mode on every background cycle so the cached value stays current; corrected Docker healthcheck to use the correct endpoint (#14, #15). Thanks @jasonacox-sam!
+- `pwModel()` incorrectly identified part number 3012170 as Powerwall 3 — corrected to Powerwall 2/2+ (#25). Thanks @jasonacox-sam!
 - `rsa_key_path` excluded from API responses to prevent path disclosure; a safe boolean `rsa_key_configured` is exposed instead (#17).
 - `upload.sh` trap used `-d` to test for the `pypowerwall_symlink` cleanup target — changed to `-L` so it correctly detects a symlink even if its target is temporarily missing (#17).
 - `upload.sh` now checks that the `pypowerwall/` source tree exists before attempting a beta build, exiting with a clear error message if it is absent (#17).

--- a/app/config.py
+++ b/app/config.py
@@ -65,16 +65,16 @@ Environment Variables (Proxy Compatible):
         PW_CACHE_FILE        - Cache file path (default: auto - uses PW_AUTH_PATH/.powerwall or /tmp/.powerwall)
         PW_SITEID            - Tesla site ID for multi-site accounts (default: none)
         PW_CONTROL_SECRET    - Enable control commands (default: none/disabled)
-        PW_NEG_SOLAR         - Allow negative solar values "yes"/"no" (default: "no")
-        PROXY_BASE_URL       - Base URL for reverse proxy (default: "/")
+        PW_NEG_SOLAR         - Allow negative solar values "yes"/"no" (default: "no")        PW_RSA_KEY_PATH      - Path to RSA-4096 private key PEM for TEDAPI v1r LAN access (default: none)        PROXY_BASE_URL       - Base URL for reverse proxy (default: "/")
 
 Connection Modes:
 
     TEDAPI (Local Gateway Access):
         • Fastest, most reliable
         • Requires direct connection to gateway WiFi or local network
-        • Configuration: PW_HOST + PW_GW_PWD
-        • Example: 192.168.91.1 with gateway password
+        • Configuration: PW_HOST + PW_GW_PWD  (password-based)
+        •            OR: PW_HOST + PW_RSA_KEY_PATH  (RSA key-based, v1r mode)
+        • Example: 192.168.91.1 with gateway password or RSA PEM key
     
     Cloud Mode:
         • Remote access from anywhere
@@ -189,6 +189,7 @@ class GatewayConfig(BaseSettings):
     host: Optional[str] = None
     port: Optional[int] = Field(default=None, ge=1, le=65535)  # Non-standard HTTPS port (e.g. 8443 via travel router)
     gw_pwd: Optional[str] = None  # Gateway Wi-Fi password for TEDAPI mode
+    rsa_key_path: Optional[str] = None  # Path to RSA-4096 private key PEM for v1r LAN TEDAPI access
     email: Optional[str] = None
     authpath: Optional[
         str
@@ -253,6 +254,9 @@ class Settings(BaseSettings):
     siteid: Optional[str] = Field(default=None, alias="PW_SITEID")
     control_secret: Optional[str] = Field(default=None, alias="PW_CONTROL_SECRET")
     proxy_base_url: str = Field(default="/", alias="PROXY_BASE_URL")
+    pw_rsa_key_path: Optional[str] = Field(
+        default=None, alias="PW_RSA_KEY_PATH"
+    )  # RSA-4096 private key PEM path for TEDAPI v1r LAN access
     neg_solar: bool = Field(
         default=False, alias="PW_NEG_SOLAR"
     )  # Allow negative solar values (default: no)
@@ -303,6 +307,7 @@ class Settings(BaseSettings):
                     name="Default Gateway",
                     host=self.pw_host,
                     gw_pwd=self.pw_gw_pwd,
+                    rsa_key_path=self.pw_rsa_key_path,
                     email=self.pw_email,
                     authpath=self.pw_authpath,
                     timezone=self.pw_timezone,

--- a/app/config.py
+++ b/app/config.py
@@ -173,7 +173,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.2.0"
+SERVER_VERSION = "0.2.1"
 
 
 class GatewayConfig(BaseSettings):

--- a/app/config.py
+++ b/app/config.py
@@ -67,6 +67,7 @@ Environment Variables (Proxy Compatible):
         PW_CONTROL_SECRET    - Enable control commands (default: none/disabled)
         PW_NEG_SOLAR         - Allow negative solar values "yes"/"no" (default: "no")
         PW_RSA_KEY_PATH      - Path to RSA-4096 private key PEM for TEDAPI v1r LAN access (default: none)
+        PW_WIFI_HOST         - WiFi host IP for TEDAPI v1r WiFi fallback (default: none)
         PROXY_BASE_URL       - Base URL for reverse proxy (default: "/")
 
 Connection Modes:
@@ -192,6 +193,7 @@ class GatewayConfig(BaseSettings):
     port: Optional[int] = Field(default=None, ge=1, le=65535)  # Non-standard HTTPS port (e.g. 8443 via travel router)
     gw_pwd: Optional[str] = None  # Gateway Wi-Fi password for TEDAPI mode
     rsa_key_path: Optional[str] = None  # Path to RSA-4096 private key PEM for v1r LAN TEDAPI access
+    wifi_host: Optional[str] = None  # WiFi host IP for TEDAPI v1r WiFi fallback
     email: Optional[str] = None
     authpath: Optional[
         str
@@ -259,6 +261,9 @@ class Settings(BaseSettings):
     pw_rsa_key_path: Optional[str] = Field(
         default=None, alias="PW_RSA_KEY_PATH"
     )  # RSA-4096 private key PEM path for TEDAPI v1r LAN access
+    pw_wifi_host: Optional[str] = Field(
+        default=None, alias="PW_WIFI_HOST"
+    )  # WiFi host IP for TEDAPI v1r WiFi fallback
     neg_solar: bool = Field(
         default=False, alias="PW_NEG_SOLAR"
     )  # Allow negative solar values (default: no)
@@ -310,6 +315,7 @@ class Settings(BaseSettings):
                     host=self.pw_host,
                     gw_pwd=self.pw_gw_pwd,
                     rsa_key_path=self.pw_rsa_key_path,
+                    wifi_host=self.pw_wifi_host,
                     email=self.pw_email,
                     authpath=self.pw_authpath,
                     timezone=self.pw_timezone,

--- a/app/config.py
+++ b/app/config.py
@@ -65,7 +65,9 @@ Environment Variables (Proxy Compatible):
         PW_CACHE_FILE        - Cache file path (default: auto - uses PW_AUTH_PATH/.powerwall or /tmp/.powerwall)
         PW_SITEID            - Tesla site ID for multi-site accounts (default: none)
         PW_CONTROL_SECRET    - Enable control commands (default: none/disabled)
-        PW_NEG_SOLAR         - Allow negative solar values "yes"/"no" (default: "no")        PW_RSA_KEY_PATH      - Path to RSA-4096 private key PEM for TEDAPI v1r LAN access (default: none)        PROXY_BASE_URL       - Base URL for reverse proxy (default: "/")
+        PW_NEG_SOLAR         - Allow negative solar values "yes"/"no" (default: "no")
+        PW_RSA_KEY_PATH      - Path to RSA-4096 private key PEM for TEDAPI v1r LAN access (default: none)
+        PROXY_BASE_URL       - Base URL for reverse proxy (default: "/")
 
 Connection Modes:
 

--- a/app/config.py
+++ b/app/config.py
@@ -175,7 +175,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.2.1"
+SERVER_VERSION = "0.2.2"
 
 
 class GatewayConfig(BaseSettings):

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -128,14 +128,14 @@ class GatewayManager:
         for config in gateway_configs:
             try:
                 # Validate configuration
-                # TEDAPI mode: need host + gw_pwd
+                # TEDAPI mode: need host + (gw_pwd OR rsa_key_path)
                 # Cloud mode: need email (authpath is optional, pypowerwall has defaults)
-                has_tedapi = config.host and config.gw_pwd
+                has_tedapi = config.host and (config.gw_pwd or config.rsa_key_path)
                 has_cloud = config.email  # cloud_mode is auto-set, email is sufficient
 
                 if not (has_tedapi or has_cloud):
                     logger.error(
-                        f"Invalid configuration for gateway {config.id}: need host+gw_pwd (TEDAPI) or email (Cloud)"
+                        f"Invalid configuration for gateway {config.id}: need host+gw_pwd or host+rsa_key_path (TEDAPI) or email (Cloud)"
                     )
                     continue
 
@@ -149,6 +149,7 @@ class GatewayManager:
                     host=config.host,
                     port=config.port,
                     gw_pwd=config.gw_pwd,
+                    rsa_key_path=config.rsa_key_path,
                     email=config.email,
                     timezone=config.timezone,
                     cloud_mode=config.cloud_mode,
@@ -288,6 +289,8 @@ class GatewayManager:
                             tedapi_kwargs["cachefile"] = settings.cache_file
                         if settings.siteid:
                             tedapi_kwargs["siteid"] = settings.siteid
+                        if config.rsa_key_path:
+                            tedapi_kwargs["rsa_key_path"] = config.rsa_key_path
                         pw = await asyncio.wait_for(
                             loop.run_in_executor(
                                 self._executor,

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -150,6 +150,7 @@ class GatewayManager:
                     port=config.port,
                     gw_pwd=config.gw_pwd,
                     rsa_key_path=config.rsa_key_path,
+                    rsa_key_configured=bool(config.rsa_key_path),
                     email=config.email,
                     timezone=config.timezone,
                     cloud_mode=config.cloud_mode,

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -267,6 +267,14 @@ class GatewayManager:
                             ),
                             timeout=15.0,
                         )
+                        connected = await asyncio.wait_for(
+                            loop.run_in_executor(self._executor, pw.is_connected),
+                            timeout=10.0,
+                        )
+                        if not connected:
+                            raise Exception(
+                                f"pypowerwall failed to connect to gateway {gateway_id} (cloud mode)"
+                            )
                     else:
                         # Build host string with optional non-standard port
                         # e.g. host="192.168.1.50", port=8443 -> "192.168.1.50:8443"
@@ -299,6 +307,14 @@ class GatewayManager:
                             ),
                             timeout=15.0,
                         )
+                        connected = await asyncio.wait_for(
+                            loop.run_in_executor(self._executor, pw.is_connected),
+                            timeout=10.0,
+                        )
+                        if not connected:
+                            raise Exception(
+                                f"pypowerwall failed to connect to gateway {gateway_id} (TEDAPI mode)"
+                            )
 
                     self.connections[gateway_id] = pw
                     del self._pending_configs[gateway_id]

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -151,6 +151,7 @@ class GatewayManager:
                     gw_pwd=config.gw_pwd,
                     rsa_key_path=config.rsa_key_path,
                     rsa_key_configured=bool(config.rsa_key_path),
+                    wifi_host=config.wifi_host,
                     email=config.email,
                     timezone=config.timezone,
                     cloud_mode=config.cloud_mode,
@@ -300,6 +301,8 @@ class GatewayManager:
                             tedapi_kwargs["siteid"] = settings.siteid
                         if config.rsa_key_path:
                             tedapi_kwargs["rsa_key_path"] = config.rsa_key_path
+                        if config.wifi_host:
+                            tedapi_kwargs["wifi_host"] = config.wifi_host
                         pw = await asyncio.wait_for(
                             loop.run_in_executor(
                                 self._executor,

--- a/app/models/gateway.py
+++ b/app/models/gateway.py
@@ -44,6 +44,7 @@ class Gateway(BaseModel):
     host: Optional[str] = None
     port: Optional[int] = Field(default=None, ge=1, le=65535)  # Non-standard HTTPS port (e.g. 8443 via travel router)
     gw_pwd: Optional[str] = None  # Gateway Wi-Fi password for TEDAPI
+    rsa_key_path: Optional[str] = None  # RSA-4096 private key PEM path for TEDAPI v1r LAN access
     email: Optional[str] = None
     site_id: Optional[str] = None  # Tesla Site ID (populated after connection)
     timezone: str = "America/Los_Angeles"

--- a/app/models/gateway.py
+++ b/app/models/gateway.py
@@ -45,7 +45,8 @@ class Gateway(BaseModel):
     port: Optional[int] = Field(default=None, ge=1, le=65535)  # Non-standard HTTPS port (e.g. 8443 via travel router)
     gw_pwd: Optional[str] = None  # Gateway Wi-Fi password for TEDAPI
     rsa_key_path: Optional[str] = Field(default=None, exclude=True)  # RSA-4096 private key PEM path (internal only; not serialized in API responses)
-    rsa_key_configured: bool = False  # True when rsa_key_path is set; safe to expose in API responses
+    rsa_key_configured: bool = False
+    wifi_host: Optional[str] = None  # True when rsa_key_path is set; safe to expose in API responses
     email: Optional[str] = None
     site_id: Optional[str] = None  # Tesla Site ID (populated after connection)
     timezone: str = "America/Los_Angeles"

--- a/app/models/gateway.py
+++ b/app/models/gateway.py
@@ -44,7 +44,8 @@ class Gateway(BaseModel):
     host: Optional[str] = None
     port: Optional[int] = Field(default=None, ge=1, le=65535)  # Non-standard HTTPS port (e.g. 8443 via travel router)
     gw_pwd: Optional[str] = None  # Gateway Wi-Fi password for TEDAPI
-    rsa_key_path: Optional[str] = None  # RSA-4096 private key PEM path for TEDAPI v1r LAN access
+    rsa_key_path: Optional[str] = Field(default=None, exclude=True)  # RSA-4096 private key PEM path (internal only; not serialized in API responses)
+    rsa_key_configured: bool = False  # True when rsa_key_path is set; safe to expose in API responses
     email: Optional[str] = None
     site_id: Optional[str] = None  # Tesla Site ID (populated after connection)
     timezone: str = "America/Los_Angeles"

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1524,29 +1524,22 @@
                 
                 // Mode
                 let mode = '--';
-                let qualifiers = [];
-                
+
                 // Determine base mode
-                if (stats.fleetapi || stats.cloudmode) {
+                if (stats.fleetapi) {
+                    mode = 'FleetAPI';
+                } else if (stats.cloudmode) {
                     mode = 'Cloud';
-                    if (stats.fleetapi) {
-                        qualifiers.push('FleetAPI');
-                    }
+                } else if (stats.tedapi) {
+                    const hasRsaKey = Object.values(gatewayMeta).some(gw => gw.rsa_key_path);
+                    mode = hasRsaKey ? 'TEDAPI v1r' : 'TEDAPI';
                 } else {
                     mode = 'Local';
-                    if (stats.tedapi) {
-                        qualifiers.push('TEDAPI');
-                    }
                 }
-                
-                // Add PW3 if applicable
+
+                // Append PW3 qualifier if applicable
                 if (stats.pw3) {
-                    qualifiers.push('PW3');
-                }
-                
-                // Build final mode string
-                if (qualifiers.length > 0) {
-                    mode += ' (' + qualifiers.join(' ') + ')';
+                    mode += ' (PW3)';
                 }
                 
                 document.getElementById('server-mode').textContent = mode;
@@ -1983,7 +1976,7 @@
                     // Handle both nested and flat response formats
                     const gw = status.gateway || status;
                     const isOnline = status.online ?? false;
-                    const mode = gw.fleetapi ? 'FleetAPI' : gw.cloud_mode ? 'Cloud' : 'TEDAPI';
+                    const mode = gw.fleetapi ? 'FleetAPI' : gw.cloud_mode ? 'Cloud' : gw.rsa_key_path ? 'TEDAPI v1r' : 'TEDAPI';
                     const hostInfo = (gw.cloud_mode || gw.fleetapi)
                         ? (gw.site_id || gw.email || id)
                         : (gw.host || id);
@@ -2033,6 +2026,7 @@
                         Object.entries(statuses).map(([id, s]) => [id, {
                             name: s.gateway?.name || id,
                             type: s.gateway?.type || 'powerwall',
+                            rsa_key_path: s.gateway?.rsa_key_path || null,
                             // pw3 is a system-wide flag; attach to every gateway entry
                             pw3: window._systemPw3 || false,
                         }])

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1531,7 +1531,7 @@
                 } else if (stats.cloudmode) {
                     mode = 'Cloud';
                 } else if (stats.tedapi) {
-                    const hasRsaKey = Object.values(gatewayMeta).some(gw => gw.rsa_key_path);
+                    const hasRsaKey = Object.values(gatewayMeta).some(gw => gw.rsa_key_configured);
                     mode = hasRsaKey ? 'TEDAPI v1r' : 'TEDAPI';
                 } else {
                     mode = 'Local';
@@ -1976,7 +1976,7 @@
                     // Handle both nested and flat response formats
                     const gw = status.gateway || status;
                     const isOnline = status.online ?? false;
-                    const mode = gw.fleetapi ? 'FleetAPI' : gw.cloud_mode ? 'Cloud' : gw.rsa_key_path ? 'TEDAPI v1r' : 'TEDAPI';
+                    const mode = gw.fleetapi ? 'FleetAPI' : gw.cloud_mode ? 'Cloud' : gw.rsa_key_configured ? 'TEDAPI v1r' : 'TEDAPI';
                     const hostInfo = (gw.cloud_mode || gw.fleetapi)
                         ? (gw.site_id || gw.email || id)
                         : (gw.host || id);
@@ -2026,7 +2026,7 @@
                         Object.entries(statuses).map(([id, s]) => [id, {
                             name: s.gateway?.name || id,
                             type: s.gateway?.type || 'powerwall',
-                            rsa_key_path: s.gateway?.rsa_key_path || null,
+                            rsa_key_configured: s.gateway?.rsa_key_configured || false,
                             // pw3 is a system-wide flag; attach to every gateway entry
                             pw3: window._systemPw3 || false,
                         }])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.2.0"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.2.1"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.2.1"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.2.2"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.12
 uvicorn[standard]==0.29.0
 pydantic==2.11.3
 pydantic-settings==2.9.1
-pypowerwall==0.14.10
+pypowerwall==0.15.0
 aiohttp==3.12.15
 websockets==13.1
 psutil==6.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ aiohttp==3.12.15
 websockets==13.1
 psutil==6.1.1
 beautifulsoup4==4.12.3
+cryptography

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,3 +49,22 @@ def test_gateway_config_cloud_mode():
     assert config.cloud_mode is True
     assert config.email == "test@example.com"
     assert config.authpath == "/path/to/auth"
+
+
+def test_settings_rsa_key_path(monkeypatch):
+    """Test that PW_RSA_KEY_PATH is loaded from environment."""
+    monkeypatch.setenv("PW_RSA_KEY_PATH", "/keys/tedapi_rsa_private.pem")
+    settings = Settings()
+    assert settings.pw_rsa_key_path == "/keys/tedapi_rsa_private.pem"
+
+
+def test_gateway_config_rsa_key_path():
+    """Test GatewayConfig accepts rsa_key_path for TEDAPI v1r mode."""
+    config = GatewayConfig(
+        id="v1r-test",
+        name="TEDAPI v1r Gateway",
+        host="192.168.91.1",
+        rsa_key_path="/keys/tedapi_rsa_private.pem",
+    )
+    assert config.rsa_key_path == "/keys/tedapi_rsa_private.pem"
+    assert config.gw_pwd is None

--- a/tests/test_gateway_manager.py
+++ b/tests/test_gateway_manager.py
@@ -122,3 +122,37 @@ async def test_polling_with_missing_optional_data(mock_gateway_manager, mock_pyp
     assert status.data.aggregates is not None
     assert status.data.vitals is None
     assert status.data.strings is None
+
+
+def test_gateway_rsa_key_configured():
+    """Test rsa_key_configured flag and path disclosure prevention."""
+    from app.models.gateway import Gateway
+
+    gw = Gateway(
+        id="v1r",
+        name="TEDAPI v1r",
+        host="192.168.91.1",
+        rsa_key_path="/keys/tedapi_rsa_private.pem",
+        rsa_key_configured=True,
+    )
+    assert gw.rsa_key_configured is True
+    # rsa_key_path must NOT appear in serialized output (path disclosure prevention)
+    data = gw.model_dump()
+    assert "rsa_key_path" not in data
+    assert data["rsa_key_configured"] is True
+
+
+def test_gateway_rsa_key_not_configured():
+    """Test rsa_key_configured defaults to False when no key is set."""
+    from app.models.gateway import Gateway
+
+    gw = Gateway(
+        id="tedapi",
+        name="TEDAPI Gateway",
+        host="192.168.91.1",
+        gw_pwd="wifi-password",
+    )
+    assert gw.rsa_key_configured is False
+    data = gw.model_dump()
+    assert "rsa_key_path" not in data
+    assert data["rsa_key_configured"] is False

--- a/tests/test_gateway_manager.py
+++ b/tests/test_gateway_manager.py
@@ -156,3 +156,49 @@ def test_gateway_rsa_key_not_configured():
     data = gw.model_dump()
     assert "rsa_key_path" not in data
     assert data["rsa_key_configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_rsa_key_path_passed_to_powerwall_constructor(monkeypatch, mock_pypowerwall):
+    """Test that rsa_key_path is passed to pypowerwall.Powerwall() when configured.
+
+    Covers the plumbing in gateway_manager._poll_gateway() lines 292-293:
+        if config.rsa_key_path:
+            tedapi_kwargs["rsa_key_path"] = config.rsa_key_path
+    """
+    from unittest.mock import Mock
+    from app.config import GatewayConfig
+    from app.models.gateway import Gateway, GatewayStatus
+    import pypowerwall
+
+    # Replace Powerwall constructor with a spy that returns the standard mock instance
+    powerwall_spy = Mock(return_value=mock_pypowerwall)
+    monkeypatch.setattr(pypowerwall, "Powerwall", powerwall_spy)
+
+    gw = Gateway(
+        id="v1r-connect",
+        name="TEDAPI v1r",
+        host="192.168.91.1",
+        rsa_key_path="/keys/tedapi_rsa_private.pem",
+        rsa_key_configured=True,
+    )
+    config = GatewayConfig(
+        id="v1r-connect",
+        name="TEDAPI v1r",
+        host="192.168.91.1",
+        rsa_key_path="/keys/tedapi_rsa_private.pem",
+    )
+
+    gateway_manager.gateways["v1r-connect"] = gw
+    gateway_manager._pending_configs["v1r-connect"] = config
+    gateway_manager.cache["v1r-connect"] = GatewayStatus(gateway=gw, online=False)
+    gateway_manager._consecutive_failures["v1r-connect"] = 0
+    gateway_manager._next_poll_time["v1r-connect"] = 0
+
+    await gateway_manager._poll_gateway("v1r-connect")
+
+    # Powerwall must have been constructed exactly once with the correct kwargs
+    assert powerwall_spy.called, "pypowerwall.Powerwall() was never called"
+    call_kwargs = powerwall_spy.call_args.kwargs
+    assert call_kwargs.get("rsa_key_path") == "/keys/tedapi_rsa_private.pem"
+    assert call_kwargs.get("host") == "192.168.91.1"

--- a/upload.sh
+++ b/upload.sh
@@ -74,6 +74,14 @@ if [ "$last_path" == "pypowerwall-server" ]; then
     DOCKERFILE="Dockerfile.beta"
     LATEST_TAG=""  # Beta builds do not overwrite :latest
 
+    # Preflight: Dockerfile.beta COPYs pypowerwall/ into the image; fail fast if missing.
+    if [ ! -d "pypowerwall" ] && [ ! -L "pypowerwall" ]; then
+      echo "ERROR: Beta builds require a 'pypowerwall/' directory or symlink in the project root."
+      echo "  Dockerfile.beta will COPY ./pypowerwall into the image."
+      echo "  Create it (e.g. ln -s /path/to/pypowerwall/pypowerwall pypowerwall) and re-run."
+      exit 1
+    fi
+
     # Docker BuildKit does not follow symlinks that point outside the build context.
     # If pypowerwall/ is a symlink (e.g. to ../pypowerwall/pypowerwall), dereference it
     # into a real directory so the COPY step in Dockerfile.beta works correctly.
@@ -84,8 +92,10 @@ if [ "$last_path" == "pypowerwall-server" ]; then
       mv pypowerwall pypowerwall_symlink
       mv pypowerwall_real pypowerwall
       PYPW_DEREFFED=true
-      # Ensure symlink is always restored even if the build fails
-      trap 'if [ "$PYPW_DEREFFED" = true ] && [ -d pypowerwall_symlink ]; then rm -rf pypowerwall; mv pypowerwall_symlink pypowerwall; fi' EXIT
+      # Ensure symlink is always restored even if the build fails.
+      # Use -L (is a symlink) not -d (is a directory) so the check works even
+      # when the symlink target is temporarily missing or broken.
+      trap 'if [ "$PYPW_DEREFFED" = true ] && [ -L pypowerwall_symlink ]; then rm -rf pypowerwall; mv pypowerwall_symlink pypowerwall; fi' EXIT
     fi
   fi
 


### PR DESCRIPTION
This requires merge of https://github.com/jasonacox/pypowerwall/pull/265

**Added:**
- `PW_RSA_KEY_PATH` environment variable — path to an RSA-4096 private key PEM file for TEDAPI v1r LAN access (new pypowerwall authentication mode). Supported in single-gateway env-var config and `gateways.yaml` multi-gateway config.
- Console **Connect Mode** and **Connected Gateways** panels now display `TEDAPI v1r` when `rsa_key_path` is configured, or `TEDAPI` otherwise (previously always showed `TEDAPI`).
- `Dockerfile.beta` — alternative Dockerfile for beta builds that installs the production `requirements.txt` (for all transitive deps) then shadows the installed `pypowerwall` package with the local source tree via `PYTHONPATH=/app`. Used by `upload.sh` when building a beta release tag.
