### PR TITLE
Add MQTT Support - v0.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,25 @@ All configuration uses `PW_` prefix for consistency with pypowerwall proxy:
 | `PW_NEG_SOLAR` | yes | Allow negative solar values |
 | `PW_GRACEFUL_DEGRADATION` | yes | Serve stale data when offline |
 
+MQTT uses a separate `MQTT_` prefix (not a Powerwall concept):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MQTT_HOST` | None | Broker hostname/IP. **Required to enable MQTT.** |
+| `MQTT_PORT` | 1883 | Broker port |
+| `MQTT_USERNAME` | None | Optional broker username |
+| `MQTT_PASSWORD` | None | Optional broker password |
+| `MQTT_TLS` | false | Enable TLS/SSL |
+| `MQTT_TLS_CA_CERT` | None | Path to CA certificate |
+| `MQTT_TLS_INSECURE` | false | Skip cert verification (dev only) |
+| `MQTT_TOPIC_PREFIX` | pypowerwall | Root topic prefix |
+| `MQTT_RETAIN` | true | Retain messages on broker |
+| `MQTT_QOS` | 1 | QoS level (0, 1, or 2) |
+| `MQTT_HA_DISCOVERY` | true | Publish Home Assistant auto-discovery payloads |
+| `MQTT_HA_PREFIX` | homeassistant | HA discovery prefix |
+| `MQTT_CLIENT_ID` | pypowerwall-server | MQTT client identifier |
+| `MQTT_KEEPALIVE` | 60 | Keepalive interval (seconds) |
+
 ### Pydantic Settings
 
 Use `Field` with `validation_alias` for environment variable mapping:
@@ -361,8 +380,13 @@ The `track_requests` middleware in `app/main.py` does double duty: request stati
 | `app/models/gateway.py` | Pydantic models |
 | `app/utils/transform.py` | Static file serving and JS injection into HTML |
 | `app/utils/stats_tracker.py` | Request statistics |
-| `app/static/index.html` | Console UI dashboard — Powerwall status, health panel, battery graphics |
+| `app/mqtt/__init__.py` | MQTT package — exports `mqtt_publisher` singleton |
+| `app/mqtt/publisher.py` | `MqttPublisher` — connection loop, topic publishing, LWT, TLS, reconnect |
+| `app/mqtt/ha_discovery.py` | Home Assistant auto-discovery payload builder (pure function) |
+| `app/static/index.html` | Console UI dashboard — Powerwall status, health panel, battery graphics, MQTT broker panel |
 | `app/static/powerflow/app.js` | ⚠️ **PATCHED** vendored Tesla Gateway web UI — `isAuthenticated` always returns `true` (issue #7). **Do NOT replace with a clean copy.** |
+| `mqtt-tools/README.md` | Broker setup guide, CLI monitoring, GUI usage, HA integration steps |
+| `mqtt-tools/monitor.py` | Live tkinter GUI — connects to broker, shows real-time Powerwall telemetry |
 
 ## Version Management
 

--- a/MQTT.md
+++ b/MQTT.md
@@ -1,0 +1,345 @@
+# MQTT Support — Design & Implementation Plan
+
+Related: [Issue #1](https://github.com/jasonacox/pypowerwall-server/issues/1)
+
+---
+
+## Overview
+
+Add an **opt-in MQTT publisher** to pypowerwall-server that pushes Powerwall telemetry to any MQTT broker after every successful poll cycle. Designed primarily for Home Assistant integration but compatible with any MQTT-based system (Node-RED, InfluxDB MQTT adapter, etc.).
+
+Key design goals:
+- **Zero impact when disabled** — if `MQTT_HOST` is not set, no code path changes
+- **Non-blocking** — publish happens asynchronously after the poll cache is updated; it never delays HTTP responses
+- **Multi-gateway aware** — each gateway publishes to its own sub-topic tree
+- **Home Assistant auto-discovery** — optional `homeassistant/` discovery payloads so sensors appear automatically in HA without manual YAML
+
+---
+
+## Architecture
+
+```
+                        ┌─────────────────────────┐
+                        │      GatewayManager      │
+                        │  (background poll loop)  │
+                        └────────────┬────────────┘
+                                     │ after each successful _poll_gateway()
+                                     ▼
+                        ┌─────────────────────────┐
+                        │      MqttPublisher       │  app/mqtt/publisher.py
+                        │  (asyncio coroutine)     │
+                        │                          │
+                        │  • build topic payloads  │
+                        │  • connect / reconnect   │
+                        │  • publish with retain   │
+                        └────────────┬────────────┘
+                                     │ aiomqtt (async MQTT client)
+                                     ▼
+                        ┌─────────────────────────┐
+                        │       MQTT Broker        │
+                        │  (Mosquitto, HiveMQ …)   │
+                        └─────────────────────────┘
+                                     │
+                        ┌────────────┴────────────┐
+                        │                         │
+               ┌────────▼────────┐    ┌───────────▼──────────┐
+               │  Home Assistant │    │  Node-RED / Grafana   │
+               │  (auto-discover)│    │  / InfluxDB / etc.    │
+               └─────────────────┘    └──────────────────────┘
+```
+
+### Integration point in `gateway_manager.py`
+
+```python
+# In _poll_gateway(), after self.cache[gateway_id] is updated:
+from app.mqtt.publisher import mqtt_publisher
+if mqtt_publisher.enabled:
+    asyncio.create_task(
+        mqtt_publisher.publish_gateway(gateway_id, status)
+    )
+```
+
+The `asyncio.create_task()` call is fire-and-forget — MQTT failures never propagate back to the poll loop.
+
+---
+
+## New Files
+
+```
+app/
+  mqtt/
+    __init__.py          # exports mqtt_publisher singleton
+    publisher.py         # MqttPublisher class — connection mgmt + publish logic
+    ha_discovery.py      # Home Assistant MQTT discovery payload builders
+```
+
+---
+
+## Environment Variables
+
+All use `MQTT_` prefix (no `PW_` prefix — MQTT is not a Powerwall concept).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MQTT_HOST` | *(unset)* | Broker hostname or IP. **Required to enable MQTT.** |
+| `MQTT_PORT` | `1883` | Broker port (`8883` for TLS) |
+| `MQTT_USERNAME` | *(unset)* | Optional broker username |
+| `MQTT_PASSWORD` | *(unset)* | Optional broker password |
+| `MQTT_TLS` | `no` | Enable TLS/SSL (`yes`/`no`) |
+| `MQTT_TLS_CA_CERT` | *(unset)* | Path to CA certificate for TLS verification |
+| `MQTT_TLS_INSECURE` | `no` | Skip TLS certificate verification (dev only) |
+| `MQTT_TOPIC_PREFIX` | `pypowerwall` | Root topic prefix |
+| `MQTT_RETAIN` | `yes` | Publish with MQTT retain flag |
+| `MQTT_QOS` | `1` | QoS level (0, 1, or 2) |
+| `MQTT_HA_DISCOVERY` | `yes` | Publish Home Assistant auto-discovery payloads |
+| `MQTT_HA_PREFIX` | `homeassistant` | HA discovery topic prefix |
+| `MQTT_CLIENT_ID` | `pypowerwall-server` | MQTT client identifier |
+| `MQTT_KEEPALIVE` | `60` | Broker keepalive interval (seconds) |
+
+Add to `app/config.py` Settings class:
+
+```python
+# MQTT settings
+mqtt_host: Optional[str] = Field(default=None, alias="MQTT_HOST")
+mqtt_port: int = Field(default=1883, alias="MQTT_PORT")
+mqtt_username: Optional[str] = Field(default=None, alias="MQTT_USERNAME")
+mqtt_password: Optional[str] = Field(default=None, alias="MQTT_PASSWORD")
+mqtt_tls: bool = Field(default=False, alias="MQTT_TLS")
+mqtt_tls_ca_cert: Optional[str] = Field(default=None, alias="MQTT_TLS_CA_CERT")
+mqtt_tls_insecure: bool = Field(default=False, alias="MQTT_TLS_INSECURE")
+mqtt_topic_prefix: str = Field(default="pypowerwall", alias="MQTT_TOPIC_PREFIX")
+mqtt_retain: bool = Field(default=True, alias="MQTT_RETAIN")
+mqtt_qos: int = Field(default=1, alias="MQTT_QOS")
+mqtt_ha_discovery: bool = Field(default=True, alias="MQTT_HA_DISCOVERY")
+mqtt_ha_prefix: str = Field(default="homeassistant", alias="MQTT_HA_PREFIX")
+mqtt_client_id: str = Field(default="pypowerwall-server", alias="MQTT_CLIENT_ID")
+mqtt_keepalive: int = Field(default=60, alias="MQTT_KEEPALIVE")
+
+@property
+def mqtt_enabled(self) -> bool:
+    return bool(self.mqtt_host)
+```
+
+---
+
+## Topic Structure
+
+Base path: `{MQTT_TOPIC_PREFIX}/{gateway_id}/`
+
+### Individual sensor topics (scalar values — ideal for HA)
+
+| Topic | Value | Unit |
+|-------|-------|------|
+| `pypowerwall/{gw}/battery` | `85.3` | `%` |
+| `pypowerwall/{gw}/solar` | `2340` | `W` |
+| `pypowerwall/{gw}/grid` | `-1100` | `W` (negative = exporting) |
+| `pypowerwall/{gw}/home` | `1240` | `W` |
+| `pypowerwall/{gw}/powerwall` | `1200` | `W` (positive = discharging) |
+| `pypowerwall/{gw}/grid_status` | `UP` or `DOWN` | — |
+| `pypowerwall/{gw}/mode` | `self_consumption` | — |
+| `pypowerwall/{gw}/reserve` | `20.0` | `%` |
+| `pypowerwall/{gw}/online` | `true` or `false` | — |
+
+### Full JSON topics (for advanced consumers)
+
+| Topic | Value |
+|-------|-------|
+| `pypowerwall/{gw}/aggregates` | Full `/api/meters/aggregates` JSON |
+| `pypowerwall/{gw}/status` | `{"online": true, "soe": 85.3, "mode": "...", ...}` summary |
+
+### Availability topic (for HA)
+
+| Topic | Value |
+|-------|-------|
+| `pypowerwall/{gw}/availability` | `online` or `offline` |
+
+Published `online` on each successful poll; `offline` published as a **Last Will and Testament (LWT)** message so HA marks sensors unavailable if the server crashes.
+
+---
+
+## Home Assistant Auto-Discovery
+
+When `MQTT_HA_DISCOVERY=yes`, on first connection (and once per server restart) the publisher sends HA [MQTT discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) payloads.
+
+Discovery topic pattern: `{MQTT_HA_PREFIX}/sensor/pypowerwall_{gw}_{sensor}/config`
+
+Example for battery SOE:
+```json
+Topic: homeassistant/sensor/pypowerwall_default_battery/config
+{
+  "name": "Battery",
+  "unique_id": "pypowerwall_default_battery",
+  "state_topic": "pypowerwall/default/battery",
+  "availability_topic": "pypowerwall/default/availability",
+  "unit_of_measurement": "%",
+  "device_class": "battery",
+  "state_class": "measurement",
+  "device": {
+    "identifiers": ["pypowerwall_default"],
+    "name": "Powerwall (default)",
+    "manufacturer": "Tesla",
+    "model": "Powerwall",
+    "sw_version": "23.44.0"
+  }
+}
+```
+
+Sensors to auto-discover per gateway:
+
+| Sensor | HA device_class | Unit | Icon |
+|--------|----------------|------|------|
+| Battery SOE | `battery` | `%` | — |
+| Solar Power | `power` | `W` | `mdi:solar-power` |
+| Grid Power | `power` | `W` | `mdi:transmission-tower` |
+| Home Power | `power` | `W` | `mdi:home-lightning-bolt` |
+| Powerwall Power | `power` | `W` | `mdi:battery-charging` |
+| Grid Status | — | — | `mdi:transmission-tower` |
+| Operation Mode | — | — | `mdi:cog` |
+| Backup Reserve | — | `%` | `mdi:battery-lock` |
+
+Binary sensors:
+| Sensor | HA device_class |
+|--------|----------------|
+| Grid Connected | `connectivity` |
+| Gateway Online | `connectivity` |
+
+---
+
+## `MqttPublisher` Class Design
+
+```python
+# app/mqtt/publisher.py
+
+class MqttPublisher:
+    """Async MQTT publisher for Powerwall telemetry."""
+
+    def __init__(self):
+        self._client = None          # aiomqtt.Client
+        self._connected = False
+        self._discovery_sent: set[str] = set()  # gateway IDs already discovered
+
+    @property
+    def enabled(self) -> bool:
+        from app.config import settings  # late import
+        return settings.mqtt_enabled
+
+    async def connect(self): ...
+    async def disconnect(self): ...
+    async def publish_gateway(self, gateway_id: str, status: GatewayStatus): ...
+    async def _publish_discovery(self, gateway_id: str, status: GatewayStatus): ...
+    async def _publish_scalar(self, topic: str, value): ...
+    async def _reconnect_if_needed(self): ...
+
+mqtt_publisher = MqttPublisher()  # module-level singleton
+```
+
+### Reconnection strategy
+
+- On publish failure: log warning, mark disconnected, attempt reconnect next cycle
+- Use exponential backoff (max 60s) to avoid hammering an unreachable broker
+- Do not raise exceptions — MQTT failures are logged and silently swallowed so HTTP responses are never affected
+
+---
+
+## `main.py` Lifespan Changes
+
+```python
+# In lifespan(), after gateway_manager.initialize():
+from app.mqtt.publisher import mqtt_publisher
+if mqtt_publisher.enabled:
+    await mqtt_publisher.connect()
+    logger.info(f"MQTT publisher connected to {settings.mqtt_host}:{settings.mqtt_port}")
+
+# In lifespan() shutdown section:
+if mqtt_publisher.enabled:
+    await mqtt_publisher.disconnect()
+```
+
+---
+
+## Dependencies
+
+Add to `requirements.txt`:
+
+```
+aiomqtt>=2.3.0
+```
+
+`aiomqtt` wraps `paho-mqtt` with a native asyncio interface that fits the existing event loop without needing executor bridging.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Core publisher (MVP)
+- [x] Add MQTT settings to `app/config.py`
+- [x] Create `app/mqtt/__init__.py` and `app/mqtt/publisher.py`
+- [x] Implement `connect()`, `disconnect()`, `publish_gateway()`
+- [x] Publish scalar sensor topics and `aggregates` JSON topic
+- [x] Publish LWT (`offline`) and `availability` topics
+- [x] Hook into `gateway_manager._poll_gateway()` post-cache update
+- [x] Start/stop in `main.py` lifespan
+- [x] Add `aiomqtt` to `requirements.txt`
+- [x] Log MQTT activity at DEBUG level (silent when not configured)
+
+### Phase 2 — Home Assistant discovery
+- [x] Create `app/mqtt/ha_discovery.py`
+- [x] Implement discovery payload builders for all sensors
+- [x] Publish discovery on connect (once per gateway per run)
+- [x] Include `device` block so all sensors group under one HA device card
+- [x] Test with real Home Assistant instance
+
+### Phase 3 — Polish & docs
+- [x] Add MQTT section to README
+- [x] Add MQTT variables to `docker-compose.yml` example (commented out)
+- [x] Add tests: `tests/test_mqtt_publisher.py` and `tests/test_mqtt_ha_discovery.py` (mock broker)
+- [x] Update `AGENTS.md` with MQTT architecture notes
+- [x] Update `RELEASE.md` when shipped
+- [x] `mqtt-tools/` folder — broker setup guide (`README.md`) and live monitor GUI (`monitor.py`)
+- [x] Console MQTT Broker panel (`GET /api/mqtt/status` + dashboard card)
+
+---
+
+## Example `docker-compose.yml` snippet
+
+```yaml
+services:
+  pypowerwall-server:
+    image: jasonacox/pypowerwall-server:latest
+    environment:
+      PW_HOST: 192.168.91.1
+      PW_GW_PWD: your_gateway_password
+      # MQTT (optional — remove to disable)
+      MQTT_HOST: 192.168.1.10
+      MQTT_PORT: 1883
+      MQTT_USERNAME: mqtt_user
+      MQTT_PASSWORD: mqtt_pass
+      MQTT_HA_DISCOVERY: "yes"
+```
+
+---
+
+## Example Home Assistant Result
+
+After enabling MQTT, the following entities appear automatically under a **"Powerwall (default)"** device in HA:
+
+```
+Powerwall (default)
+  ├── Battery              85.3 %
+  ├── Solar Power          2340 W
+  ├── Grid Power           -1100 W
+  ├── Home Power           1240 W
+  ├── Powerwall Power      1200 W
+  ├── Grid Status          Connected
+  ├── Operation Mode       self_consumption
+  └── Backup Reserve       20.0 %
+```
+
+---
+
+## Security Considerations
+
+- `MQTT_PASSWORD` is never logged or exposed in API responses
+- TLS support (`MQTT_TLS=yes`) for production broker connections
+- `MQTT_TLS_INSECURE` defaults to `no` — must be explicitly enabled for dev
+- No MQTT subscribe / inbound command handling in this design (publish-only); control commands remain exclusively through the existing `POST /control/*` HTTP endpoints

