### PR TITLE
feat: hybrid TEDAPI + cloud control for write operations (reserve, mode, grid_charging)

### DIFF
--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -99,10 +99,19 @@ async def control_api(
 
     # Map control paths to pypowerwall cloud control methods.
     # Used for TEDAPI gateways with cloud credentials (hybrid mode).
+    # Validate grid_charging requires an explicit boolean value to prevent
+    # silent state changes from malformed or empty payloads.
+    if path == "grid_charging":
+        if "value" not in data or not isinstance(data["value"], bool):
+            raise HTTPException(
+                status_code=400,
+                detail="'value' must be a boolean (true or false)",
+            )
+
     cloud_control_map = {
         "reserve": ("set_reserve", lambda d: [d.get("value", 0)]),
         "mode": ("set_mode", lambda d: [d.get("value", "self_consumption")]),
-        "grid_charging": ("set_grid_charging", lambda d: [d.get("value", False)]),
+        "grid_charging": ("set_grid_charging", lambda d: [d["value"]]),
     }
 
     if path in cloud_control_map and gateway_manager._cloud_control:

--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -91,8 +91,8 @@ async def control_api(
 ):
     """Authenticated control endpoint for POST operations.
 
-    Routes to cloud control connection for write operations (set_reserve, set_mode)
-    when available, since TEDAPI doesn't support POST/write APIs.
+    Routes to cloud control connection for write operations (set_reserve, set_mode,
+    set_grid_charging) when available, since TEDAPI doesn't support POST/write APIs.
     Falls back to direct post for cloud-mode or FleetAPI gateways.
     """
     verify_control_token(authorization)
@@ -102,6 +102,7 @@ async def control_api(
     cloud_control_map = {
         "reserve": ("set_reserve", lambda d: [d.get("value", 0)]),
         "mode": ("set_mode", lambda d: [d.get("value", "self_consumption")]),
+        "grid_charging": ("set_grid_charging", lambda d: [d.get("value", False)]),
     }
 
     if path in cloud_control_map and gateway_manager._cloud_control:

--- a/app/config.py
+++ b/app/config.py
@@ -66,6 +66,8 @@ Environment Variables (Proxy Compatible):
         PW_SITEID            - Tesla site ID for multi-site accounts (default: none)
         PW_CONTROL_SECRET    - Enable control commands (default: none/disabled)
         PW_NEG_SOLAR         - Allow negative solar values "yes"/"no" (default: "no")
+        PW_RSA_KEY_PATH      - Path to RSA-4096 private key PEM for TEDAPI v1r LAN access (default: none)
+        PW_WIFI_HOST         - WiFi host IP for TEDAPI v1r WiFi fallback (default: none)
         PROXY_BASE_URL       - Base URL for reverse proxy (default: "/")
 
 Connection Modes:
@@ -73,8 +75,9 @@ Connection Modes:
     TEDAPI (Local Gateway Access):
         • Fastest, most reliable
         • Requires direct connection to gateway WiFi or local network
-        • Configuration: PW_HOST + PW_GW_PWD
-        • Example: 192.168.91.1 with gateway password
+        • Configuration: PW_HOST + PW_GW_PWD  (password-based)
+        •            OR: PW_HOST + PW_RSA_KEY_PATH  (RSA key-based, v1r mode)
+        • Example: 192.168.91.1 with gateway password or RSA PEM key
     
     Cloud Mode:
         • Remote access from anywhere
@@ -173,7 +176,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.2.1"
+SERVER_VERSION = "0.2.2"
 
 
 class GatewayConfig(BaseSettings):
@@ -189,6 +192,8 @@ class GatewayConfig(BaseSettings):
     host: Optional[str] = None
     port: Optional[int] = Field(default=None, ge=1, le=65535)  # Non-standard HTTPS port (e.g. 8443 via travel router)
     gw_pwd: Optional[str] = None  # Gateway Wi-Fi password for TEDAPI mode
+    rsa_key_path: Optional[str] = None  # Path to RSA-4096 private key PEM for v1r LAN TEDAPI access
+    wifi_host: Optional[str] = None  # WiFi host IP for TEDAPI v1r WiFi fallback
     email: Optional[str] = None
     authpath: Optional[
         str
@@ -197,8 +202,6 @@ class GatewayConfig(BaseSettings):
     cloud_mode: bool = False
     fleetapi: bool = False
     type: str = "powerwall"  # "powerwall" | "inverter" (solar-only, no batteries)
-    rsa_key_path: Optional[str] = None  # RSA-4096 private key PEM path for TEDAPI v1r mode
-    wifi_host: Optional[str] = None  # WiFi TEDAPI host for v1r wifi fallback
 
     model_config = {"env_prefix": ""}
 
@@ -214,8 +217,6 @@ class Settings(BaseSettings):
     # Powerwall connection settings
     pw_host: Optional[str] = Field(default=None, alias="PW_HOST")
     pw_gw_pwd: Optional[str] = Field(default=None, alias="PW_GW_PWD")
-    pw_rsa_key_path: Optional[str] = Field(default=None, alias="PW_RSA_KEY_PATH")  # RSA-4096 key for TEDAPI v1r
-    pw_wifi_host: Optional[str] = Field(default=None, alias="PW_WIFI_HOST")  # WiFi host for v1r fallback
     pw_password: Optional[str] = Field(
         default=None, alias="PW_PASSWORD"
     )  # Legacy PW2 local access
@@ -257,6 +258,12 @@ class Settings(BaseSettings):
     siteid: Optional[str] = Field(default=None, alias="PW_SITEID")
     control_secret: Optional[str] = Field(default=None, alias="PW_CONTROL_SECRET")
     proxy_base_url: str = Field(default="/", alias="PROXY_BASE_URL")
+    pw_rsa_key_path: Optional[str] = Field(
+        default=None, alias="PW_RSA_KEY_PATH"
+    )  # RSA-4096 private key PEM path for TEDAPI v1r LAN access
+    pw_wifi_host: Optional[str] = Field(
+        default=None, alias="PW_WIFI_HOST"
+    )  # WiFi host IP for TEDAPI v1r WiFi fallback
     neg_solar: bool = Field(
         default=False, alias="PW_NEG_SOLAR"
     )  # Allow negative solar values (default: no)
@@ -307,12 +314,12 @@ class Settings(BaseSettings):
                     name="Default Gateway",
                     host=self.pw_host,
                     gw_pwd=self.pw_gw_pwd,
+                    rsa_key_path=self.pw_rsa_key_path,
+                    wifi_host=self.pw_wifi_host,
                     email=self.pw_email,
                     authpath=self.pw_authpath,
                     timezone=self.pw_timezone,
                     cloud_mode=bool(self.pw_email and not self.pw_host),
-                    rsa_key_path=self.pw_rsa_key_path,
-                    wifi_host=self.pw_wifi_host or None,
                 )
             ]
 

--- a/app/config.py
+++ b/app/config.py
@@ -197,6 +197,8 @@ class GatewayConfig(BaseSettings):
     cloud_mode: bool = False
     fleetapi: bool = False
     type: str = "powerwall"  # "powerwall" | "inverter" (solar-only, no batteries)
+    rsa_key_path: Optional[str] = None  # RSA-4096 private key PEM path for TEDAPI v1r mode
+    wifi_host: Optional[str] = None  # WiFi TEDAPI host for v1r wifi fallback
 
     model_config = {"env_prefix": ""}
 
@@ -212,6 +214,8 @@ class Settings(BaseSettings):
     # Powerwall connection settings
     pw_host: Optional[str] = Field(default=None, alias="PW_HOST")
     pw_gw_pwd: Optional[str] = Field(default=None, alias="PW_GW_PWD")
+    pw_rsa_key_path: Optional[str] = Field(default=None, alias="PW_RSA_KEY_PATH")  # RSA-4096 key for TEDAPI v1r
+    pw_wifi_host: Optional[str] = Field(default=None, alias="PW_WIFI_HOST")  # WiFi host for v1r fallback
     pw_password: Optional[str] = Field(
         default=None, alias="PW_PASSWORD"
     )  # Legacy PW2 local access
@@ -307,6 +311,8 @@ class Settings(BaseSettings):
                     authpath=self.pw_authpath,
                     timezone=self.pw_timezone,
                     cloud_mode=bool(self.pw_email and not self.pw_host),
+                    rsa_key_path=self.pw_rsa_key_path,
+                    wifi_host=self.pw_wifi_host or None,
                 )
             ]
 

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -135,14 +135,14 @@ class GatewayManager:
         for config in gateway_configs:
             try:
                 # Validate configuration
