### PR TITLE
feat: hybrid TEDAPI + cloud control for write operations

### DIFF
--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -89,11 +89,34 @@ def verify_control_token(authorization: Optional[str] = Header(None)):
 async def control_api(
     path: str, data: dict, authorization: Optional[str] = Header(None)
 ):
-    """Authenticated control endpoint for POST operations."""
+    """Authenticated control endpoint for POST operations.
+
+    Routes to cloud control connection for write operations (set_reserve, set_mode)
+    when available, since TEDAPI doesn't support POST/write APIs.
+    Falls back to direct post for cloud-mode or FleetAPI gateways.
+    """
     verify_control_token(authorization)
 
-    gateway_id = get_default_gateway()
+    # Map control paths to pypowerwall cloud control methods.
+    # Used for TEDAPI gateways with cloud credentials (hybrid mode).
+    cloud_control_map = {
+        "reserve": ("set_reserve", lambda d: [d.get("value", 0)]),
+        "mode": ("set_mode", lambda d: [d.get("value", "self_consumption")]),
+    }
 
+    if path in cloud_control_map and gateway_manager._cloud_control:
+        method, args_fn = cloud_control_map[path]
+        result = await gateway_manager.cloud_control(
+            method, *args_fn(data), timeout=10.0
+        )
+        if result is None:
+            raise HTTPException(
+                status_code=503, detail="Control operation failed via cloud"
+            )
+        return result
+
+    # Fallback: direct post for cloud-mode/FleetAPI gateways or unmapped paths
+    gateway_id = get_default_gateway()
     result = await gateway_manager.call_api(
         gateway_id, "post", f"/api/{path}", data, timeout=10.0
     )

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -195,7 +195,7 @@ class GatewayManager:
         for config in gateway_configs:
             if config.host and config.gw_pwd and config.email and not config.cloud_mode:
                 try:
-                    authpath = config.authpath or settings.authpath or ""
+                    authpath = config.authpath or settings.pw_authpath or ""
                     loop = asyncio.get_running_loop()
                     cloud_kwargs = {
                         "email": config.email,
@@ -214,11 +214,11 @@ class GatewayManager:
                     logger.info(
                         "Cloud control connection established for write operations"
                     )
+                    break  # Only need one cloud control connection
                 except Exception as e:
                     logger.warning(
                         f"Cloud control connection failed (control will be unavailable): {e}"
                     )
-                break  # Only need one cloud control connection
 
         # Start polling task
         if self.gateways:

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -99,6 +99,13 @@ class GatewayManager:
         # Will be sized during initialize() based on gateway count
         self._executor: Optional[ThreadPoolExecutor] = None
 
+        # Cloud connection for control operations (set_reserve, set_mode).
+        # TEDAPI doesn't support POST/write APIs, so a separate cloud-mode
+        # pypowerwall instance is created when cloud credentials are available
+        # alongside a TEDAPI gateway. This enables hybrid operation:
+        # TEDAPI for fast local reads, cloud for control writes.
+        self._cloud_control: Optional[pypowerwall.Powerwall] = None
+
     async def initialize(
         self, gateway_configs: List[GatewayConfig], poll_interval: int = 5
     ):
@@ -181,6 +188,37 @@ class GatewayManager:
                 )
             except Exception as e:
                 logger.error(f"Failed to initialize gateway {config.id}: {e}")