--- a/MQTT.md
+++ b/MQTT.md
@@ -343,3 +343,117 @@ Powerwall (default)
 - TLS support (`MQTT_TLS=yes`) for production broker connections
 - `MQTT_TLS_INSECURE` defaults to `no` — must be explicitly enabled for dev
 - No MQTT subscribe / inbound command handling in this design (publish-only); control commands remain exclusively through the existing `POST /control/*` HTTP endpoints
+
+
+## Test Instructions - Quick Start
+
+These steps let you verify MQTT end-to-end without a real Powerwall — using only Docker, Mosquitto, and the built-in simulator.
+
+### 1. Start a local Mosquitto broker
+
+```bash
+docker run -d --rm --name mosquitto \
+  -p 1883:1883 \
+  eclipse-mosquitto \
+  mosquitto -c /mosquitto-no-auth.conf
+```
+
+> The `-c /mosquitto-no-auth.conf` flag starts the broker with no authentication, which is fine for local testing.
+
+### 2. Subscribe to all pypowerwall topics (in a separate terminal)
+
+```bash
+docker run --rm eclipse-mosquitto \
+  mosquitto_sub -h host.docker.internal -p 1883 -v -t "pypowerwall/#"
+```
+
+You should see messages like `pypowerwall/default/battery 85.3` appear once per poll cycle.
+
+### 3. Clone the PR branch and install dependencies
+
+```bash
+git clone -b mqtt https://github.com/jasonacox/pypowerwall-server.git
+cd pypowerwall-server
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+### 4. Run the server with MQTT enabled
+
+Replace `<gateway_ip>` and `<password>` with your Powerwall's IP and local password (or use the simulator — see step 4b below):
+
+```bash
+MQTT_HOST=localhost \
+MQTT_PORT=1883 \
+MQTT_HA_DISCOVERY=true \
+PW_HOST=<gateway_ip> \
+PW_GW_PWD=<password> \
+uvicorn app.main:app --host 127.0.0.1 --port 8675
+```
+
+#### 4b. No Powerwall? Use the built-in simulator
+
+In one terminal:
+
+```bash
+cd sandbox/pwsimulator
+docker build -t pwsimulator .
+docker run --rm -p 443:443 pwsimulator
+```
+
+Then start the server pointing at the simulator:
+
+```bash
+MQTT_HOST=localhost \
+MQTT_PORT=1883 \
+MQTT_HA_DISCOVERY=true \
+PW_HOST=localhost \
+PW_GW_PWD=password \
+uvicorn app.main:app --host 127.0.0.1 --port 8675
+```
+
+### 5. Verify Home Assistant discovery payloads
+
+```bash
+docker run --rm eclipse-mosquitto \
+  mosquitto_sub -h host.docker.internal -p 1883 -v -t "homeassistant/#"
+```
+
+You should see `homeassistant/sensor/pypowerwall_default_battery/config` (and others) with JSON payloads. These are the auto-discovery messages that tell HA how to create the sensor entities.
+
+### 6. Run the unit tests
+
+No broker required — all MQTT tests use mocks:
+
+```bash
+pytest tests/test_mqtt_publisher.py tests/test_mqtt_ha_discovery.py -v
+```
+
+### 7. (Optional) Run the live monitor GUI
+
+```bash
+pip install paho-mqtt
+python mqtt-tools/monitor.py --host localhost
+```
+
+The GUI shows live battery %, power flows, grid status, and mode, updating every poll cycle. Close the window to exit.
+
+---
+
+### Expected topic output (one poll cycle)
+
+```
+pypowerwall/default/availability     online
+pypowerwall/default/battery          85.3
+pypowerwall/default/solar            2340
+pypowerwall/default/grid             -1100
+pypowerwall/default/home             1240
+pypowerwall/default/powerwall        1200
+pypowerwall/default/grid_status      UP
+pypowerwall/default/mode             self_consumption
+pypowerwall/default/reserve          20.0
+pypowerwall/default/online           true
+pypowerwall/default/aggregates       {...}
+pypowerwall/default/status           {...}
+```
+

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A high-performance FastAPI-based server for monitoring and managing Tesla Powerw
 - **Real-Time Updates** - WebSocket streaming with 1-second updates and background polling with intelligent caching
 - **Complete API** - Full backward compatibility with pypowerwall proxy plus new multi-gateway and aggregate endpoints
 - **Console Web UI** - Tesla Power Flow animation, management console, and auto-generated API documentation at /docs
-- **Planned: MQTT Integration** - Publish metrics to MQTT brokers for Home Assistant and other automation systems
+- **MQTT Integration** - Publish live Powerwall metrics to any MQTT broker; built-in Home Assistant auto-discovery; see [mqtt-tools/README.md](mqtt-tools/README.md)
 
 ## Quick Start
 
@@ -313,6 +313,37 @@ server {
 | `https://lab.lan/pypowerwall/console` | `GET /console` — Management console |
 | `https://lab.lan/pypowerwall/api/...` | `GET /api/...` — API endpoints |
 | `https://lab.lan/pypowerwall/static/...` | `GET /static/...` — Static assets |
+
+## MQTT Integration
+
+Set `MQTT_HOST` to enable publishing. All other variables are optional.
+
+```bash
+export MQTT_HOST=192.168.1.100       # broker IP — required to enable MQTT
+export MQTT_PORT=1883                # default: 1883
+export MQTT_USERNAME=mqttuser        # optional
+export MQTT_PASSWORD=mqttpassword    # optional
+export MQTT_HA_DISCOVERY=true        # auto-configure Home Assistant sensors (default: true)
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MQTT_HOST` | *(none)* | Broker hostname/IP. **Required to enable MQTT.** |
+| `MQTT_PORT` | `1883` | Broker port |
+| `MQTT_USERNAME` | *(none)* | Username for authentication |
+| `MQTT_PASSWORD` | *(none)* | Password for authentication |
+| `MQTT_TLS` | `false` | Enable TLS/SSL |
+| `MQTT_TLS_CA_CERT` | *(none)* | Path to CA certificate |
+| `MQTT_TLS_INSECURE` | `false` | Disable cert verification (testing only) |
+| `MQTT_TOPIC_PREFIX` | `pypowerwall` | Root topic prefix |
+| `MQTT_RETAIN` | `true` | Retain messages on broker |
+| `MQTT_QOS` | `1` | MQTT QoS level (0, 1, or 2) |
+| `MQTT_HA_DISCOVERY` | `true` | Publish Home Assistant auto-discovery payloads |
+| `MQTT_HA_PREFIX` | `homeassistant` | HA discovery prefix |
+| `MQTT_CLIENT_ID` | `pypowerwall-server` | MQTT client identifier |
+| `MQTT_KEEPALIVE` | `60` | Connection keepalive in seconds |
+
+Topics are published under `{MQTT_TOPIC_PREFIX}/{gateway_id}/` — e.g. `pypowerwall/default/battery`, `pypowerwall/default/solar`, etc. See [mqtt-tools/README.md](mqtt-tools/README.md) for the full topic list, broker setup guide, Home Assistant integration steps, and the live monitor GUI.
 
 ## API Endpoints
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,22 @@
 
 ## Version History
 
+### [0.3.0] - 2026-04-18
+
+**Added:**
+- **MQTT Integration** — publish live Powerwall telemetry to any MQTT broker. Set `MQTT_HOST` to enable. All sensor values are published under `{MQTT_TOPIC_PREFIX}/{gateway_id}/` with LWT (`offline`) and `availability` topics for clean broker state.
+- **Home Assistant auto-discovery** — on connect, discovery payloads are published for all sensors so they appear automatically under a single HA device card, requiring zero manual HA configuration (#21).
+- **`mqtt-tools/` folder** — `README.md` broker setup guide with CLI monitoring, HA integration steps, and live GUI instructions; `monitor.py` dark-theme tkinter GUI that subscribes to the broker and displays real-time Powerwall metrics for all gateways.
+- **Console MQTT Broker panel** — new card on the management dashboard (`/`) showing broker connectivity, topic prefix, HA discovery, QoS, retain, and TLS status. Fetched from the new `GET /api/mqtt/status` endpoint.
+- **`{prefix}/{gw}/name` topic** — friendly gateway name (from `gateways.yaml`) is published so the monitor GUI card title matches the configured name.
+- **`MqttPublisher.connected` property** — safe public accessor for broker connection state (replaces internal `_connected` access).
+- Exponential backoff reconnect in `MqttPublisher._connection_loop()` (1 s → 2 s → … → 60 s cap).
+- TLS/SSL support via `MQTT_TLS`, `MQTT_TLS_CA_CERT`, and `MQTT_TLS_INSECURE` environment variables.
+- 37 new tests: `tests/test_mqtt_publisher.py` (18) and `tests/test_mqtt_ha_discovery.py` (19), all with mock broker (no live MQTT dependency).
+
+**Changed:**
+- MQTT env variables added to `docker-compose.yml` as commented-out block for easy opt-in.
+
 ### [0.2.2] - 2026-03-04
 
 **Added:**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@
 - **Console MQTT Broker panel** — new card on the management dashboard (`/`) showing broker connectivity, topic prefix, HA discovery, QoS, retain, and TLS status. Fetched from the new `GET /api/mqtt/status` endpoint.
 - **`{prefix}/{gw}/name` topic** — friendly gateway name (from `gateways.yaml`) is published so the monitor GUI card title matches the configured name.
 - **`MqttPublisher.connected` property** — safe public accessor for broker connection state (replaces internal `_connected` access).
-- Exponential backoff reconnect in `MqttPublisher._connection_loop()` (1 s → 2 s → … → 60 s cap).
+- Exponential backoff reconnect in `MqttPublisher._connection_loop()` (2 s → 4 s → … → 60 s cap).
 - TLS/SSL support via `MQTT_TLS`, `MQTT_TLS_CA_CERT`, and `MQTT_TLS_INSECURE` environment variables.
 - 37 new tests: `tests/test_mqtt_publisher.py` (18) and `tests/test_mqtt_ha_discovery.py` (19), all with mock broker (no live MQTT dependency).
 

--- a/app/config.py
+++ b/app/config.py
@@ -176,7 +176,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.2.2"
+SERVER_VERSION = "0.3.0"
 
 
 class GatewayConfig(BaseSettings):
@@ -270,6 +270,28 @@ class Settings(BaseSettings):
 
     # CORS configuration
     cors_origins: List[str] = Field(default=["*"], alias="CORS_ORIGINS")
+
+    # MQTT settings
+    # Set MQTT_HOST to enable MQTT publishing. All other MQTT_ variables are optional.
+    mqtt_host: Optional[str] = Field(default=None, alias="MQTT_HOST")
+    mqtt_port: int = Field(default=1883, alias="MQTT_PORT")
+    mqtt_username: Optional[str] = Field(default=None, alias="MQTT_USERNAME")
+    mqtt_password: Optional[str] = Field(default=None, alias="MQTT_PASSWORD")
+    mqtt_tls: bool = Field(default=False, alias="MQTT_TLS")
+    mqtt_tls_ca_cert: Optional[str] = Field(default=None, alias="MQTT_TLS_CA_CERT")
+    mqtt_tls_insecure: bool = Field(default=False, alias="MQTT_TLS_INSECURE")
+    mqtt_topic_prefix: str = Field(default="pypowerwall", alias="MQTT_TOPIC_PREFIX")
+    mqtt_retain: bool = Field(default=True, alias="MQTT_RETAIN")
+    mqtt_qos: int = Field(default=1, alias="MQTT_QOS")
+    mqtt_ha_discovery: bool = Field(default=True, alias="MQTT_HA_DISCOVERY")
+    mqtt_ha_prefix: str = Field(default="homeassistant", alias="MQTT_HA_PREFIX")
+    mqtt_client_id: str = Field(default="pypowerwall-server", alias="MQTT_CLIENT_ID")
+    mqtt_keepalive: int = Field(default=60, alias="MQTT_KEEPALIVE")
+
+    @property
+    def mqtt_enabled(self) -> bool:
+        """MQTT publishing is enabled when MQTT_HOST is set."""
+        return bool(self.mqtt_host)
 
     # Gateway configuration
     gateways: List[GatewayConfig] = Field(default_factory=list)

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -683,6 +683,17 @@ class GatewayManager:
                 gateway=gateway, data=data, online=True, last_updated=data.timestamp
             )
 
+            # Fire-and-forget MQTT publish after the cache is updated.
+            # Importing here (late import) avoids a circular dependency at module
+            # load time (publisher.py → config → gateway_manager).
+            # create_task() ensures MQTT failures never raise into this poll path.
+            from app.mqtt.publisher import mqtt_publisher
+            if mqtt_publisher.enabled:
+                asyncio.create_task(
+                    mqtt_publisher.publish_gateway(gateway_id, self.cache[gateway_id]),
+                    name=f"mqtt-publish-{gateway_id}",
+                )
+
         except Exception as e:
             gateway = self.gateways[gateway_id]
 

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -737,6 +737,14 @@ class GatewayManager:
                 gateway=gateway, online=False, error=str(e), last_updated=now
             )
 