-                # TEDAPI mode: need host + gw_pwd
+                # TEDAPI mode: need host + (gw_pwd OR rsa_key_path)
                 # Cloud mode: need email (authpath is optional, pypowerwall has defaults)
-                has_tedapi = config.host and config.gw_pwd
+                has_tedapi = config.host and (config.gw_pwd or config.rsa_key_path)
                 has_cloud = config.email  # cloud_mode is auto-set, email is sufficient
 
                 if not (has_tedapi or has_cloud):
                     logger.error(
-                        f"Invalid configuration for gateway {config.id}: need host+gw_pwd (TEDAPI) or email (Cloud)"
+                        f"Invalid configuration for gateway {config.id}: need host+gw_pwd or host+rsa_key_path (TEDAPI) or email (Cloud)"
                     )
                     continue
 
@@ -156,6 +156,9 @@ class GatewayManager:
                     host=config.host,
                     port=config.port,
                     gw_pwd=config.gw_pwd,
+                    rsa_key_path=config.rsa_key_path,
+                    rsa_key_configured=bool(config.rsa_key_path),
+                    wifi_host=config.wifi_host,
                     email=config.email,
                     timezone=config.timezone,
                     cloud_mode=config.cloud_mode,
@@ -303,6 +306,14 @@ class GatewayManager:
                             ),
                             timeout=15.0,
                         )
