### PR TITLE
fix: fixed-tick polling cadence (#38)

### DIFF
--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -254,13 +254,15 @@ class GatewayManager:
         sleep-after-poll approach the effective interval was poll_duration + sleep,
         causing drift (e.g. ~8-9s actual interval when PW_CACHE_EXPIRE=5).
 
-        The loop records the wall-clock time at the start of each cycle and only
-        sleeps for the *remaining* time after all gateways have been polled, so
-        the next cycle starts as close to the configured interval as possible.
+        The loop records the monotonic clock time (via ``loop.time()``) at the
+        start of each cycle and only sleeps for the *remaining* time after all
+        gateways have been polled, so the next cycle starts as close to the
+        configured interval as possible.
         """
         while True:
             try:
-                loop_start = asyncio.get_event_loop().time()
+                loop = asyncio.get_running_loop()
+                loop_start = loop.time()
 
                 # Poll all gateways concurrently
                 tasks = [
@@ -270,7 +272,7 @@ class GatewayManager:
                 await asyncio.gather(*tasks, return_exceptions=True)
 
                 # Sleep only the remaining time to maintain fixed interval
-                elapsed = asyncio.get_event_loop().time() - loop_start
+                elapsed = loop.time() - loop_start
                 sleep_time = max(0, self._poll_interval - elapsed)
                 await asyncio.sleep(sleep_time)
             except asyncio.CancelledError:

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -247,9 +247,21 @@ class GatewayManager:
         logger.info("Gateway manager shutdown complete")
 
     async def _poll_gateways(self):
-        """Background task to poll all gateways periodically."""
+        """Background task to poll all gateways on a fixed cadence.
+
+        Uses a fixed-tick scheduling pattern to ensure consistent poll-to-poll
+        intervals regardless of how long the actual poll takes. With the previous
+        sleep-after-poll approach the effective interval was poll_duration + sleep,
+        causing drift (e.g. ~8-9s actual interval when PW_CACHE_EXPIRE=5).
+
+        The loop records the wall-clock time at the start of each cycle and only
+        sleeps for the *remaining* time after all gateways have been polled, so
+        the next cycle starts as close to the configured interval as possible.
+        """
         while True:
             try:
+                loop_start = asyncio.get_event_loop().time()
+
                 # Poll all gateways concurrently
                 tasks = [
                     self._poll_gateway(gateway_id)
@@ -257,7 +269,10 @@ class GatewayManager:
                 ]
                 await asyncio.gather(*tasks, return_exceptions=True)
 
-                await asyncio.sleep(self._poll_interval)
+                # Sleep only the remaining time to maintain fixed interval
+                elapsed = asyncio.get_event_loop().time() - loop_start
+                sleep_time = max(0, self._poll_interval - elapsed)
+                await asyncio.sleep(sleep_time)
             except asyncio.CancelledError:
                 break
             except Exception as e:


### PR DESCRIPTION
## Problem

The polling loop in `app/core/gateway_manager.py` used a **sleep-after-poll** pattern:

```python
await asyncio.gather(*tasks, return_exceptions=True)
await asyncio.sleep(self._poll_interval)
```

This means the effective interval is `poll_duration + sleep_time`. With the default `PW_CACHE_EXPIRE=5`, a poll that takes ~3-4 seconds results in actual cache refresh intervals of ~8-9 seconds — nearly double the configured value. Fixes #38.

## Solution

Switch to **fixed-tick scheduling**: record the wall-clock time at the start of each cycle and sleep only for the _remaining_ time after polling completes.

```python
loop_start = asyncio.get_event_loop().time()

# Poll all gateways concurrently
tasks = [...]
await asyncio.gather(*tasks, return_exceptions=True)

# Sleep only the remaining time to maintain fixed interval
elapsed = asyncio.get_event_loop().time() - loop_start
sleep_time = max(0, self._poll_interval - elapsed)
await asyncio.sleep(sleep_time)
```

This ensures poll cycles start consistently at the configured interval regardless of how long individual polls take. If a poll takes _longer_ than the full interval, `max(0, ...)` prevents a negative sleep and the next cycle starts immediately (same safe fallback behavior as before).

## Changes

- `app/core/gateway_manager.py`: Updated `_poll_gateways()` with fixed-tick scheduling and expanded docstring explaining the behavior.

## Testing

All 21 existing tests pass:

```
21 passed in 0.10s
```

— Sam 🔌