+            # Publish the offline status to MQTT so HA reflects gateway going offline.
+            from app.mqtt.publisher import mqtt_publisher
+            if mqtt_publisher.enabled:
+                asyncio.create_task(
+                    mqtt_publisher.publish_gateway(gateway_id, self.cache[gateway_id]),
+                    name=f"mqtt-publish-{gateway_id}",
+                )
+
     def get_gateway(self, gateway_id: str) -> Optional[GatewayStatus]:
         """Get status for a specific gateway with graceful degradation support.
 

--- a/app/main.py
+++ b/app/main.py
@@ -138,10 +138,19 @@ async def lifespan(app: FastAPI):
             mode_info = gateway.host or "TEDAPI"
         logger.info(f"  - {gateway_id}: {gateway.name} ({mode_info})")
 
+    # Start MQTT publisher (no-op when MQTT_HOST is not set)
+    from app.mqtt.publisher import mqtt_publisher
+    await mqtt_publisher.start()
+    if settings.mqtt_enabled:
+        logger.info(
+            f"MQTT publisher enabled — broker: {settings.mqtt_host}:{settings.mqtt_port}"
+        )
+
     yield
 
     # Shutdown
     logger.info("Shutting down PyPowerwall Server...")
+    await mqtt_publisher.stop()
     await gateway_manager.shutdown()
 
 
@@ -310,6 +319,25 @@ app.include_router(aggregates.router, prefix="/api/aggregate", tags=["Aggregates
 app.include_router(websockets.router, prefix="/ws", tags=["WebSockets"])
 
 app.include_router(legacy.router, tags=["Legacy Proxy Compatibility"])
+
+
+@app.get("/api/mqtt/status", tags=["MQTT"])
+async def get_mqtt_status():
+    """Get MQTT publisher status and configuration."""
+    from app.config import settings
+    from app.mqtt.publisher import mqtt_publisher
+
+    return {
+        "enabled": settings.mqtt_enabled,
+        "host": settings.mqtt_host,
+        "port": settings.mqtt_port,
+        "connected": mqtt_publisher.connected if settings.mqtt_enabled else False,
+        "topic_prefix": settings.mqtt_topic_prefix,
+        "ha_discovery": settings.mqtt_ha_discovery,
+        "qos": settings.mqtt_qos,
+        "retain": settings.mqtt_retain,
+        "tls": settings.mqtt_tls,
+    }
 
 # Mount static files
 app.mount("/static", StaticFiles(directory=str(static_path)), name="static")

--- a/app/models/gateway.py
+++ b/app/models/gateway.py
@@ -1,6 +1,6 @@
 """Pydantic models for gateway configuration and data."""
 from typing import Optional, Dict, Any, List, Union
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
 
 
 class Gateway(BaseModel):

--- a/app/mqtt/__init__.py
+++ b/app/mqtt/__init__.py
@@ -1,0 +1,4 @@
+"""MQTT publisher for pypowerwall-server."""
+from app.mqtt.publisher import mqtt_publisher
+
+__all__ = ["mqtt_publisher"]

--- a/app/mqtt/ha_discovery.py
+++ b/app/mqtt/ha_discovery.py
@@ -1,0 +1,231 @@
+"""
+Home Assistant MQTT Discovery — builds and publishes auto-discovery payloads.
+
+When MQTT_HA_DISCOVERY=true (default), calling publish_discovery() for a gateway
+causes Home Assistant to automatically create a "Powerwall" device with all sensors
+grouped under it — no manual YAML configuration needed.
+
+Discovery topics follow the HA convention:
+    {ha_prefix}/sensor/pypowerwall_{gateway_id}_{sensor}/config
+
+Each payload is retained so HA re-reads it after restarts.
+
+Sensor catalogue
+----------------
+Sensors (numeric):
+    battery     — Battery charge (%, device_class=battery)
+    solar       — Solar power (W, device_class=power)
+    grid        — Grid power (W, device_class=power, positive=importing)
+    home        — Home load (W, device_class=power)
+    powerwall   — Powerwall power (W, device_class=power, positive=discharging)
+    reserve     — Backup reserve target (%)
+
+Text sensors:
+    grid_status — "UP" | "DOWN" | "unknown"
+    mode        — Operation mode string (e.g. "self_consumption", "backup")
+    version     — Firmware version string
+
+Binary sensor:
+    online      — Gateway connection status
+
+All sensors share a single "Powerwall" device block so HA groups them together.
+The device model is set from PowerwallData.version when available, otherwise
+"Powerwall".
+
+References
+----------
+    https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+    https://www.home-assistant.io/integrations/sensor.mqtt/
+    https://www.home-assistant.io/integrations/binary_sensor.mqtt/
+"""
+import json
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _device_block(gateway_id: str, gateway_name: str, version: Optional[str]) -> dict:
+    """Build the shared HA device block for all sensors on this gateway."""
+    return {
+        "identifiers": [f"pypowerwall_{gateway_id}"],
+        "name": gateway_name,
+        "manufacturer": "Tesla",
+        "model": "Powerwall",
+        "sw_version": version or "unknown",
+        "via_device": "pypowerwall-server",
+    }
+
+
+def build_discovery_payloads(
+    gateway_id: str,
+    gateway_name: str,
+    topic_prefix: str,
+    ha_prefix: str,
+    version: Optional[str] = None,
+) -> list[tuple[str, str]]:
+    """Build all HA auto-discovery (topic, payload) pairs for a gateway.
+
+    Args:
+        gateway_id:    Gateway identifier (slug used in topics/unique IDs).
+        gateway_name:  Human-readable name shown in HA device card.
+        topic_prefix:  MQTT topic prefix (e.g. "pypowerwall").
+        ha_prefix:     Home Assistant discovery prefix (e.g. "homeassistant").
+        version:       Powerwall firmware version string (optional).
+
+    Returns:
+        List of (topic, json_payload_str) tuples, one per sensor/binary sensor.
+    """
+    device = _device_block(gateway_id, gateway_name, version)
+    data_prefix = f"{topic_prefix}/{gateway_id}"
+    avail_topic = f"{data_prefix}/availability"
+
+    def avail() -> list:
+        return [{"topic": avail_topic, "payload_available": "online", "payload_not_available": "offline"}]
+
+    def sensor(
+        uid_suffix: str,
+        name: str,
+        state_topic: str,
+        unit: Optional[str] = None,
+        device_class: Optional[str] = None,
+        state_class: str = "measurement",
+        icon: Optional[str] = None,
+        entity_category: Optional[str] = None,
+    ) -> tuple[str, str]:
+        """Build a single numeric/text sensor discovery entry."""
+        unique_id = f"pypowerwall_{gateway_id}_{uid_suffix}"
+        disc_topic = f"{ha_prefix}/sensor/{unique_id}/config"
+        payload: dict = {
+            "name": name,
+            "unique_id": unique_id,
+            "state_topic": state_topic,
+            "device": device,
+            "availability": avail(),
+            "availability_mode": "any",
+        }
+        if unit:
+            payload["unit_of_measurement"] = unit
+        if device_class:
+            payload["device_class"] = device_class
+        if state_class:
+            payload["state_class"] = state_class
+        if icon:
+            payload["icon"] = icon
+        if entity_category:
+            payload["entity_category"] = entity_category
+        return disc_topic, json.dumps(payload)
+
+    def binary_sensor(
+        uid_suffix: str,
+        name: str,
+        state_topic: str,
+        payload_on: str = "true",
+        payload_off: str = "false",
+        device_class: Optional[str] = None,
+        icon: Optional[str] = None,
+    ) -> tuple[str, str]:
+        """Build a single binary sensor discovery entry."""
+        unique_id = f"pypowerwall_{gateway_id}_{uid_suffix}"
+        disc_topic = f"{ha_prefix}/binary_sensor/{unique_id}/config"
+        payload: dict = {
+            "name": name,
+            "unique_id": unique_id,
+            "state_topic": state_topic,
+            "payload_on": payload_on,
+            "payload_off": payload_off,
+            "device": device,
+            "availability": avail(),
+            "availability_mode": "any",
+        }
+        if device_class:
+            payload["device_class"] = device_class
+        if icon:
+            payload["icon"] = icon
+        return disc_topic, json.dumps(payload)
+
+    results: list[tuple[str, str]] = [
+        # --- Numeric sensors ---
+        sensor(
+            "battery", "Battery",
+            f"{data_prefix}/battery",
+            unit="%",
+            device_class="battery",
+            state_class="measurement",
+        ),
+        sensor(
+            "solar", "Solar Power",
+            f"{data_prefix}/solar",
+            unit="W",
+            device_class="power",
+            state_class="measurement",
+            icon="mdi:solar-power",
+        ),
+        sensor(
+            "grid", "Grid Power",
+            f"{data_prefix}/grid",
+            unit="W",
+            device_class="power",
+            state_class="measurement",
+            icon="mdi:transmission-tower",
+        ),
+        sensor(
+            "home", "Home Load",
+            f"{data_prefix}/home",
+            unit="W",
+            device_class="power",
+            state_class="measurement",
+            icon="mdi:home-lightning-bolt",
+        ),
+        sensor(
+            "powerwall", "Powerwall Power",
+            f"{data_prefix}/powerwall",
+            unit="W",
+            device_class="power",
+            state_class="measurement",
+            icon="mdi:battery-charging",
+        ),
+        sensor(
+            "reserve", "Backup Reserve",
+            f"{data_prefix}/reserve",
+            unit="%",
+            state_class="measurement",
+            icon="mdi:battery-lock",
+        ),
+        # --- Text sensors ---
+        sensor(
+            "grid_status", "Grid Status",
+            f"{data_prefix}/grid_status",
+            unit=None,
+            device_class=None,
+            state_class=None,  # type: ignore[arg-type]
+            icon="mdi:transmission-tower",
+        ),
+        sensor(
+            "mode", "Operation Mode",
+            f"{data_prefix}/mode",
+            unit=None,
+            device_class=None,
+            state_class=None,  # type: ignore[arg-type]
+            icon="mdi:cog",
+        ),
+        sensor(
+            "version", "Firmware Version",
+            f"{data_prefix}/version",
+            unit=None,
+            device_class=None,
+            state_class=None,  # type: ignore[arg-type]
+            icon="mdi:information",
+            entity_category="diagnostic",
+        ),
+        # --- Binary sensor ---
+        binary_sensor(
+            "online", "Gateway Online",
+            f"{data_prefix}/online",
+            payload_on="true",
+            payload_off="false",
+            device_class="connectivity",
+            icon="mdi:lan-connect",
+        ),
+    ]
+    return results

--- a/app/mqtt/ha_discovery.py
+++ b/app/mqtt/ha_discovery.py
@@ -53,7 +53,6 @@ def _device_block(gateway_id: str, gateway_name: str, version: Optional[str]) ->
         "manufacturer": "Tesla",
         "model": "Powerwall",
         "sw_version": version or "unknown",
-        "via_device": "pypowerwall-server",
     }
 
 

--- a/app/mqtt/ha_discovery.py
+++ b/app/mqtt/ha_discovery.py
@@ -80,8 +80,17 @@ def build_discovery_payloads(
     data_prefix = f"{topic_prefix}/{gateway_id}"
     avail_topic = f"{data_prefix}/availability"
 
+    # Both the per-gateway topic and the global LWT topic are included so that
+    # HA marks entities unavailable when either the gateway goes offline
+    # (per-gateway) OR the server crashes/disconnects (global LWT).
+    # "all" mode: entity is available only when EVERY topic says "online".
+    global_avail_topic = f"{topic_prefix}/availability"
+
     def avail() -> list:
-        return [{"topic": avail_topic, "payload_available": "online", "payload_not_available": "offline"}]
+        return [
+            {"topic": avail_topic, "payload_available": "online", "payload_not_available": "offline"},
+            {"topic": global_avail_topic, "payload_available": "online", "payload_not_available": "offline"},
+        ]
 
     def sensor(
         uid_suffix: str,
@@ -102,7 +111,7 @@ def build_discovery_payloads(
             "state_topic": state_topic,
             "device": device,
             "availability": avail(),
-            "availability_mode": "any",
+            "availability_mode": "all",
         }
         if unit:
             payload["unit_of_measurement"] = unit
@@ -136,7 +145,7 @@ def build_discovery_payloads(
             "payload_off": payload_off,
             "device": device,
             "availability": avail(),
-            "availability_mode": "any",
+            "availability_mode": "all",
         }
         if device_class:
             payload["device_class"] = device_class

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -1,0 +1,408 @@
+"""
+MQTT Publisher — pushes Powerwall telemetry to an MQTT broker.
+
+Enabled by setting MQTT_HOST in environment (see app/config.py for full variable list).
+When MQTT_HOST is not set this module is completely inert — no imports of aiomqtt
+happen, no background task is started, and no code paths in the poll loop are changed.
+
+Architecture
+------------
+A single long-running asyncio task (_connection_loop) maintains a persistent
+connection to the broker with automatic reconnect and exponential backoff.
+After each successful gateway poll, gateway_manager calls:
+
+    asyncio.create_task(mqtt_publisher.publish_gateway(gateway_id, status))
+
+The task is fire-and-forget: MQTT failures are logged at DEBUG level and never
+propagate back to the poll loop, so HTTP API reliability is unaffected.
+
+Thread safety
+-------------
+The publisher runs entirely within the asyncio event loop.  No threading locks
+are required because all state mutations happen from coroutines (single thread).
+The _connected flag and _client reference are read/written only from coroutines.
+
+Reconnect strategy
+------------------
+The connection loop uses exponential backoff: 2 s, 4 s, 8 s … capped at 60 s.
+On each successful publish failure, _connected is set to False; the connection
+loop detects this on its next 5-second heartbeat and tears down the context
+manager, triggering the outer reconnect logic.
+
+Topic layout
+------------
+    {prefix}/{gateway_id}/battery         float  — SOE %
+    {prefix}/{gateway_id}/solar           float  — W (positive = producing)
+    {prefix}/{gateway_id}/grid            float  — W (positive = importing)
+    {prefix}/{gateway_id}/home            float  — W
+    {prefix}/{gateway_id}/powerwall       float  — W (positive = discharging)
+    {prefix}/{gateway_id}/grid_status     str    — "UP" | "DOWN" | "unknown"
+    {prefix}/{gateway_id}/mode            str    — operation mode
+    {prefix}/{gateway_id}/reserve         float  — backup reserve %
+    {prefix}/{gateway_id}/online          str    — "true" | "false"
+    {prefix}/{gateway_id}/aggregates      JSON   — full aggregates dict
+    {prefix}/{gateway_id}/status          JSON   — summary dict
+    {prefix}/{gateway_id}/availability    str    — "online" | "offline" (LWT)
+"""
+import asyncio
+import json
+import logging
+import ssl
+from typing import Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+class MqttPublisher:
+    """Async MQTT publisher with persistent connection and reconnect logic."""
+
+    def __init__(self):
+        self._client = None              # aiomqtt.Client instance (inside context)
+        self._connected: bool = False    # True only while inside active async with
+        self._connection_task: Optional[asyncio.Task] = None
+        self._shutdown: bool = False
+        self._discovery_sent: Set[str] = set()   # gateway IDs with discovery published
+        self._backoff: int = 2           # current reconnect backoff in seconds
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def enabled(self) -> bool:
+        """True when MQTT_HOST is configured."""
+        from app.config import settings  # late import — avoids circular deps
+        return settings.mqtt_enabled
+
+    @property
+    def connected(self) -> bool:
+        """True when the broker connection is currently active."""
+        return self._connected
+
+    async def start(self) -> None:
+        """Start the background connection task.  Called from main.py lifespan."""
+        if not self.enabled:
+            return
+        self._shutdown = False
+        self._connection_task = asyncio.create_task(
+            self._connection_loop(), name="mqtt-connection"
+        )
+        logger.info("MQTT publisher starting...")
+
+    async def stop(self) -> None:
+        """Gracefully stop the publisher.  Called from main.py lifespan shutdown."""
+        if not self.enabled:
+            return
+        self._shutdown = True
+        if self._connection_task and not self._connection_task.done():
+            self._connection_task.cancel()
+            try:
+                await self._connection_task
+            except asyncio.CancelledError:
+                pass
+        logger.info("MQTT publisher stopped.")
+
+    async def _publish_ha_discovery(self, gateway_id: str, status) -> None:
+        """Publish Home Assistant auto-discovery payloads for a gateway.
+
+        Called once per gateway on first connection (tracked in _discovery_sent).
+        Re-sent after every broker reconnect so HA re-discovers after restarts.
+
+        Args:
+            gateway_id: Gateway identifier.
+            status:     GatewayStatus used to extract name and version.
+        """
+        if not self._connected or self._client is None:
+            return
+        try:
+            from app.config import settings  # late import
+            from app.mqtt.ha_discovery import build_discovery_payloads
+
+            gateway_name = (
+                status.gateway.name
+                if status.gateway and status.gateway.name
+                else gateway_id
+            )
+            version = status.data.version if status.data else None
+
+            payloads = build_discovery_payloads(
+                gateway_id=gateway_id,
+                gateway_name=gateway_name,
+                topic_prefix=settings.mqtt_topic_prefix,
+                ha_prefix=settings.mqtt_ha_prefix,
+                version=version,
+            )
+            for topic, payload in payloads:
+                await self._safe_publish(topic, payload, retain=True, qos=1)
+
+            logger.info(
+                f"MQTT HA discovery published for gateway '{gateway_id}' "
+                f"({len(payloads)} entities)"
+            )
+        except Exception as e:
+            logger.debug(f"MQTT HA discovery error for {gateway_id}: {e}")
+
+    async def publish_gateway(self, gateway_id: str, status) -> None:
+        """Publish all sensor topics for a single gateway after a successful poll.
+
+        This is called from gateway_manager._poll_gateway() via create_task(),
+        so it runs as a fire-and-forget coroutine.  All exceptions are swallowed.
+
+        Args:
+            gateway_id: Gateway identifier (used as sub-topic component).
+            status:     GatewayStatus object with current data.
+        """
+        if not self._connected or self._client is None:
+            return
+
+        # Send HA discovery payloads the first time we see this gateway
+        # (also re-sent after reconnect since _discovery_sent is cleared there)
+        if gateway_id not in self._discovery_sent:
+            from app.config import settings  # late import
+            if settings.mqtt_ha_discovery:
+                await self._publish_ha_discovery(gateway_id, status)
+            self._discovery_sent.add(gateway_id)
+
+        try:
+            from app.config import settings  # late import
+            prefix = f"{settings.mqtt_topic_prefix}/{gateway_id}"
+            qos = settings.mqtt_qos
+            retain = settings.mqtt_retain
+
+            data = status.data
+
+            # --- scalar sensor topics ---
+            await self._safe_publish(
+                f"{prefix}/online",
+                "true" if status.online else "false",
+                retain, qos,
+            )
+
+            # Gateway friendly name (from gateways.yaml)
+            if status.gateway and status.gateway.name:
+                await self._safe_publish(
+                    f"{prefix}/name", status.gateway.name, retain, qos
+                )
+
+            if data is not None:
+                # Battery state-of-energy
+                if data.soe is not None:
+                    await self._safe_publish(
+                        f"{prefix}/battery", f"{data.soe:.1f}", retain, qos
+                    )
+
+                # Power flow from aggregates
+                if data.aggregates:
+                    agg = data.aggregates
+                    solar = _extract_power(agg, "solar")
+                    grid = _extract_power(agg, "site")
+                    home = _extract_power(agg, "load")
+                    pw_power = _extract_power(agg, "battery")
+
+                    if solar is not None:
+                        await self._safe_publish(
+                            f"{prefix}/solar", f"{solar:.1f}", retain, qos
+                        )
+                    if grid is not None:
+                        await self._safe_publish(
+                            f"{prefix}/grid", f"{grid:.1f}", retain, qos
+                        )
+                    if home is not None:
+                        await self._safe_publish(
+                            f"{prefix}/home", f"{home:.1f}", retain, qos
+                        )
+                    if pw_power is not None:
+                        await self._safe_publish(
+                            f"{prefix}/powerwall", f"{pw_power:.1f}", retain, qos
+                        )
+
+                    # Full aggregates JSON (useful for Node-RED, InfluxDB, etc.)
+                    await self._safe_publish(
+                        f"{prefix}/aggregates",
+                        json.dumps(agg),
+                        retain, qos,
+                    )
+
+                if data.grid_status is not None:
+                    await self._safe_publish(
+                        f"{prefix}/grid_status",
+                        str(data.grid_status),
+                        retain, qos,
+                    )
+
+                if data.mode is not None:
+                    await self._safe_publish(
+                        f"{prefix}/mode", str(data.mode), retain, qos
+                    )
+
+                if data.reserve is not None:
+                    await self._safe_publish(
+                        f"{prefix}/reserve", f"{data.reserve:.1f}", retain, qos
+                    )
+
+                if data.version is not None:
+                    await self._safe_publish(
+                        f"{prefix}/version", str(data.version), retain, qos
+                    )
+
+                # Summary JSON topic
+                summary = {
+                    "online": status.online,
+                    "soe": data.soe,
+                    "solar": solar if data.aggregates else None,
+                    "grid": grid if data.aggregates else None,
+                    "home": home if data.aggregates else None,
+                    "powerwall": pw_power if data.aggregates else None,
+                    "grid_status": data.grid_status,
+                    "mode": data.mode,
+                    "reserve": data.reserve,
+                    "version": data.version,
+                }
+                await self._safe_publish(
+                    f"{prefix}/status", json.dumps(summary), retain, qos
+                )
+
+            # Mark availability as online
+            await self._safe_publish(
+                f"{prefix}/availability", "online", retain, qos
+            )
+
+        except Exception as e:
+            # Catch-all: MQTT must never raise into the poll loop
+            logger.debug(f"MQTT publish_gateway error for {gateway_id}: {e}")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _safe_publish(
+        self, topic: str, payload: str, retain: bool, qos: int
+    ) -> None:
+        """Publish a single message, marking disconnected on failure."""
+        if not self._connected or self._client is None:
+            return
+        try:
+            await self._client.publish(topic, payload, qos=qos, retain=retain)
+        except Exception as e:
+            logger.debug(f"MQTT publish failed on {topic}: {e}")
+            # Signal the connection loop to reconnect
+            self._connected = False
+
+    async def _connection_loop(self) -> None:
+        """Maintain a persistent MQTT connection with exponential-backoff reconnect.
+
+        Design
+        ------
+        * Outer while loop: reconnect on any error.
+        * Inner while loop: heartbeat that keeps the async-with context alive
+          and detects when _connected has been set to False by a failed publish.
+        * On CancelledError (shutdown): exits cleanly.
+        * LWT (Last Will and Testament) ensures the broker publishes "offline"
+          to the availability topics if the connection drops unexpectedly.
+        """
+        try:
+            import aiomqtt  # deferred — only loaded when MQTT is enabled
+        except ImportError:
+            logger.error(
+                "aiomqtt is not installed. "
+                "Install it with: pip install 'aiomqtt>=2.3.0'"
+            )
+            return
+
+        from app.config import settings  # late import
+
+        self._backoff = 2
+
+        while not self._shutdown:
+            try:
+                # Build Last-Will-and-Testament payloads for all known gateway IDs.
+                # We use the first gateway's availability topic for the LWT; individual
+                # gateway availability is updated inside publish_gateway().
+                # This is a best-effort LWT — the broker publishes it if we disconnect
+                # without a clean DISCONNECT packet (e.g. crash, network loss).
+                will_topic = f"{settings.mqtt_topic_prefix}/availability"
+                will = aiomqtt.Will(
+                    topic=will_topic,
+                    payload="offline",
+                    qos=1,
+                    retain=True,
+                )
+
+                # Build TLS context if requested
+                tls_context: Optional[ssl.SSLContext] = None
+                if settings.mqtt_tls:
+                    tls_context = ssl.create_default_context(
+                        cafile=settings.mqtt_tls_ca_cert or None
+                    )
+                    if settings.mqtt_tls_insecure:
+                        tls_context.check_hostname = False
+                        tls_context.verify_mode = ssl.CERT_NONE
+
+                client_kwargs = dict(
+                    hostname=settings.mqtt_host,
+                    port=settings.mqtt_port,
+                    username=settings.mqtt_username,
+                    password=settings.mqtt_password,
+                    keepalive=settings.mqtt_keepalive,
+                    identifier=settings.mqtt_client_id,
+                    will=will,
+                    tls_context=tls_context,
+                )
+
+                logger.info(
+                    f"MQTT connecting to {settings.mqtt_host}:{settings.mqtt_port}"
+                )
+
+                async with aiomqtt.Client(**client_kwargs) as client:
+                    self._client = client
+                    self._connected = True
+                    self._backoff = 2  # reset on successful connect
+                    # Clear discovery set so HA payloads are re-sent after reconnect
+                    self._discovery_sent.clear()
+                    logger.info(
+                        f"MQTT connected to {settings.mqtt_host}:{settings.mqtt_port}"
+                    )
+
+                    # Inner heartbeat loop: stays alive until a publish failure
+                    # sets _connected=False, or until shutdown is requested.
+                    # The 5-second sleep matches the default poll interval so we
+                    # detect disconnect promptly without busy-waiting.
+                    while self._connected and not self._shutdown:
+                        await asyncio.sleep(5)
+
+                    # If we exited the inner loop due to a publish failure
+                    # (not shutdown), let the context manager close cleanly then
+                    # fall through to the reconnect logic below.
+                    if not self._shutdown:
+                        logger.debug("MQTT inner loop exited — reconnecting...")
+
+            except asyncio.CancelledError:
+                # Shutdown requested — exit cleanly
+                self._connected = False
+                self._client = None
+                break
+
+            except Exception as e:
+                self._connected = False
+                self._client = None
+                if not self._shutdown:
+                    logger.warning(
+                        f"MQTT connection error: {e}. Retrying in {self._backoff}s"
+                    )
+                    await asyncio.sleep(self._backoff)
+                    self._backoff = min(self._backoff * 2, 60)
+
+        self._connected = False
+        self._client = None
+
+
+def _extract_power(aggregates: dict, key: str) -> Optional[float]:
+    """Safely extract instant_power (W) from an aggregates dict."""
+    try:
+        return float(aggregates[key]["instant_power"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+# Module-level singleton — imported by gateway_manager and main.py
+mqtt_publisher = MqttPublisher()

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -363,6 +363,17 @@ class MqttPublisher:
                         f"MQTT connected to {settings.mqtt_host}:{settings.mqtt_port}"
                     )
 
+                    # Publish the global "online" availability heartbeat.
+                    # This is the retained counterpart to the LWT "offline" payload.
+                    # HA discovery payloads reference this topic with
+                    # availability_mode="all", so without this message every entity
+                    # stays stuck at "unavailable" even when state data is flowing.
+                    global_avail_topic = f"{settings.mqtt_topic_prefix}/availability"
+                    await self._safe_publish(
+                        global_avail_topic, "online",
+                        retain=True, qos=settings.mqtt_qos,
+                    )
+
                     # Inner heartbeat loop: stays alive until a publish failure
                     # sets _connected=False, or until shutdown is requested.
                     # The 5-second sleep matches the default poll interval so we

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -133,7 +133,7 @@ class MqttPublisher:
                 version=version,
             )
             for topic, payload in payloads:
-                await self._safe_publish(topic, payload, retain=True, qos=1)
+                await self._safe_publish(topic, payload, retain=True, qos=settings.mqtt_qos)
 
             logger.info(
                 f"MQTT HA discovery published for gateway '{gateway_id}' "

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -666,6 +666,39 @@
         .gateways-card {
             grid-column: span 12;
         }
+
+        /* MQTT Card */
+        .mqtt-card {
+            grid-column: span 12;
+        }
+        .mqtt-status-badge {
+            font-size: 0.8em;
+            font-weight: 600;
+            padding: 3px 10px;
+            border-radius: 12px;
+            background: rgba(255,255,255,0.06);
+            color: var(--text-secondary);
+        }
+        .mqtt-status-badge.connected {
+            background: rgba(63, 185, 80, 0.15);
+            color: var(--accent-green);
+        }
+        .mqtt-status-badge.disconnected {
+            background: rgba(248, 81, 73, 0.15);
+            color: var(--accent-red);
+        }
+        .mqtt-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 8px;
+        }
+        .mqtt-grid .health-item {
+            padding: 8px 12px;
+            border-left: 3px solid var(--text-muted);
+        }
+        .mqtt-grid .health-value {
+            font-size: 0.95em;
+        }
         
         .gateway-list {
             display: grid;
@@ -1172,6 +1205,52 @@
                     <div class="no-strings">Loading gateways...</div>
                 </div>
             </div>
+
+            <!-- MQTT Broker (hidden until MQTT is configured) -->
+            <div class="card mqtt-card" id="mqtt-card" style="display:none">
+                <div class="card-header">
+                    <div class="card-title">
+                        <span class="icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" fill="none"/>
+                                <polyline points="9 22 9 12 15 12 15 22" fill="none"/>
+                            </svg>
+                        </span>
+                        MQTT Broker
+                    </div>
+                    <div class="mqtt-status-badge" id="mqtt-status-badge">--</div>
+                </div>
+                <div class="mqtt-grid">
+                    <div class="health-item">
+                        <div class="health-label">Broker</div>
+                        <div class="health-value" id="mqtt-broker">--</div>
+                    </div>
+                    <div class="health-item">
+                        <div class="health-label">Connection</div>
+                        <div class="health-value" id="mqtt-connection">--</div>
+                    </div>
+                    <div class="health-item">
+                        <div class="health-label">Topic Prefix</div>
+                        <div class="health-value" id="mqtt-prefix">--</div>
+                    </div>
+                    <div class="health-item">
+                        <div class="health-label">HA Discovery</div>
+                        <div class="health-value" id="mqtt-ha">--</div>
+                    </div>
+                    <div class="health-item">
+                        <div class="health-label">QoS</div>
+                        <div class="health-value" id="mqtt-qos">--</div>
+                    </div>
+                    <div class="health-item">
+                        <div class="health-label">Retain</div>
+                        <div class="health-value" id="mqtt-retain">--</div>
+                    </div>
+                    <div class="health-item">
+                        <div class="health-label">TLS</div>
+                        <div class="health-value" id="mqtt-tls">--</div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     
@@ -1512,6 +1591,40 @@
         }
 
         // Fetch server stats
+        async function loadMqtt() {
+            try {
+                const response = await fetch('/api/mqtt/status');
+                if (!response.ok) return;
+                const mqtt = await response.json();
+                if (!mqtt.enabled) return;
+
+                document.getElementById('mqtt-card').style.display = '';
+                document.getElementById('mqtt-broker').textContent = `${mqtt.host}:${mqtt.port}`;
+
+                const badge = document.getElementById('mqtt-status-badge');
+                const connEl = document.getElementById('mqtt-connection');
+                if (mqtt.connected) {
+                    badge.textContent = '● Connected';
+                    badge.className = 'mqtt-status-badge connected';
+                    connEl.textContent = '● Connected';
+                    connEl.style.color = 'var(--accent-green)';
+                } else {
+                    badge.textContent = '● Disconnected';
+                    badge.className = 'mqtt-status-badge disconnected';
+                    connEl.textContent = '● Disconnected';
+                    connEl.style.color = 'var(--accent-red)';
+                }
+
+                document.getElementById('mqtt-prefix').textContent = mqtt.topic_prefix;
+                document.getElementById('mqtt-ha').textContent = mqtt.ha_discovery ? 'Enabled' : 'Disabled';
+                document.getElementById('mqtt-qos').textContent = `QoS ${mqtt.qos}`;
+                document.getElementById('mqtt-retain').textContent = mqtt.retain ? 'Yes' : 'No';
+                document.getElementById('mqtt-tls').textContent = mqtt.tls ? 'Enabled' : 'Disabled';
+            } catch (e) {
+                // MQTT endpoint unavailable — silently skip
+            }
+        }
+
         async function loadStats() {
             try {
                 const response = await fetch('/stats');
@@ -2045,6 +2158,7 @@
             loadStats();
             loadPowerwalls();
             loadGateways();
+            loadMqtt();
 
             // Refresh secondary data periodically
             setInterval(() => {
@@ -2053,6 +2167,7 @@
                 loadStats();
                 loadPowerwalls();
                 loadGateways();
+                loadMqtt();
             }, 30000);
         })();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,15 @@ services:
       # Reverse proxy sub-path (optional) - uncomment if serving under a prefix
       # - PROXY_BASE_URL=/pypowerwall
       
+      # MQTT (optional) - uncomment and set MQTT_HOST to enable
+      # - MQTT_HOST=192.168.1.100
+      # - MQTT_PORT=1883
+      # - MQTT_USERNAME=mqttuser
+      # - MQTT_PASSWORD=mqttpassword
+      # - MQTT_HA_DISCOVERY=true      # auto-configure Home Assistant sensors
+      # - MQTT_TOPIC_PREFIX=pypowerwall
+      # - MQTT_TLS=false
+      
       # Control features (optional) - Uncomment to enable:
       # - CONTROL_ENABLED=true
       # - CONTROL_TOKEN=your-secure-random-token-here

--- a/mqtt-tools/README.md
+++ b/mqtt-tools/README.md
@@ -1,0 +1,428 @@
+# pypowerwall-server MQTT Tools
+
+This folder contains tooling to help you set up and use the MQTT integration
+built into pypowerwall-server.
+
+---
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `monitor.py` | Live Python/tkinter GUI - connects to your broker and displays real-time Powerwall data |
+
+---
+
+## 1. Setting Up an MQTT Broker
+
+pypowerwall-server can publish to **any** MQTT broker.
+The simplest option for home use is **Mosquitto**, the reference open-source broker.
+
+### Option A - Docker (recommended, one command)
+
+```bash
+# Run a basic Mosquitto broker on port 1883
+docker run -d \
+  --name mosquitto \
+  --restart unless-stopped \
+  -p 1883:1883 \
+  -p 9001:9001 \
+  eclipse-mosquitto
+```
+
+> **Note:** The default Docker image starts with no persistent config, which is
+> fine for testing. For production see Option B.
+
+### Option B - Docker with authentication and persistence
+
+1. Create a config folder:
+
+   ```bash
+   mkdir -p ~/mosquitto/{config,data,log}
+   ```
+
+2. Create `~/mosquitto/config/mosquitto.conf`:
+
+   ```
+   # Allow connections on standard port
+   listener 1883
+   protocol mqtt
+
+   # Require password authentication
+   allow_anonymous false
+   password_file /mosquitto/config/passwd
+
+   # Persistence
+   persistence true
+   persistence_location /mosquitto/data/
+
+   # Logging
+   log_dest file /mosquitto/log/mosquitto.log
+   log_type all
+   ```
+
+3. Create a user account (replace `mqttuser` / `mqttpassword`):
+
+   ```bash
+   docker run --rm -v ~/mosquitto/config:/mosquitto/config \
+     eclipse-mosquitto \
+     mosquitto_passwd -c /mosquitto/config/passwd mqttuser
+   # Enter password when prompted
+   ```
+
+4. Start the broker:
+
+   ```bash
+   docker run -d \
+     --name mosquitto \
+     --restart unless-stopped \
+     -p 1883:1883 \
+     -v ~/mosquitto/config:/mosquitto/config \
+     -v ~/mosquitto/data:/mosquitto/data \
+     -v ~/mosquitto/log:/mosquitto/log \
+     eclipse-mosquitto
+   ```
+
+### Option C - Native install (Debian / Ubuntu / Raspberry Pi OS)
+
+```bash
+sudo apt update && sudo apt install -y mosquitto mosquitto-clients
+
+# Enable and start
+sudo systemctl enable mosquitto
+sudo systemctl start mosquitto
+
+# Optional: create a user
+sudo mosquitto_passwd -c /etc/mosquitto/passwd mqttuser
+# Add to /etc/mosquitto/mosquitto.conf:
+#   allow_anonymous false
+#   password_file /etc/mosquitto/passwd
+sudo systemctl restart mosquitto
+```
+
+### Option D - macOS (Homebrew)
+
+```bash
+brew install mosquitto
+brew services start mosquitto
+# Config file: /opt/homebrew/etc/mosquitto/mosquitto.conf
+```
+
+### Verify the broker works
+
+```bash
+# Subscribe to all topics in one terminal
+mosquitto_sub -h localhost -t '#' -v
+
+# Publish a test message in another terminal
+mosquitto_pub -h localhost -t test/hello -m "world"
+```
+
+---
+
+## 2. Configuring pypowerwall-server for MQTT
+
+Set environment variables before starting the server.  The only **required**
+variable is `MQTT_HOST`:
+
+```bash
+export MQTT_HOST=192.168.1.100       # Your broker's IP or hostname
+export MQTT_PORT=1883                # Default: 1883
+export MQTT_USERNAME=mqttuser        # Optional
+export MQTT_PASSWORD=mqttpassword    # Optional
+export MQTT_TOPIC_PREFIX=pypowerwall # Default: pypowerwall
+```
+
+Or add them to `docker-compose.yml` (see the commented-out block in the root
+`docker-compose.yml`):
+
+```yaml
+services:
+  pypowerwall-server:
+    environment:
+      - MQTT_HOST=192.168.1.100
+      - MQTT_PORT=1883
+      - MQTT_USERNAME=mqttuser
+      - MQTT_PASSWORD=mqttpassword
+      - MQTT_HA_DISCOVERY=true      # Auto-configure Home Assistant sensors
+```
+
+### Full variable reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MQTT_HOST` | *(none)* | Broker hostname/IP. **Required to enable MQTT.** |
+| `MQTT_PORT` | `1883` | Broker port |
+| `MQTT_USERNAME` | *(none)* | Username for authentication |
+| `MQTT_PASSWORD` | *(none)* | Password for authentication |
+| `MQTT_TLS` | `false` | Enable TLS/SSL |
+| `MQTT_TLS_CA_CERT` | *(none)* | Path to CA certificate file |
+| `MQTT_TLS_INSECURE` | `false` | Disable certificate verification (testing only) |
+| `MQTT_TOPIC_PREFIX` | `pypowerwall` | Root topic prefix |
+| `MQTT_RETAIN` | `true` | Retain messages on broker |
+| `MQTT_QOS` | `1` | MQTT QoS level (0, 1, or 2) |
+| `MQTT_HA_DISCOVERY` | `true` | Publish Home Assistant auto-discovery payloads |
+| `MQTT_HA_PREFIX` | `homeassistant` | Home Assistant discovery prefix |
+| `MQTT_CLIENT_ID` | `pypowerwall-server` | MQTT client identifier |
+| `MQTT_KEEPALIVE` | `60` | Connection keepalive in seconds |
+
+---
+
+## 3. Topic Layout
+
+All topics are published under `{MQTT_TOPIC_PREFIX}/{gateway_id}/`:
+
+| Topic suffix | Type | Example value | Notes |
+|---|---|---|---|
+| `battery` | float | `75.3` | State of Energy % |
+| `solar` | float | `3120.0` | Solar power W (positive = producing) |
+| `grid` | float | `-400.0` | Grid power W (negative = exporting) |
+| `home` | float | `2720.0` | Home load W |
+| `powerwall` | float | `0.0` | Powerwall power W (positive = discharging) |
+| `reserve` | float | `20.0` | Backup reserve % |
+| `grid_status` | string | `UP` | `UP`, `DOWN`, or `unknown` |
+| `mode` | string | `self_consumption` | Operation mode |
+| `version` | string | `23.44.0` | Powerwall firmware version |
+| `online` | string | `true` | Gateway connection status |
+| `aggregates` | JSON | `{...}` | Full aggregates dict |
+| `status` | JSON | `{...}` | Summary JSON (all scalar fields) |
+| `availability` | string | `online` | LWT topic - `online` or `offline` |
+
+**Example** (single gateway named `default`):
+```
+pypowerwall/default/battery     → 75.3
+pypowerwall/default/solar       → 3120.0
+pypowerwall/default/grid        → -400.0
+pypowerwall/default/home        → 2720.0
+pypowerwall/default/powerwall   → 0.0
+pypowerwall/default/grid_status → UP
+pypowerwall/default/mode        → self_consumption
+pypowerwall/default/online      → true
+pypowerwall/default/availability → online
+```
+
+---
+
+## 4. Command-Line Monitoring
+
+The quickest way to watch live updates is with `mosquitto_sub` (part of the
+`mosquitto-clients` package):
+
+```bash
+# Watch all pypowerwall topics
+mosquitto_sub -h localhost -t 'pypowerwall/#' -v
+
+# Watch a specific gateway
+mosquitto_sub -h localhost -t 'pypowerwall/default/#' -v
+
+# Watch a single sensor
+mosquitto_sub -h localhost -t 'pypowerwall/default/battery' -v
+
+# With authentication
+mosquitto_sub -h 192.168.1.100 -u mqttuser -P mqttpassword -t 'pypowerwall/#' -v
+```
+
+Each line of output shows the topic followed by its current value:
+```
+pypowerwall/default/battery 75.3
+pypowerwall/default/solar 3120.0
+pypowerwall/default/grid -400.0
+pypowerwall/default/availability online
+```
+
+---
+
+## 5. Monitor GUI
+
+`monitor.py` is a zero-dependency (only `paho-mqtt` and the standard-library
+`tkinter`) desktop application that connects to your broker and shows live
+Powerwall readings.
+
+### Install
+
+```bash
+pip install paho-mqtt
+```
+
+`tkinter` is included with the standard Python installer on Windows.
+On macOS and Linux it may need to be installed separately:
+
+```bash
+# macOS - Homebrew Python (match your Python version)
+brew install python-tk@3.13
+
+# Debian/Ubuntu/Raspberry Pi OS
+sudo apt install python3-tk
+
+# Fedora/RHEL
+sudo dnf install python3-tkinter
+```
+
+### Run
+
+```bash
+python monitor.py                              # broker at localhost:1883
+python monitor.py --host 192.168.1.100         # custom broker host
+python monitor.py --host broker.local --port 8883 --username user --password pass
+python monitor.py --prefix myhome             # custom topic prefix
+```
+
+The window automatically discovers all gateways present on the broker and
+creates one card per gateway. Values update in real time as the server
+publishes new telemetry (default: every 5 seconds).
+
+### Screenshot
+
+<img width="792" height="564" alt="pyPowerwall MQTT Monitor" src="https://github.com/user-attachments/assets/abb4bfbc-8c91-4e72-bd33-abf397cc5acf" />
+
+---
+
+## 6. Home Assistant Integration
+
+When `MQTT_HA_DISCOVERY=true` (the default), pypowerwall-server automatically
+publishes MQTT discovery payloads the first time each gateway connects. Home
+Assistant reads these and creates a full device entity with no manual YAML
+required.
+
+### Prerequisites
+
+1. **MQTT integration** must be installed in Home Assistant.
+2. Home Assistant and pypowerwall-server must point to the **same broker**.
+
+### Step-by-step setup
+
+#### Step 1 - Install the HA MQTT integration
+
+- In HA go to **Settings → Devices & Services → Add Integration**.
+- Search for **MQTT** and select it.
+- Enter your broker's IP, port, and credentials.
+- Click **Submit**. HA will confirm the connection.
+
+#### Step 2 - Connect pypowerwall-server to the same broker
+
+Ensure `MQTT_HOST` is set (and `MQTT_HA_DISCOVERY=true`, which is the default).
+
+When the server starts you will see in its log:
+
+```
+INFO  MQTT connected to 192.168.1.100:1883
+INFO  MQTT HA discovery published for gateway 'default' (10 entities)
+```
+
+#### Step 3 - Find the device in Home Assistant
+
+- Go to **Settings → Devices & Services → MQTT → Devices**.
+- Look for a device named after your gateway (e.g. "Home Powerwall").
+- All 10 entities appear grouped on the device card:
+
+  | Entity | Device Class | Unit |
+  |--------|-------------|------|
+  | Battery | battery | % |
+  | Solar Power | power | W |
+  | Grid Power | power | W |
+  | Home Load | power | W |
+  | Powerwall Power | power | W |
+  | Backup Reserve | - | % |
+  | Grid Status | - | text |
+  | Operation Mode | - | text |
+  | Firmware Version | diagnostic | text |
+  | Gateway Online | connectivity | binary |
+
+#### Step 4 - Add to an Energy Dashboard
+
+HA's Energy Dashboard requires **energy sensors** (kWh), not power sensors (W).
+Use a Riemann Sum helper to integrate power into energy:
+
+1. **Settings → Devices & Services → Helpers → Create Helper → Riemann Sum Integral**.
+2. Settings:
+   - **Input sensor**: `sensor.battery_solar_power` (or whichever power sensor)
+   - **Integration method**: Left Riemann sum (or trapezoidal)
+   - **Unit time**: hours  → produces kWh
+3. Add the resulting energy sensors to **Settings → Energy → Solar production**,
+   **Grid consumption**, etc.
+
+#### Example Lovelace card (YAML)
+
+Paste into a manual card in your dashboard:
+
+```yaml
+type: entities
+title: Powerwall
+entities:
+  - entity: sensor.home_powerwall_battery
+    name: Battery
+  - entity: sensor.home_powerwall_solar_power
+    name: Solar
+  - entity: sensor.home_powerwall_grid_power
+    name: Grid
+  - entity: sensor.home_powerwall_home_load
+    name: Home
+  - entity: sensor.home_powerwall_powerwall_power
+    name: Powerwall
+  - entity: sensor.home_powerwall_backup_reserve
+    name: Reserve
+  - entity: sensor.home_powerwall_grid_status
+    name: Grid Status
+  - entity: sensor.home_powerwall_operation_mode
+    name: Mode
+  - entity: binary_sensor.home_powerwall_gateway_online
+    name: Online
+```
+
+> **Tip:** Entity IDs follow the pattern `sensor.{gateway_name}_{sensor_name}`.
+> If your gateway is named "Home Powerwall" and the sensor is "Battery", the
+> entity ID is `sensor.home_powerwall_battery`. Adjust accordingly.
+
+#### Automations
+
+**Notify when grid goes down:**
+
+```yaml
+alias: "Powerwall: Grid Outage Alert"
+trigger:
+  - platform: state
+    entity_id: sensor.home_powerwall_grid_status
+    to: "DOWN"
+action:
+  - service: notify.mobile_app_your_phone
+    data:
+      title: "⚡ Grid Outage"
+      message: "Grid is DOWN - Powerwall is running on battery."
+```
+
+**Alert when battery is low:**
+
+```yaml
+alias: "Powerwall: Low Battery Warning"
+trigger:
+  - platform: numeric_state
+    entity_id: sensor.home_powerwall_battery
+    below: 15
+action:
+  - service: notify.mobile_app_your_phone
+    data:
+      title: "🔋 Low Battery"
+      message: "Powerwall battery is below 15%."
+```
+
+#### Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Device doesn't appear in HA | Check broker logs; confirm `MQTT_HA_DISCOVERY=true`; restart pypowerwall-server |
+| Entities show "unavailable" | Check the `availability` topic; gateway may be offline |
+| Wrong entity names | The gateway `name` field in `gateways.yaml` is used as the device name |
+| Duplicate devices | Delete old MQTT devices in HA and restart pypowerwall-server to re-publish discovery |
+| Energy dashboard missing kWh | Create Riemann Sum helpers as described in Step 4 above |
+
+---
+
+## 7. Security Notes
+
+- **Do not expose port 1883 to the internet.** Use a VPN or SSH tunnel for remote access.
+- For LAN deployments with authentication, use `MQTT_USERNAME` / `MQTT_PASSWORD`.
+- For TLS, set `MQTT_TLS=true` and provide a CA cert via `MQTT_TLS_CA_CERT`.
+  Many home users run Mosquitto with a self-signed certificate; set
+  `MQTT_TLS_INSECURE=true` only for testing on a trusted LAN.
+- Passwords are passed via environment variables only - never hard-coded in
+  source files.

--- a/mqtt-tools/monitor.py
+++ b/mqtt-tools/monitor.py
@@ -1,0 +1,453 @@
+"""
+pyPowerwall MQTT Monitor
+========================
+A lightweight tkinter GUI that subscribes to a pypowerwall-server MQTT broker
+and shows live Powerwall telemetry updates.
+
+Requirements:
+    pip install paho-mqtt
+
+Usage:
+    python monitor.py [--host broker_host] [--port 1883] [--prefix pypowerwall]
+
+The window shows live values for every gateway detected on the broker.
+Values refresh automatically whenever the server publishes an update
+(default: every 5 seconds).
+
+Tested with Python 3.11+ on macOS, Linux, and Windows.
+"""
+import argparse
+import json
+import queue
+import sys
+import threading
+import tkinter as tk
+from tkinter import ttk
+from datetime import datetime
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Attempt to import paho-mqtt; show a friendly error if missing
+# ---------------------------------------------------------------------------
+try:
+    import paho.mqtt.client as mqtt
+except ImportError:
+    print(
+        "ERROR: paho-mqtt is not installed.\n"
+        "Install it with:  pip install paho-mqtt\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Theme — dark palette
+# ---------------------------------------------------------------------------
+
+T = {
+    "bg":           "#1E2228",   # window / canvas background
+    "card_bg":      "#282C34",   # gateway card background
+    "card_border":  "#3A3F4B",   # card border / divider
+    "header_bg":    "#21252B",   # card header strip
+    "bar_bg":       "#17191E",   # status bar
+    "label_fg":     "#636D83",   # dim label text
+    "value_fg":     "#ABB2BF",   # default value text
+    "title_fg":     "#E5C07B",   # app title
+    "header_fg":    "#61AFEF",   # gateway name in card header
+    "time_fg":      "#4B5263",   # last-update timestamp
+    "unit_fg":      "#4B5263",   # unit suffix
+    "sep":          "#2C313A",   # separator line
+    # value colours
+    "green":        "#98C379",
+    "yellow":       "#E5C07B",
+    "blue":         "#61AFEF",
+    "purple":       "#C678DD",
+    "orange":       "#D19A66",
+    "red":          "#E06C75",
+    "cyan":         "#56B6C2",
+    "grey":         "#5C6370",
+}
+
+# (label, unit, color-key, formatter)
+#   formatter: "pct" | "watt" | "text"
+SENSORS: list[tuple[str, str, str, str, str]] = [
+    # key            label          unit   color      fmt
+    ("battery",      "Battery",     "%",   "green",   "pct"),
+    ("solar",        "Solar",       "W",   "yellow",  "watt"),
+    ("grid",         "Grid",        "W",   "blue",    "watt"),
+    ("home",         "Home Load",   "W",   "purple",  "watt"),
+    ("powerwall",    "Powerwall",   "W",   "orange",  "watt"),
+    ("reserve",      "Reserve",     "%",   "cyan",    "pct"),
+    ("grid_status",  "Grid Status", "",    "value_fg","text"),
+    ("mode",         "Mode",        "",    "value_fg","text"),
+    ("version",      "Firmware",    "",    "grey",    "text"),
+    ("online",       "Online",      "",    "value_fg","text"),
+]
+
+STATUS_COLORS: dict[str, str] = {
+    "online":  "green",
+    "offline": "red",
+    "true":    "green",
+    "false":   "red",
+    "UP":      "green",
+    "DOWN":    "red",
+}
+
+# Keys that use a smaller font or no fixed width
+SPECIAL_FONT: dict[str, int] = {
+    "version": 9,    # firmware string can be long
+    "online":  14,   # circle indicator looks better larger
+}
+# Keys where we don't impose a character-width cap (let the column expand)
+FREE_WIDTH_KEYS: frozenset[str] = frozenset({"mode", "version", "online"})
+
+
+def fmt_value(key: str, fmt: str, raw: str) -> str:
+    try:
+        f = float(raw)
+        if fmt == "pct":
+            return f"{f:.1f}"
+        if fmt == "watt":
+            return f"{f:,.0f}"
+    except ValueError:
+        pass
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# MQTT worker thread
+# ---------------------------------------------------------------------------
+
+class MqttWorker(threading.Thread):
+    def __init__(self, host: str, port: int, prefix: str,
+                 username: Optional[str], password: Optional[str],
+                 update_queue: queue.Queue):
+        super().__init__(daemon=True, name="mqtt-worker")
+        self.host = host
+        self.port = port
+        self.prefix = prefix
+        self.username = username
+        self.password = password
+        self.queue = update_queue
+        self._stop_event = threading.Event()
+        self._client: Optional[mqtt.Client] = None
+
+    def stop(self):
+        self._stop_event.set()
+        if self._client:
+            self._client.disconnect()
+
+    def run(self):
+        client = mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION2,
+            client_id="pypowerwall-monitor",
+            clean_session=True,
+        )
+        self._client = client
+        if self.username:
+            client.username_pw_set(self.username, self.password)
+        client.on_connect = self._on_connect
+        client.on_disconnect = self._on_disconnect
+        client.on_message = self._on_message
+        self.queue.put(("status", "connecting", f"Connecting to {self.host}:{self.port}…"))
+        try:
+            client.connect(self.host, self.port, keepalive=60)
+        except Exception as exc:
+            self.queue.put(("status", "error", str(exc)))
+            return
+        while not self._stop_event.is_set():
+            client.loop(timeout=1.0)
+
+    def _on_connect(self, client, userdata, flags, reason_code, properties):
+        if reason_code.is_failure:
+            self.queue.put(("status", "error", f"Connect failed: {reason_code}"))
+        else:
+            self.queue.put(("status", "connected", f"Connected to {self.host}:{self.port} — subscribed to {self.prefix}/#"))
+            client.subscribe(f"{self.prefix}/#", qos=1)
+
+    def _on_disconnect(self, client, userdata, disconnect_flags, reason_code, properties):
+        if not self._stop_event.is_set():
+            self.queue.put(("status", "reconnecting", f"Disconnected — reconnecting…"))
+
+    def _on_message(self, client, userdata, msg):
+        try:
+            self.queue.put(("message", msg.topic,
+                            msg.payload.decode("utf-8", errors="replace")))
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Main application window
+# ---------------------------------------------------------------------------
+
+class MonitorApp(tk.Tk):
+    POLL_MS = 200
+
+    def __init__(self, host: str, port: int, prefix: str,
+                 username: Optional[str], password: Optional[str]):
+        super().__init__()
+        self.title("pyPowerwall MQTT Monitor")
+        self.configure(bg=T["bg"])
+        self.minsize(680, 420)
+        self.resizable(True, True)
+
+        self.prefix = prefix
+        self._queue: queue.Queue = queue.Queue()
+        self._gateways: dict[str, dict[str, str]] = {}
+        self._gateway_frames: dict[str, "GatewayCard"] = {}
+        self._last_update: dict[str, datetime] = {}
+
+        self._build_ui()
+
+        self._worker = MqttWorker(host, port, prefix, username, password, self._queue)
+        self._worker.start()
+        self.after(self.POLL_MS, self._drain_queue)
+        self.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    def _build_ui(self):
+        # ── Status bar (bottom) ────────────────────────────────────────
+        bar = tk.Frame(self, bg=T["bar_bg"], pady=7, padx=14)
+        bar.pack(side=tk.BOTTOM, fill=tk.X)
+
+        self._status_dot = tk.Label(bar, text="●", fg=T["grey"],
+                                    bg=T["bar_bg"], font=("", 11))
+        self._status_dot.pack(side=tk.LEFT)
+
+        self._status_var = tk.StringVar(value="Initialising…")
+        tk.Label(bar, textvariable=self._status_var, fg="#636D83",
+                 bg=T["bar_bg"], font=("", 10)).pack(side=tk.LEFT, padx=(6, 0))
+
+        # ── Scrollable content area ────────────────────────────────────
+        self._canvas = tk.Canvas(self, bg=T["bg"], highlightthickness=0,
+                                  bd=0)
+        vsb = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self._canvas.yview)
+        self._canvas.configure(yscrollcommand=vsb.set)
+        vsb.pack(side=tk.RIGHT, fill=tk.Y)
+        self._canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        self._inner = tk.Frame(self._canvas, bg=T["bg"])
+        self._win_id = self._canvas.create_window((0, 0), window=self._inner, anchor="nw")
+        self._inner.bind("<Configure>", lambda e: self._canvas.configure(
+            scrollregion=self._canvas.bbox("all")))
+        self._canvas.bind("<Configure>", lambda e: self._canvas.itemconfig(
+            self._win_id, width=e.width))
+
+        # ── App title ─────────────────────────────────────────────────
+        tk.Label(self._inner, text="⚡  pyPowerwall MQTT Monitor",
+                 font=("", 17, "bold"), fg=T["title_fg"], bg=T["bg"],
+                 pady=18).pack()
+
+        self._no_data = tk.Label(self._inner,
+                                  text="Waiting for data from broker…",
+                                  font=("", 12), fg=T["grey"], bg=T["bg"])
+        self._no_data.pack(pady=30)
+
+    def _drain_queue(self):
+        try:
+            while True:
+                item = self._queue.get_nowait()
+                kind = item[0]
+                if kind == "status":
+                    self._set_status(item[1], item[2])
+                elif kind == "message":
+                    self._handle_msg(item[1], item[2])
+        except queue.Empty:
+            pass
+        finally:
+            self.after(self.POLL_MS, self._drain_queue)
+
+    def _set_status(self, state: str, text: str):
+        self._status_var.set(text)
+        color = {"connected": T["green"], "error": T["red"],
+                 "reconnecting": T["orange"], "connecting": T["blue"]}.get(state, T["grey"])
+        self._status_dot.config(fg=color)
+
+    def _handle_msg(self, topic: str, payload: str):
+        parts = topic.split("/")
+        if len(parts) < 3 or not topic.startswith(self.prefix + "/"):
+            return
+        gw_id = parts[1]
+        suffix = "/".join(parts[2:])
+        if suffix.startswith("config") or "/config" in suffix:
+            return
+
+        if gw_id not in self._gateways:
+            self._gateways[gw_id] = {}
+            card = GatewayCard(self._inner, gw_id)
+            card.pack(fill=tk.X, padx=20, pady=10)
+            self._gateway_frames[gw_id] = card
+            if self._no_data.winfo_exists():
+                self._no_data.pack_forget()
+
+        if suffix == "name":
+            card = self._gateway_frames.get(gw_id)
+            if card:
+                card.set_display_name(payload)
+            return
+
+        self._gateways[gw_id][suffix] = payload
+        self._last_update[gw_id] = datetime.now()
+        card = self._gateway_frames.get(gw_id)
+        if card:
+            card.refresh(self._gateways[gw_id], self._last_update[gw_id])
+
+    def _on_close(self):
+        self._worker.stop()
+        self.destroy()
+
+
+# ---------------------------------------------------------------------------
+# Gateway card
+# ---------------------------------------------------------------------------
+
+class GatewayCard(tk.Frame):
+    """Dark card showing all sensor rows for one gateway."""
+
+    def __init__(self, parent, gateway_id: str):
+        super().__init__(parent, bg=T["card_border"], padx=1, pady=1)
+        self.gateway_id = gateway_id
+        self._vars: dict[str, tk.StringVar] = {}
+        self._labels: dict[str, tk.Label] = {}
+        self._last_var = tk.StringVar(value="—")
+        self._title_var = tk.StringVar(value=gateway_id.upper())
+        self._build()
+
+    def set_display_name(self, name: str) -> None:
+        """Update the card title with the friendly gateway name."""
+        self._title_var.set(name)
+
+    def _build(self):
+        inner = tk.Frame(self, bg=T["card_bg"])
+        inner.pack(fill=tk.BOTH, expand=True)
+
+        # ── Card header ───────────────────────────────────────────────
+        hdr = tk.Frame(inner, bg=T["header_bg"], padx=16, pady=10)
+        hdr.pack(fill=tk.X)
+
+        tk.Label(hdr, textvariable=self._title_var, font=("", 12, "bold"),
+                 fg=T["header_fg"], bg=T["header_bg"]).pack(side=tk.LEFT)
+
+        right = tk.Frame(hdr, bg=T["header_bg"])
+        right.pack(side=tk.RIGHT)
+        tk.Label(right, text="Last update  ", font=("", 9),
+                 fg=T["time_fg"], bg=T["header_bg"]).pack(side=tk.LEFT)
+        tk.Label(right, textvariable=self._last_var, font=("", 9, "bold"),
+                 fg=T["label_fg"], bg=T["header_bg"]).pack(side=tk.LEFT)
+
+        # thin separator
+        tk.Frame(inner, bg=T["sep"], height=1).pack(fill=tk.X)
+
+        # ── Sensor grid ───────────────────────────────────────────────
+        body = tk.Frame(inner, bg=T["card_bg"], padx=20, pady=14)
+        body.pack(fill=tk.X)
+
+        # 2 columns of sensors, left and right halves separated by a spacer
+        # Layout per sensor: [label] [value] [unit]
+        COLS = 2
+        for idx, (key, label, unit, color_key, fmt) in enumerate(SENSORS):
+            col_base = (idx % COLS) * 4        # 0 or 4
+            row = idx // COLS
+
+            # Vertical rule between the two halves
+            if col_base == 4:
+                tk.Frame(body, bg=T["card_border"], width=1).grid(
+                    row=row, column=3, sticky="ns", padx=(16, 0), pady=2
+                )
+
+            # Label
+            lbl = tk.Label(body, text=label, font=("", 10), width=11,
+                           anchor="e", fg=T["label_fg"], bg=T["card_bg"])
+            lbl.grid(row=row, column=col_base, sticky="e",
+                     padx=(16 if col_base == 4 else 0, 8), pady=5)
+
+            # Value
+            var = tk.StringVar(value="—")
+            self._vars[key] = var
+            fsize = SPECIAL_FONT.get(key, 11)
+            val_kwargs: dict = dict(
+                textvariable=var,
+                font=("", fsize, "bold"),
+                anchor="w",
+                fg=T["value_fg"],
+                bg=T["card_bg"],
+            )
+            if key not in FREE_WIDTH_KEYS:
+                val_kwargs["width"] = 10
+            val_lbl = tk.Label(body, **val_kwargs)
+            val_lbl.grid(row=row, column=col_base + 1, sticky="ew", pady=5)
+            self._labels[key] = val_lbl
+
+            # Unit
+            tk.Label(body, text=unit, font=("", 9), width=3, anchor="w",
+                     fg=T["unit_fg"], bg=T["card_bg"]).grid(
+                row=row, column=col_base + 2, sticky="w"
+            )
+
+        # Make value columns expand equally
+        body.columnconfigure(1, weight=1)
+        body.columnconfigure(5, weight=1)
+
+    def refresh(self, data: dict[str, str], ts: datetime):
+        self._last_var.set(ts.strftime("%H:%M:%S"))
+
+        for key, label, unit, default_color_key, fmt in SENSORS:
+            var = self._vars.get(key)
+            lbl = self._labels.get(key)
+            if var is None or lbl is None:
+                continue
+
+            raw = data.get(key)
+            if raw is None and "status" in data:
+                try:
+                    summary = json.loads(data["status"])
+                    v = summary.get(key)
+                    raw = str(v) if v is not None else None
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
+            if key == "online":
+                if raw is None:
+                    var.set("●")
+                    lbl.config(fg=T["grey"])
+                else:
+                    is_online = raw.lower() in ("true", "1", "online", "yes")
+                    var.set("●")
+                    lbl.config(fg=T["green"] if is_online else T["red"])
+            elif raw is None:
+                var.set("—")
+                lbl.config(fg=T["grey"])
+            else:
+                var.set(fmt_value(key, fmt, raw))
+                color_key = STATUS_COLORS.get(raw, default_color_key)
+                lbl.config(fg=T.get(color_key, T["value_fg"]))
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="pyPowerwall MQTT Monitor GUI")
+    p.add_argument("--host", default="localhost")
+    p.add_argument("--port", type=int, default=1883)
+    p.add_argument("--prefix", default="pypowerwall")
+    p.add_argument("--username", default=None)
+    p.add_argument("--password", default=None)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    app = MonitorApp(
+        host=args.host,
+        port=args.port,
+        prefix=args.prefix,
+        username=args.username,
+        password=args.password,
+    )
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/mqtt-tools/monitor.py
+++ b/mqtt-tools/monitor.py
@@ -144,6 +144,7 @@ class MqttWorker(threading.Thread):
             clean_session=True,
         )
         self._client = client
+        client.reconnect_delay_set(min_delay=2, max_delay=30)
         if self.username:
             client.username_pw_set(self.username, self.password)
         client.on_connect = self._on_connect
@@ -155,8 +156,7 @@ class MqttWorker(threading.Thread):
         except Exception as exc:
             self.queue.put(("status", "error", str(exc)))
             return
-        while not self._stop_event.is_set():
-            client.loop(timeout=1.0)
+        client.loop_forever()
 
     def _on_connect(self, client, userdata, flags, reason_code, properties):
         if reason_code.is_failure:
@@ -183,6 +183,8 @@ class MqttWorker(threading.Thread):
 
 class MonitorApp(tk.Tk):
     POLL_MS = 200
+    STALE_TIMEOUT_S = 30   # seconds without an update before marking a gateway stale
+    STALE_CHECK_MS = 5000  # how often to run the staleness check
 
     def __init__(self, host: str, port: int, prefix: str,
                  username: Optional[str], password: Optional[str]):
@@ -203,6 +205,7 @@ class MonitorApp(tk.Tk):
         self._worker = MqttWorker(host, port, prefix, username, password, self._queue)
         self._worker.start()
         self.after(self.POLL_MS, self._drain_queue)
+        self.after(self.STALE_CHECK_MS, self._check_staleness)
         self.protocol("WM_DELETE_WINDOW", self._on_close)
 
     def _build_ui(self):
@@ -292,6 +295,17 @@ class MonitorApp(tk.Tk):
         if card:
             card.refresh(self._gateways[gw_id], self._last_update[gw_id])
 
+    def _check_staleness(self):
+        """Periodically flag gateway cards that have stopped receiving updates."""
+        now = datetime.now()
+        for gw_id, card in self._gateway_frames.items():
+            last = self._last_update.get(gw_id)
+            if last is None:
+                continue
+            age = (now - last).total_seconds()
+            card.set_stale(age > self.STALE_TIMEOUT_S, age)
+        self.after(self.STALE_CHECK_MS, self._check_staleness)
+
     def _on_close(self):
         self._worker.stop()
         self.destroy()
@@ -330,10 +344,17 @@ class GatewayCard(tk.Frame):
 
         right = tk.Frame(hdr, bg=T["header_bg"])
         right.pack(side=tk.RIGHT)
+
+        self._stale_badge = tk.Label(right, text="", font=("", 9, "bold"),
+                                     fg=T["orange"], bg=T["header_bg"])
+        self._stale_badge.pack(side=tk.LEFT, padx=(0, 10))
+
         tk.Label(right, text="Last update  ", font=("", 9),
                  fg=T["time_fg"], bg=T["header_bg"]).pack(side=tk.LEFT)
-        tk.Label(right, textvariable=self._last_var, font=("", 9, "bold"),
-                 fg=T["label_fg"], bg=T["header_bg"]).pack(side=tk.LEFT)
+        self._ts_label = tk.Label(right, textvariable=self._last_var,
+                                  font=("", 9, "bold"),
+                                  fg=T["label_fg"], bg=T["header_bg"])
+        self._ts_label.pack(side=tk.LEFT)
 
         # thin separator
         tk.Frame(inner, bg=T["sep"], height=1).pack(fill=tk.X)
@@ -388,8 +409,21 @@ class GatewayCard(tk.Frame):
         body.columnconfigure(1, weight=1)
         body.columnconfigure(5, weight=1)
 
+    def set_stale(self, stale: bool, age_s: float = 0) -> None:
+        """Show or clear the stale warning badge in the card header."""
+        if stale:
+            mins, secs = divmod(int(age_s), 60)
+            age_str = f"{mins}m {secs}s" if mins else f"{secs}s"
+            self._stale_badge.config(text=f"⚠ No updates for {age_str}")
+            self._ts_label.config(fg=T["orange"])
+        else:
+            self._stale_badge.config(text="")
+            self._ts_label.config(fg=T["label_fg"])
+
     def refresh(self, data: dict[str, str], ts: datetime):
         self._last_var.set(ts.strftime("%H:%M:%S"))
+        # Clear any stale warning when fresh data arrives
+        self.set_stale(False)
 
         for key, label, unit, default_color_key, fmt in SENSORS:
             var = self._vars.get(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.2.2"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.3.0"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ websockets==13.1
 psutil==6.1.1
 beautifulsoup4==4.12.3
 cryptography
+aiomqtt>=2.3.0

--- a/tests/test_mqtt_ha_discovery.py
+++ b/tests/test_mqtt_ha_discovery.py
@@ -1,0 +1,306 @@
+"""
+Tests for Phase 2 — Home Assistant MQTT auto-discovery payloads.
+
+These tests validate:
+  - build_discovery_payloads() returns the expected number of entries
+  - Every entry has a valid discovery topic path
+  - Key sensor payloads carry correct HA fields (unique_id, device_class, unit, etc.)
+  - The shared device block appears on every payload and contains gateway info
+  - Availability config references the correct availability topic
+  - The MqttPublisher._publish_ha_discovery() integration path works end-to-end
+  - Discovery is sent exactly once per gateway per connection (not on every poll)
+  - Discovery is re-sent after a reconnect (_discovery_sent cleared)
+"""
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.mqtt.ha_discovery import build_discovery_payloads
+from app.mqtt.publisher import MqttPublisher
+from app.models.gateway import Gateway, GatewayStatus, PowerwallData
+
+
+# ---------------------------------------------------------------------------
+# Helpers (shared with test_mqtt_publisher.py pattern)
+# ---------------------------------------------------------------------------
+
+def make_status(
+    gateway_id: str = "test-gw",
+    gateway_name: str = "Test Gateway",
+    version: str = "23.44.0",
+    online: bool = True,
+    soe: float = 75.0,
+) -> GatewayStatus:
+    gateway = Gateway(id=gateway_id, name=gateway_name, host="192.168.91.1", online=online)
+    data = PowerwallData(
+        soe=soe,
+        aggregates={
+            "solar": {"instant_power": 3000.0},
+            "site": {"instant_power": -500.0},
+            "load": {"instant_power": 2500.0},
+            "battery": {"instant_power": 0.0},
+        },
+        grid_status="UP",
+        mode="self_consumption",
+        reserve=20.0,
+        version=version,
+        timestamp=1_000_000.0,
+    )
+    return GatewayStatus(gateway=gateway, data=data, online=online, last_updated=1_000_000.0)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for build_discovery_payloads()
+# ---------------------------------------------------------------------------
+
+class TestBuildDiscoveryPayloads:
+    def _payloads(self, gateway_id="home", gateway_name="Home Powerwall",
+                  prefix="pypowerwall", ha_prefix="homeassistant",
+                  version="23.44.0") -> list[tuple[str, dict]]:
+        raw = build_discovery_payloads(
+            gateway_id=gateway_id,
+            gateway_name=gateway_name,
+            topic_prefix=prefix,
+            ha_prefix=ha_prefix,
+            version=version,
+        )
+        return [(topic, json.loads(payload)) for topic, payload in raw]
+
+    def test_returns_expected_count(self):
+        results = self._payloads()
+        # 9 sensors + 1 binary sensor = 10
+        assert len(results) == 10
+
+    def test_all_topics_start_with_ha_prefix(self):
+        results = self._payloads(ha_prefix="homeassistant")
+        for topic, _ in results:
+            assert topic.startswith("homeassistant/"), f"Bad topic: {topic}"
+
+    def test_sensor_topics_contain_gateway_id(self):
+        results = self._payloads(gateway_id="home")
+        for topic, _ in results:
+            assert "pypowerwall_home_" in topic
+
+    def test_binary_sensor_topic_present(self):
+        results = self._payloads()
+        binary_topics = [t for t, _ in results if "/binary_sensor/" in t]
+        assert len(binary_topics) == 1
+        assert "online" in binary_topics[0]
+
+    def test_sensor_topics_end_with_config(self):
+        results = self._payloads()
+        for topic, _ in results:
+            assert topic.endswith("/config"), f"Topic should end with /config: {topic}"
+
+    def test_device_block_on_every_payload(self):
+        results = self._payloads(gateway_id="cabin", gateway_name="Cabin Powerwall", version="24.0.1")
+        for topic, payload in results:
+            assert "device" in payload, f"Missing device block: {topic}"
+            device = payload["device"]
+            assert device["manufacturer"] == "Tesla"
+            assert device["model"] == "Powerwall"
+            assert device["sw_version"] == "24.0.1"
+            assert "pypowerwall_cabin" in device["identifiers"][0]
+            assert device["name"] == "Cabin Powerwall"
+
+    def test_battery_sensor_fields(self):
+        results = dict(self._payloads())
+        battery_topic = "homeassistant/sensor/pypowerwall_home_battery/config"
+        assert battery_topic in results
+        p = results[battery_topic]
+        assert p["unit_of_measurement"] == "%"
+        assert p["device_class"] == "battery"
+        assert p["state_class"] == "measurement"
+        assert p["state_topic"] == "pypowerwall/home/battery"
+        assert p["unique_id"] == "pypowerwall_home_battery"
+
+    def test_solar_sensor_fields(self):
+        results = dict(self._payloads())
+        topic = "homeassistant/sensor/pypowerwall_home_solar/config"
+        assert topic in results
+        p = results[topic]
+        assert p["unit_of_measurement"] == "W"
+        assert p["device_class"] == "power"
+        assert p["state_topic"] == "pypowerwall/home/solar"
+
+    def test_grid_sensor_fields(self):
+        results = dict(self._payloads())
+        topic = "homeassistant/sensor/pypowerwall_home_grid/config"
+        assert topic in results
+        p = results[topic]
+        assert p["unit_of_measurement"] == "W"
+        assert p["device_class"] == "power"
+
+    def test_version_sensor_is_diagnostic(self):
+        results = dict(self._payloads())
+        topic = "homeassistant/sensor/pypowerwall_home_version/config"
+        assert topic in results
+        p = results[topic]
+        assert p.get("entity_category") == "diagnostic"
+
+    def test_online_binary_sensor_fields(self):
+        results = dict(self._payloads())
+        topic = "homeassistant/binary_sensor/pypowerwall_home_online/config"
+        assert topic in results
+        p = results[topic]
+        assert p["device_class"] == "connectivity"
+        assert p["payload_on"] == "true"
+        assert p["payload_off"] == "false"
+        assert p["state_topic"] == "pypowerwall/home/online"
+
+    def test_availability_references_correct_topic(self):
+        results = self._payloads(gateway_id="main", prefix="pw")
+        for topic, payload in results:
+            avail_list = payload.get("availability", [])
+            assert len(avail_list) == 1
+            assert avail_list[0]["topic"] == "pw/main/availability"
+            assert avail_list[0]["payload_available"] == "online"
+            assert avail_list[0]["payload_not_available"] == "offline"
+
+    def test_custom_prefix_and_ha_prefix(self):
+        results = build_discovery_payloads(
+            gateway_id="site2",
+            gateway_name="Site 2",
+            topic_prefix="mypw",
+            ha_prefix="ha",
+            version="22.1.0",
+        )
+        for topic, _ in results:
+            assert topic.startswith("ha/")
+        payloads = {t: json.loads(p) for t, p in results}
+        battery = payloads.get("ha/sensor/pypowerwall_site2_battery/config")
+        assert battery is not None
+        assert battery["state_topic"] == "mypw/site2/battery"
+
+    def test_version_none_handled(self):
+        """build_discovery_payloads() must not crash when version is None."""
+        results = build_discovery_payloads(
+            gateway_id="gw",
+            gateway_name="GW",
+            topic_prefix="pypowerwall",
+            ha_prefix="homeassistant",
+            version=None,
+        )
+        assert len(results) == 10
+        for _, payload_str in results:
+            p = json.loads(payload_str)
+            assert p["device"]["sw_version"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for MqttPublisher._publish_ha_discovery()
+# ---------------------------------------------------------------------------
+
+class TestPublisherHaDiscovery:
+    def _make_publisher(self, monkeypatch) -> MqttPublisher:
+        from app.config import settings as _settings
+        monkeypatch.setattr(_settings, "mqtt_host", "localhost")
+        monkeypatch.setattr(_settings, "mqtt_topic_prefix", "pypowerwall")
+        monkeypatch.setattr(_settings, "mqtt_ha_prefix", "homeassistant")
+        monkeypatch.setattr(_settings, "mqtt_ha_discovery", True)
+        monkeypatch.setattr(_settings, "mqtt_qos", 1)
+        monkeypatch.setattr(_settings, "mqtt_retain", True)
+        return MqttPublisher()
+
+    @pytest.mark.asyncio
+    async def test_discovery_published_on_first_poll(self, monkeypatch):
+        """Discovery payloads are sent on the first publish_gateway() call."""
+        pub = self._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status()
+        await pub.publish_gateway("test-gw", status)
+
+        topics = [c.args[0] for c in mock_client.publish.call_args_list]
+        disc_topics = [t for t in topics if "homeassistant" in t]
+        assert len(disc_topics) == 10  # one per sensor/binary_sensor
+
+    @pytest.mark.asyncio
+    async def test_discovery_sent_only_once_per_connection(self, monkeypatch):
+        """Calling publish_gateway() twice must not send discovery twice."""
+        pub = self._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status()
+        await pub.publish_gateway("test-gw", status)
+        first_call_count = mock_client.publish.call_count
+
+        # Second poll for same gateway - discovery must NOT be repeated
+        await pub.publish_gateway("test-gw", status)
+        second_call_count = mock_client.publish.call_count
+
+        # Only sensor topic publishes added in second call; no new discovery
+        disc_in_second = [
+            c.args[0]
+            for c in mock_client.publish.call_args_list[first_call_count:]
+            if "homeassistant" in c.args[0]
+        ]
+        assert disc_in_second == []
+
+    @pytest.mark.asyncio
+    async def test_discovery_resent_after_reconnect(self, monkeypatch):
+        """After _discovery_sent is cleared (reconnect), discovery fires again."""
+        pub = self._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status()
+        await pub.publish_gateway("test-gw", status)
+
+        # Simulate reconnect - connection loop clears this set
+        pub._discovery_sent.clear()
+        mock_client.publish.reset_mock()
+
+        await pub.publish_gateway("test-gw", status)
+        disc_topics = [
+            c.args[0]
+            for c in mock_client.publish.call_args_list
+            if "homeassistant" in c.args[0]
+        ]
+        assert len(disc_topics) == 10
+
+    @pytest.mark.asyncio
+    async def test_discovery_skipped_when_ha_discovery_false(self, monkeypatch):
+        """No discovery payloads when MQTT_HA_DISCOVERY=false."""
+        pub = self._make_publisher(monkeypatch)
+        from app.config import settings as _settings
+        monkeypatch.setattr(_settings, "mqtt_ha_discovery", False)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status()
+        await pub.publish_gateway("test-gw", status)
+
+        topics = [c.args[0] for c in mock_client.publish.call_args_list]
+        disc_topics = [t for t in topics if "homeassistant" in t]
+        assert disc_topics == []
+
+    @pytest.mark.asyncio
+    async def test_discovery_includes_correct_device_name(self, monkeypatch):
+        """Discovery device name matches the gateway name from GatewayStatus."""
+        pub = self._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status(gateway_name="My Beach House")
+        await pub.publish_gateway("beach", status)
+
+        # Find any discovery payload and check device name
+        for call in mock_client.publish.call_args_list:
+            topic = call.args[0]
+            payload_str = call.args[1]
+            if "homeassistant" in topic:
+                payload = json.loads(payload_str)
+                assert payload["device"]["name"] == "My Beach House"
+                break
+        else:
+            pytest.fail("No discovery payload published")

--- a/tests/test_mqtt_ha_discovery.py
+++ b/tests/test_mqtt_ha_discovery.py
@@ -154,10 +154,15 @@ class TestBuildDiscoveryPayloads:
         results = self._payloads(gateway_id="main", prefix="pw")
         for topic, payload in results:
             avail_list = payload.get("availability", [])
-            assert len(avail_list) == 1
-            assert avail_list[0]["topic"] == "pw/main/availability"
-            assert avail_list[0]["payload_available"] == "online"
-            assert avail_list[0]["payload_not_available"] == "offline"
+            # Two entries: per-gateway topic and global LWT topic
+            assert len(avail_list) == 2
+            topics = {a["topic"] for a in avail_list}
+            assert "pw/main/availability" in topics
+            assert "pw/availability" in topics
+            for entry in avail_list:
+                assert entry["payload_available"] == "online"
+                assert entry["payload_not_available"] == "offline"
+            assert payload.get("availability_mode") == "all"
 
     def test_custom_prefix_and_ha_prefix(self):
         results = build_discovery_payloads(

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -1,0 +1,324 @@
+"""
+Tests for Phase 1 of MQTT support — core publisher.
+
+These tests use a mock MQTT client (no real broker required) and validate:
+  - Publisher is disabled when MQTT_HOST is not set
+  - Publisher is enabled when MQTT_HOST is set
+  - start() / stop() lifecycle management
+  - publish_gateway() builds all expected topics from a GatewayStatus
+  - Publish is silently skipped when disconnected
+  - Publish failure sets _connected=False (triggers reconnect)
+  - _extract_power() handles missing/malformed aggregates safely
+  - Connection loop reconnects after failure (backoff logic)
+  - MQTT failures never propagate to caller (fire-and-forget safety)
+"""
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.gateway import Gateway, GatewayStatus, PowerwallData
+from app.mqtt.publisher import MqttPublisher, _extract_power
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_status(
+    gateway_id: str = "test-gw",
+    online: bool = True,
+    soe: float = 75.0,
+    solar: float = 3000.0,
+    grid: float = -500.0,
+    home: float = 2500.0,
+    pw_power: float = 0.0,
+    grid_status: str = "UP",
+    mode: str = "self_consumption",
+    reserve: float = 20.0,
+    version: str = "23.44.0",
+) -> GatewayStatus:
+    """Build a minimal GatewayStatus suitable for testing."""
+    gateway = Gateway(
+        id=gateway_id,
+        name="Test Gateway",
+        host="192.168.91.1",
+        gw_pwd="test",
+        online=online,
+    )
+    data = PowerwallData(
+        soe=soe,
+        aggregates={
+            "solar": {"instant_power": solar},
+            "site": {"instant_power": grid},
+            "load": {"instant_power": home},
+            "battery": {"instant_power": pw_power},
+        },
+        grid_status=grid_status,
+        mode=mode,
+        reserve=reserve,
+        version=version,
+        timestamp=1_000_000.0,
+    )
+    return GatewayStatus(
+        gateway=gateway, data=data, online=online, last_updated=1_000_000.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# _extract_power unit tests (pure function — no async needed)
+# ---------------------------------------------------------------------------
+
+class TestExtractPower:
+    def test_normal_value(self):
+        agg = {"solar": {"instant_power": 1234.5}}
+        assert _extract_power(agg, "solar") == pytest.approx(1234.5)
+
+    def test_missing_key(self):
+        assert _extract_power({}, "solar") is None
+
+    def test_missing_instant_power(self):
+        assert _extract_power({"solar": {}}, "solar") is None
+
+    def test_non_numeric_value(self):
+        agg = {"solar": {"instant_power": "bad"}}
+        assert _extract_power(agg, "solar") is None
+
+    def test_negative_value(self):
+        agg = {"site": {"instant_power": -400.0}}
+        assert _extract_power(agg, "site") == pytest.approx(-400.0)
+
+    def test_none_aggregates(self):
+        assert _extract_power(None, "solar") is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# MqttPublisher unit tests
+# ---------------------------------------------------------------------------
+
+class TestMqttPublisherDisabled:
+    """Publisher should be completely inert when MQTT_HOST is not set."""
+
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("MQTT_HOST", raising=False)
+        pub = MqttPublisher()
+        assert pub.enabled is False
+
+    @pytest.mark.asyncio
+    async def test_start_does_nothing_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("MQTT_HOST", raising=False)
+        pub = MqttPublisher()
+        await pub.start()
+        assert pub._connection_task is None
+
+    @pytest.mark.asyncio
+    async def test_publish_gateway_does_nothing_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("MQTT_HOST", raising=False)
+        pub = MqttPublisher()
+        # Should complete without error and without calling any client methods
+        status = make_status()
+        await pub.publish_gateway("test-gw", status)  # no exception expected
+
+
+class TestMqttPublisherEnabled:
+    """Publisher behaviour when MQTT_HOST is set (mocked client)."""
+
+    def _make_publisher(self, monkeypatch) -> MqttPublisher:
+        monkeypatch.setenv("MQTT_HOST", "localhost")
+        monkeypatch.setenv("MQTT_PORT", "1883")
+        monkeypatch.setenv("MQTT_TOPIC_PREFIX", "pypowerwall")
+        monkeypatch.setenv("MQTT_QOS", "1")
+        monkeypatch.setenv("MQTT_RETAIN", "true")
+        # Reload settings so the new env vars are picked up
+        import importlib
+        import app.config as cfg_module
+        importlib.reload(cfg_module)
+        pub = MqttPublisher()
+        return pub
+
+    def test_enabled_when_host_set(self, monkeypatch):
+        from app.config import settings as _settings
+        # settings is a module-level singleton; patch its attribute directly
+        monkeypatch.setattr(_settings, "mqtt_host", "broker.local")
+        pub = MqttPublisher()
+        assert pub.enabled is True
+
+    @pytest.mark.asyncio
+    async def test_publish_skipped_when_not_connected(self, monkeypatch):
+        """publish_gateway() must be silent when disconnected."""
+        pub = self._make_publisher(monkeypatch)
+        pub._connected = False
+        pub._client = None
+
+        status = make_status()
+        # Must not raise
+        await pub.publish_gateway("test-gw", status)
+
+    @pytest.mark.asyncio
+    async def test_publish_gateway_calls_correct_topics(self, monkeypatch):
+        """All expected sensor topics are published with correct values."""
+        pub = self._make_publisher(monkeypatch)
+
+        # Set up a mock client
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status(
+            soe=75.0,
+            solar=3000.0,
+            grid=-500.0,
+            home=2500.0,
+            pw_power=0.0,
+            grid_status="UP",
+            mode="self_consumption",
+            reserve=20.0,
+        )
+
+        await pub.publish_gateway("test-gw", status)
+
+        # Collect all published topic/payload pairs
+        published: dict[str, str] = {}
+        for call in mock_client.publish.call_args_list:
+            topic = call.args[0]
+            payload = call.args[1]
+            published[topic] = payload
+
+        assert "pypowerwall/test-gw/battery" in published
+        assert published["pypowerwall/test-gw/battery"] == "75.0"
+
+        assert "pypowerwall/test-gw/solar" in published
+        assert published["pypowerwall/test-gw/solar"] == "3000.0"
+
+        assert "pypowerwall/test-gw/grid" in published
+        assert published["pypowerwall/test-gw/grid"] == "-500.0"
+
+        assert "pypowerwall/test-gw/home" in published
+        assert published["pypowerwall/test-gw/home"] == "2500.0"
+
+        assert "pypowerwall/test-gw/powerwall" in published
+        assert published["pypowerwall/test-gw/powerwall"] == "0.0"
+
+        assert "pypowerwall/test-gw/grid_status" in published
+        assert published["pypowerwall/test-gw/grid_status"] == "UP"
+
+        assert "pypowerwall/test-gw/mode" in published
+        assert published["pypowerwall/test-gw/mode"] == "self_consumption"
+
+        assert "pypowerwall/test-gw/reserve" in published
+        assert published["pypowerwall/test-gw/reserve"] == "20.0"
+
+        assert "pypowerwall/test-gw/online" in published
+        assert published["pypowerwall/test-gw/online"] == "true"
+
+        assert "pypowerwall/test-gw/availability" in published
+        assert published["pypowerwall/test-gw/availability"] == "online"
+
+    @pytest.mark.asyncio
+    async def test_aggregates_json_topic_published(self, monkeypatch):
+        """Full aggregates dict is published as JSON."""
+        pub = self._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status(solar=1500.0)
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in mock_client.publish.call_args_list}
+        assert "pypowerwall/test-gw/aggregates" in published
+        agg = json.loads(published["pypowerwall/test-gw/aggregates"])
+        assert agg["solar"]["instant_power"] == 1500.0
+
+    @pytest.mark.asyncio
+    async def test_status_summary_json_topic_published(self, monkeypatch):
+        """Summary status JSON topic is published."""
+        pub = self._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status(soe=88.0, mode="backup")
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in mock_client.publish.call_args_list}
+        assert "pypowerwall/test-gw/status" in published
+        summary = json.loads(published["pypowerwall/test-gw/status"])
+        assert summary["soe"] == 88.0
+        assert summary["mode"] == "backup"
+        assert summary["online"] is True
+
+    @pytest.mark.asyncio
+    async def test_publish_failure_marks_disconnected(self, monkeypatch):
+        """A publish error must set _connected=False (triggers reconnect loop)."""
+        pub = self._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        mock_client.publish.side_effect = Exception("broker gone")
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status()
+        # Must not raise even though publish fails
+        await pub.publish_gateway("test-gw", status)
+
+        # After the first failed publish, _connected should be False
+        assert pub._connected is False
+
+    @pytest.mark.asyncio
+    async def test_publish_with_none_data(self, monkeypatch):
+        """publish_gateway() handles GatewayStatus with data=None (offline gateway)."""
+        pub = self._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        gateway = Gateway(id="offline-gw", name="Offline", host="1.2.3.4", online=False)
+        status = GatewayStatus(gateway=gateway, online=False, last_updated=0.0)
+
+        # Must not raise
+        await pub.publish_gateway("offline-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in mock_client.publish.call_args_list}
+        # Only the online topic and availability should be published when data is None
+        assert "pypowerwall/offline-gw/online" in published
+        assert published["pypowerwall/offline-gw/online"] == "false"
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_connection_task(self, monkeypatch):
+        """stop() cancels the background connection task cleanly."""
+        pub = self._make_publisher(monkeypatch)
+
+        # Patch aiomqtt so the connection loop hangs without a real broker
+        async def fake_context(*args, **kwargs):
+            yield MagicMock(publish=AsyncMock())
+
+        with patch("app.mqtt.publisher.MqttPublisher._connection_loop", new_callable=lambda: lambda self: asyncio.sleep(9999)):
+            # Start a dummy task that sleeps
+            pub._shutdown = False
+            pub._connection_task = asyncio.create_task(asyncio.sleep(9999))
+
+            await pub.stop()
+
+            assert pub._connection_task.done()
+
+
+class TestMqttFireAndForget:
+    """Verify that MQTT failures never leak into the gateway poll path."""
+
+    @pytest.mark.asyncio
+    async def test_publish_exception_does_not_propagate(self, monkeypatch):
+        """Even if publish_gateway raises internally, create_task swallows it."""
+        monkeypatch.setenv("MQTT_HOST", "localhost")
+        pub = MqttPublisher()
+
+        mock_client = AsyncMock()
+        mock_client.publish.side_effect = RuntimeError("total failure")
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status()
+        # Called via create_task in gateway_manager; must not raise here
+        task = asyncio.create_task(pub.publish_gateway("test-gw", status))
+        await task  # no exception expected

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -286,8 +286,47 @@ class TestMqttPublisherEnabled:
         assert published["pypowerwall/offline-gw/online"] == "false"
 
     @pytest.mark.asyncio
+    async def test_connection_loop_publishes_global_availability_on_connect(self, monkeypatch):
+        """On connect, global {prefix}/availability must be published as 'online'.
+
+        This fixes issue #33: the discovery payload references this topic with
+        availability_mode='all', so without this message HA entities stay stuck
+        at 'unavailable' even when per-gateway state data is flowing correctly.
+        """
+        import aiomqtt
+        from contextlib import asynccontextmanager
+        from unittest.mock import AsyncMock, MagicMock
+
+        pub = self._make_publisher(monkeypatch)
+
+        published: dict[str, str] = {}
+
+        mock_client = MagicMock()
+        mock_client.publish = AsyncMock(
+            side_effect=lambda topic, payload, **kw: published.__setitem__(topic, payload)
+        )
+
+        @asynccontextmanager
+        async def fake_client_ctx(**kwargs):
+            yield mock_client
+
+        # Run the connection loop but stop it after one pass
+        async def fake_sleep(n):
+            pub._shutdown = True  # stop inner heartbeat immediately
+
+        with (
+            patch("aiomqtt.Client", side_effect=lambda **kw: fake_client_ctx(**kw)),
+            patch("asyncio.sleep", new=fake_sleep),
+        ):
+            await pub._connection_loop()
+
+        assert "pypowerwall/availability" in published, (
+            "Global availability topic must be published on connect (issue #33)"
+        )
+        assert published["pypowerwall/availability"] == "online"
+
+    @pytest.mark.asyncio
     async def test_stop_cancels_connection_task(self, monkeypatch):
-        """stop() cancels the background connection task cleanly."""
         pub = self._make_publisher(monkeypatch)
 
         # Patch aiomqtt so the connection loop hangs without a real broker


### PR DESCRIPTION
### [0.3.0] - 2026-04-18

**Added:**
- **MQTT Integration** — publish live Powerwall telemetry to any MQTT broker. Set `MQTT_HOST` to enable. All sensor values are published under `{MQTT_TOPIC_PREFIX}/{gateway_id}/` with LWT (`offline`) and `availability` topics for clean broker state.
- **Home Assistant auto-discovery** — on connect, discovery payloads are published for all sensors so they appear automatically under a single HA device card, requiring zero manual HA configuration (#21).
- **`mqtt-tools/` folder** — `README.md` broker setup guide with CLI monitoring, HA integration steps, and live GUI instructions; `monitor.py` dark-theme tkinter GUI that subscribes to the broker and displays real-time Powerwall metrics for all gateways.
- **Console MQTT Broker panel** — new card on the management dashboard (`/`) showing broker connectivity, topic prefix, HA discovery, QoS, retain, and TLS status. Fetched from the new `GET /api/mqtt/status` endpoint.
- **`{prefix}/{gw}/name` topic** — friendly gateway name (from `gateways.yaml`) is published so the monitor GUI card title matches the configured name.
- **`MqttPublisher.connected` property** — safe public accessor for broker connection state (replaces internal `_connected` access).
- Exponential backoff reconnect in `MqttPublisher._connection_loop()` (1 s → 2 s → … → 60 s cap).
- TLS/SSL support via `MQTT_TLS`, `MQTT_TLS_CA_CERT`, and `MQTT_TLS_INSECURE` environment variables.
- 37 new tests: `tests/test_mqtt_publisher.py` (18) and `tests/test_mqtt_ha_discovery.py` (19), all with mock broker (no live MQTT dependency).

**Changed:**
- MQTT env variables added to `docker-compose.yml` as commented-out block for easy opt-in.

Closes #1 #33 #34 

Test monitor to watch MQTT broker:

<img width="792" height="564" alt="Image" src="https://github.com/user-attachments/assets/abb4bfbc-8c91-4e72-bd33-abf397cc5acf" />

Added console panel showing MQTT broker status:

<img width="1425" height="675" alt="Image" src="https://github.com/user-attachments/assets/31a46ff5-8272-4cbb-9a4a-49260cb573a8" />

## TODO

* Test Home Assistant integration.
* Test container (beta) jasonacox/pypowerwall-server:0.3.0-beta30