+                        connected = await asyncio.wait_for(
+                            loop.run_in_executor(self._executor, pw.is_connected),
+                            timeout=10.0,
+                        )
+                        if not connected:
+                            raise Exception(
+                                f"pypowerwall failed to connect to gateway {gateway_id} (cloud mode)"
+                            )
                     else:
                         # Build host string with optional non-standard port
                         # e.g. host="192.168.1.50", port=8443 -> "192.168.1.50:8443"
@@ -318,10 +329,6 @@ class GatewayManager:
                         }
                         if settings.pw_password:
                             tedapi_kwargs["password"] = settings.pw_password
-                        if config.rsa_key_path:
-                            tedapi_kwargs["rsa_key_path"] = config.rsa_key_path
-                        if config.wifi_host:
-                            tedapi_kwargs["wifi_host"] = config.wifi_host
                         if config.email:
                             tedapi_kwargs["email"] = config.email
                         if config.authpath:
@@ -330,6 +337,10 @@ class GatewayManager:
                             tedapi_kwargs["cachefile"] = settings.cache_file
                         if settings.siteid:
                             tedapi_kwargs["siteid"] = settings.siteid
+                        if config.rsa_key_path:
+                            tedapi_kwargs["rsa_key_path"] = config.rsa_key_path
+                        if config.wifi_host:
+                            tedapi_kwargs["wifi_host"] = config.wifi_host
                         pw = await asyncio.wait_for(
                             loop.run_in_executor(
                                 self._executor,
@@ -337,6 +348,14 @@ class GatewayManager:
                             ),
                             timeout=15.0,
                         )
+                        connected = await asyncio.wait_for(
+                            loop.run_in_executor(self._executor, pw.is_connected),
+                            timeout=10.0,
+                        )
+                        if not connected:
+                            raise Exception(
+                                f"pypowerwall failed to connect to gateway {gateway_id} (TEDAPI mode)"
+                            )
 
                     self.connections[gateway_id] = pw
                     del self._pending_configs[gateway_id]

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -318,6 +318,10 @@ class GatewayManager:
                         }
                         if settings.pw_password:
                             tedapi_kwargs["password"] = settings.pw_password