+
+        # Initialize cloud control connection for TEDAPI gateways with cloud credentials.
+        # This enables hybrid operation: local TEDAPI reads + cloud control writes.
+        from app.config import settings
+        for config in gateway_configs:
+            if config.host and config.gw_pwd and config.email and not config.cloud_mode:
+                try:
+                    authpath = config.authpath or settings.authpath or ""
+                    loop = asyncio.get_running_loop()
+                    cloud_kwargs = {
+                        "email": config.email,
+                        "authpath": authpath,
+                        "cachefile": "/tmp/.powerwall.cloud",
+                        "timezone": config.timezone,
+                        "cloudmode": True,
+                    }
+                    self._cloud_control = await asyncio.wait_for(
+                        loop.run_in_executor(
+                            self._executor,
+                            lambda kw=cloud_kwargs: pypowerwall.Powerwall(**kw),
+                        ),
+                        timeout=15.0,
+                    )
+                    logger.info(
+                        "Cloud control connection established for write operations"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Cloud control connection failed (control will be unavailable): {e}"
+                    )
+                break  # Only need one cloud control connection
 
         # Start polling task
         if self.gateways:
@@ -798,6 +836,49 @@ class GatewayManager:
             return None
         except Exception as e:
             logger.warning(f"[{gateway_id}] call_api({method}) error: {e}")