+                        if config.rsa_key_path:
+                            tedapi_kwargs["rsa_key_path"] = config.rsa_key_path
+                        if config.wifi_host:
+                            tedapi_kwargs["wifi_host"] = config.wifi_host
                         if config.email:
                             tedapi_kwargs["email"] = config.email
                         if config.authpath:

--- a/tests/test_api_legacy.py
+++ b/tests/test_api_legacy.py
@@ -250,7 +250,7 @@ def test_control_mode_routes_to_cloud(
 
 
 def test_control_grid_charging_routes_to_cloud(
-    control_client, connected_gateway, monkeypatch
+    control_client, connected_gateway
 ):
     """Test that POST /control/grid_charging uses cloud_control when _cloud_control is set."""
     from app.core.gateway_manager import gateway_manager
@@ -270,7 +270,7 @@ def test_control_grid_charging_routes_to_cloud(
 
 
 def test_control_grid_charging_disable(
-    control_client, connected_gateway, monkeypatch
+    control_client, connected_gateway
 ):
     """Test that POST /control/grid_charging with False disables grid charging."""
     from app.core.gateway_manager import gateway_manager
@@ -287,6 +287,42 @@ def test_control_grid_charging_disable(
 
     assert response.status_code == 200
     mock_cloud.set_grid_charging.assert_called_once_with(False)
+
+
+def test_control_grid_charging_missing_value_returns_400(
+    control_client, connected_gateway
+):
+    """Test that POST /control/grid_charging without 'value' returns 400."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/grid_charging",
+        json={},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 400
+
+
+def test_control_grid_charging_non_boolean_value_returns_400(
+    control_client, connected_gateway
+):
+    """Test that POST /control/grid_charging with a non-boolean 'value' returns 400."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/grid_charging",
+        json={"value": "yes"},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 400
 
 
 def test_control_cloud_returns_none_gives_503(

--- a/tests/test_api_legacy.py
+++ b/tests/test_api_legacy.py
@@ -249,6 +249,46 @@ def test_control_mode_routes_to_cloud(
     mock_cloud.set_mode.assert_called_once_with("self_consumption")
 
 
+def test_control_grid_charging_routes_to_cloud(
+    control_client, connected_gateway, monkeypatch
+):
+    """Test that POST /control/grid_charging uses cloud_control when _cloud_control is set."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    mock_cloud.set_grid_charging.return_value = {"result": "Updated"}
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/grid_charging",
+        json={"value": True},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    mock_cloud.set_grid_charging.assert_called_once_with(True)
+
+
+def test_control_grid_charging_disable(
+    control_client, connected_gateway, monkeypatch
+):
+    """Test that POST /control/grid_charging with False disables grid charging."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    mock_cloud.set_grid_charging.return_value = {"result": "Updated"}
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/grid_charging",
+        json={"value": False},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    mock_cloud.set_grid_charging.assert_called_once_with(False)
+
+
 def test_control_cloud_returns_none_gives_503(
     control_client, connected_gateway, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Adds cloud control support for TEDAPI gateways, enabling write operations (set_reserve, set_mode, set_grid_charging) via a secondary cloud connection while keeping fast local TEDAPI reads.

### Changes

- **Cloud control connection**: A secondary `pypowerwall.Powerwall` in cloud mode is initialized at startup for TEDAPI gateways with cloud credentials, enabling hybrid operation (local reads + cloud writes).
- **Control routing**: `POST /control/{path}` now routes `reserve`, `mode`, and `grid_charging` through the cloud control connection when available, falling back to direct post for cloud-mode/FleetAPI gateways.
- **Grid charging control**: Adds `set_grid_charging` to the cloud control map, allowing enable/disable via `POST /control/grid_charging` with `{"value": true/false}`.
- **Comprehensive tests**: Added tests for cloud control initialization, routing, fallback behavior, and error handling.

### Motivation

TEDAPI mode doesn't support POST/write APIs natively. This hybrid approach uses TEDAPI for fast, reliable reads and the Tesla cloud API for control operations, giving the best of both worlds.

Tested on a Powerwall 3 with TEDAPI gateway — grid charging toggle works reliably (~5-15s to take effect).