+            return None
+
+    async def cloud_control(
+        self, method: str, *args, timeout: float = 10.0, **kwargs
+    ) -> Optional[Any]:
+        """Call a control method via the cloud connection.
+
+        TEDAPI (local gateway) doesn't support write operations. When cloud
+        credentials are configured alongside a TEDAPI gateway, a separate
+        cloud-mode pypowerwall connection is created for control operations
+        like set_reserve() and set_mode().
+
+        Args:
+            method: Method name on pypowerwall (e.g., 'set_reserve', 'set_mode')
+            *args: Positional arguments for the method
+            timeout: Timeout in seconds (default: 10.0)
+            **kwargs: Keyword arguments for the method
+
+        Returns:
+            Result of the method call, or None on error/timeout
+        """
+        if not self._cloud_control:
+            logger.error(f"cloud_control({method}): no cloud connection available")
+            return None
+        try:
+            method_func = getattr(self._cloud_control, method)
+            loop = asyncio.get_running_loop()
+            result = await asyncio.wait_for(
+                loop.run_in_executor(
+                    self._executor, lambda: method_func(*args, **kwargs)
+                ),
+                timeout=timeout,
+            )
+            logger.info(f"cloud_control({method}) completed successfully")
+            return result
+        except asyncio.TimeoutError:
+            logger.warning(f"cloud_control({method}) timeout after {timeout}s")
+            return None
+        except AttributeError:
+            logger.error(f"cloud_control({method}): method not found")
+            return None
+        except Exception as e:
+            logger.warning(f"cloud_control({method}) error: {e}")
             return None
 
     async def call_tedapi(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,14 @@ def reset_gateway_manager():
     gateway_manager.gateways.clear()
     gateway_manager.connections.clear()
     gateway_manager.cache.clear()
+    gateway_manager._cloud_control = None
+    gateway_manager._executor = None
     yield
     gateway_manager.gateways.clear()
     gateway_manager.connections.clear()
     gateway_manager.cache.clear()
+    gateway_manager._cloud_control = None
+    gateway_manager._executor = None
 
 
 @pytest.fixture

--- a/tests/test_api_legacy.py
+++ b/tests/test_api_legacy.py
@@ -1,4 +1,6 @@
 """Tests for legacy proxy API endpoints."""
+import pytest
+from unittest.mock import Mock
 
 
 def test_aggregates_endpoint(client, connected_gateway):
@@ -187,3 +189,138 @@ def test_endpoint_without_gateway(client, mock_gateway_manager):
     """Test endpoints return 503 when no gateway available."""
     response = client.get("/aggregates")
     assert response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# /control/<path> endpoint tests (cloud control routing)
+# ---------------------------------------------------------------------------
+
+_CONTROL_TOKEN = "test-secret-token"
+
+
+@pytest.fixture
+def control_client(monkeypatch):
+    """Test client with control features enabled via monkeypatched settings."""
+    from app.config import settings
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    monkeypatch.setattr(settings, "control_secret", _CONTROL_TOKEN)
+    return TestClient(app)
+
+
+def test_control_reserve_routes_to_cloud(
+    control_client, connected_gateway, monkeypatch
+):
+    """Test that POST /control/reserve uses cloud_control when _cloud_control is set."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    mock_cloud.set_reserve.return_value = {"result": "Updated"}
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/reserve",
+        json={"value": 20},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    mock_cloud.set_reserve.assert_called_once_with(20)
+
+
+def test_control_mode_routes_to_cloud(
+    control_client, connected_gateway, monkeypatch
+):
+    """Test that POST /control/mode uses cloud_control when _cloud_control is set."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    mock_cloud.set_mode.return_value = {"result": "Updated"}
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/mode",
+        json={"value": "self_consumption"},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    mock_cloud.set_mode.assert_called_once_with("self_consumption")
+
+
+def test_control_cloud_returns_none_gives_503(
+    control_client, connected_gateway, monkeypatch
+):
+    """Test that cloud_control returning None raises HTTP 503."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    mock_cloud.set_reserve.return_value = None
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/reserve",
+        json={"value": 20},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 503
+
+
+def test_control_reserve_fallback_without_cloud(
+    control_client, connected_gateway, mock_pypowerwall
+):
+    """Test that POST /control/reserve falls back to call_api when no _cloud_control."""
+    from app.core.gateway_manager import gateway_manager
+
+    gateway_manager._cloud_control = None
+    mock_pypowerwall.post.return_value = {"result": "Updated"}
+
+    response = control_client.post(
+        "/control/reserve",
+        json={"value": 20},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    mock_pypowerwall.post.assert_called_once()
+
+
+def test_control_unmapped_path_uses_call_api(
+    control_client, connected_gateway, mock_pypowerwall, monkeypatch
+):
+    """Test that unmapped paths always fall back to call_api even if _cloud_control is set."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    gateway_manager._cloud_control = mock_cloud
+    mock_pypowerwall.post.return_value = {"result": "OK"}
+
+    response = control_client.post(
+        "/control/some/other/path",
+        json={"key": "value"},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    # cloud mock should NOT have been called
+    mock_cloud.set_reserve.assert_not_called()
+    mock_cloud.set_mode.assert_not_called()
+    mock_pypowerwall.post.assert_called_once()
+
+
+def test_control_requires_auth_header(control_client, connected_gateway):
+    """Test that /control/* returns 401 without Authorization header."""
+    response = control_client.post("/control/reserve", json={"value": 20})
+    assert response.status_code == 401
+
+
+def test_control_rejects_wrong_token(control_client, connected_gateway):
+    """Test that /control/* returns 401 with an invalid token."""
+    response = control_client.post(
+        "/control/reserve",
+        json={"value": 20},
+        headers={"Authorization": "wrong-token"},
+    )
+    assert response.status_code == 401

--- a/tests/test_gateway_manager.py
+++ b/tests/test_gateway_manager.py
@@ -1,5 +1,7 @@
 """Tests for gateway manager."""
+import asyncio
 import pytest
+from unittest.mock import Mock
 from app.core.gateway_manager import gateway_manager
 
 
@@ -122,3 +124,230 @@ async def test_polling_with_missing_optional_data(mock_gateway_manager, mock_pyp
     assert status.data.aggregates is not None
     assert status.data.vitals is None
     assert status.data.strings is None
+
+
+# ---------------------------------------------------------------------------
+# cloud_control() method tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cloud_control_success(mock_gateway_manager):
+    """Test cloud_control dispatches to the _cloud_control connection."""
+    mock_cloud = Mock()
+    mock_cloud.set_reserve.return_value = True
+    mock_gateway_manager._cloud_control = mock_cloud
+
+    result = await mock_gateway_manager.cloud_control("set_reserve", 20)
+
+    assert result is True
+    mock_cloud.set_reserve.assert_called_once_with(20)
+
+
+@pytest.mark.asyncio
+async def test_cloud_control_no_connection(mock_gateway_manager):
+    """Test cloud_control returns None immediately when _cloud_control is not set."""
+    mock_gateway_manager._cloud_control = None
+
+    result = await mock_gateway_manager.cloud_control("set_reserve", 20)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cloud_control_method_not_found(mock_gateway_manager):
+    """Test cloud_control returns None when the method doesn't exist on the connection."""
+    mock_cloud = Mock()
+    del mock_cloud.nonexistent_method  # accessing it will raise AttributeError
+    mock_gateway_manager._cloud_control = mock_cloud
+
+    result = await mock_gateway_manager.cloud_control("nonexistent_method")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cloud_control_generic_error(mock_gateway_manager):
+    """Test cloud_control returns None on unexpected errors."""
+    mock_cloud = Mock()
+    mock_cloud.set_reserve.side_effect = RuntimeError("connection lost")
+    mock_gateway_manager._cloud_control = mock_cloud
+
+    result = await mock_gateway_manager.cloud_control("set_reserve", 20)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cloud_control_timeout(mock_gateway_manager):
+    """Test cloud_control returns None on timeout."""
+    import asyncio
+
+    mock_cloud = Mock()
+    # Simulate timeout by raising asyncio.TimeoutError inside the executor thread
+    mock_cloud.set_reserve.side_effect = asyncio.TimeoutError()
+    mock_gateway_manager._cloud_control = mock_cloud
+
+    result = await mock_gateway_manager.cloud_control("set_reserve", 20)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# initialize() cloud control setup tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_initialize_creates_cloud_control(monkeypatch):
+    """Test that initialize() creates a _cloud_control connection for TEDAPI+cloud config."""
+    from app.config import GatewayConfig
+
+    mock_cloud = Mock()
+    call_count = 0
+
+    def mock_powerwall_factory(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        return mock_cloud
+
+    import pypowerwall
+    monkeypatch.setattr(pypowerwall, "Powerwall", mock_powerwall_factory)
+
+    configs = [
+        GatewayConfig(
+            id="home",
+            name="Home Gateway",
+            host="192.168.91.1",
+            gw_pwd="secret",
+            email="user@example.com",
+        )
+    ]
+
+    gm = gateway_manager
+    gm.gateways.clear()
+    gm.connections.clear()
+    gm.cache.clear()
+    gm._cloud_control = None
+
+    await gm.initialize(configs, poll_interval=5)
+
+    # _cloud_control should be set
+    assert gm._cloud_control is not None
+
+    # Cleanup
+    await gm.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_initialize_no_cloud_control_for_cloud_mode(monkeypatch):
+    """Test that initialize() does NOT create _cloud_control for pure cloud-mode gateways."""
+    from app.config import GatewayConfig
+
+    mock_cloud = Mock()
+
+    import pypowerwall
+    monkeypatch.setattr(pypowerwall, "Powerwall", lambda **kw: mock_cloud)
+
+    configs = [
+        GatewayConfig(
+            id="remote",
+            name="Remote Gateway",
+            email="user@example.com",
+            cloud_mode=True,
+        )
+    ]
+
+    gm = gateway_manager
+    gm.gateways.clear()
+    gm.connections.clear()
+    gm.cache.clear()
+    gm._cloud_control = None
+
+    await gm.initialize(configs, poll_interval=5)
+
+    # pure cloud mode — no hybrid _cloud_control needed
+    assert gm._cloud_control is None
+
+    await gm.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_initialize_cloud_control_uses_pw_authpath_fallback(monkeypatch):
+    """Test that initialize() uses settings.pw_authpath when config.authpath is None."""
+    from app.config import GatewayConfig, settings
+
+    captured_kwargs = {}
+
+    def mock_powerwall_factory(**kwargs):
+        captured_kwargs.update(kwargs)
+        return Mock()
+
+    import pypowerwall
+    monkeypatch.setattr(pypowerwall, "Powerwall", mock_powerwall_factory)
+    monkeypatch.setattr(settings, "pw_authpath", "/global/auth/path")
+
+    configs = [
+        GatewayConfig(
+            id="home",
+            name="Home Gateway",
+            host="192.168.91.1",
+            gw_pwd="secret",
+            email="user@example.com",
+            # no authpath set on config — should fall back to settings.pw_authpath
+        )
+    ]
+
+    gm = gateway_manager
+    gm.gateways.clear()
+    gm.connections.clear()
+    gm.cache.clear()
+    gm._cloud_control = None
+
+    await gm.initialize(configs, poll_interval=5)
+
+    # The cloud control connection should have been created with the global authpath
+    # (captured_kwargs reflects the LAST Powerwall() call, which is the cloud control one
+    # since the gateway connection is deferred to first poll via lazy init)
+    assert captured_kwargs.get("authpath") == "/global/auth/path"
+
+    await gm.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_initialize_cloud_control_exception_is_handled(monkeypatch):
+    """Test that initialize() logs a warning and continues when cloud control setup fails."""
+    from app.config import GatewayConfig
+
+    call_count = 0
+
+    def mock_powerwall_factory(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if kwargs.get("cloudmode"):
+            raise RuntimeError("cloud auth failed")
+        return Mock()
+
+    import pypowerwall
+    monkeypatch.setattr(pypowerwall, "Powerwall", mock_powerwall_factory)
+
+    configs = [
+        GatewayConfig(
+            id="home",
+            name="Home Gateway",
+            host="192.168.91.1",
+            gw_pwd="secret",
+            email="user@example.com",
+        )
+    ]
+
+    gm = gateway_manager
+    gm.gateways.clear()
+    gm.connections.clear()
+    gm.cache.clear()
+    gm._cloud_control = None
+
+    # Should not raise — exception is swallowed with a warning
+    await gm.initialize(configs, poll_interval=5)
+
+    assert gm._cloud_control is None
+
+    await gm.shutdown()


### PR DESCRIPTION
## Problem

TEDAPI (local gateway) doesn't support POST/write APIs. When using `PW_CONTROL_SECRET` with a TEDAPI-only gateway, control operations like `/control/reserve` fail with `{"ERROR": "Unknown API: /api/reserve"}`.

This is a common setup: users connect locally to their Powerwall via TEDAPI for fast reads, but need Tesla Cloud to change settings like backup reserve or operating mode.

## Solution

When a TEDAPI gateway is configured with cloud credentials (`PW_EMAIL` + `PW_AUTHPATH`), create a secondary cloud-mode pypowerwall connection dedicated to control operations.

**Hybrid operation:**
- All reads (SoC, aggregates, vitals, etc.) → fast local TEDAPI (no internet needed)
- Control writes (`set_reserve`, `set_mode`) → Tesla Cloud API

**No behavior change** for existing setups:
- Pure TEDAPI users (no email): unchanged, control stays unavailable
- Pure cloud-mode users: unchanged, control goes through existing connection
- Only activates when both TEDAPI *and* cloud credentials are present

## Configuration

```env
PW_HOST=192.168.91.1            # TEDAPI for reads
PW_GW_PWD=gateway_password
PW_EMAIL=user@email.com         # Cloud for control writes
PW_AUTHPATH=/path/to/auth       # Directory with .pypowerwall.auth/.site
PW_CONTROL_SECRET=your_secret   # Enable control endpoints
```

## Changes

- **`app/core/gateway_manager.py`**: Initialize cloud control connection during startup. Add `cloud_control()` async method with timeout and error handling.
- **`app/api/legacy.py`**: Route `/control/reserve` and `/control/mode` through cloud connection when available, with fallback to direct post for cloud/FleetAPI gateways.

## Tested

Verified on a live Powerwall system with pypowerwall-server v0.2.1:
- TEDAPI reads continue working (local, no internet)
- `POST /control/reserve` successfully sets backup reserve via cloud
- Startup logs show: `Cloud control connection established for write operations`