### PR TITLE
Fix README and code env var: PW_AUTHPATH -> PW_AUTH_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ docker run -d \
   -p 8675:8675 \
   -v ~/.pypowerwall:/auth \
   -e PW_EMAIL="your@email.com" \
-  -e PW_AUTHPATH=/auth \
+  -e PW_AUTH_PATH=/auth \
   jasonacox/pypowerwall-server
 
 # One-time setup (runs auth flow to generate token files)
@@ -129,7 +129,7 @@ PROXY_BASE_URL=/pypowerwall  # Optional: serve under a sub-path (see Reverse Pro
 PW_HOST=192.168.91.1
 PW_GW_PWD=your_gateway_password          # For TEDAPI data reads
 PW_EMAIL=your-tesla-account@email.com
-PW_AUTHPATH=/path/to/auth/files            # Directory with .pypowerwall.auth/.site
+PW_AUTH_PATH=/path/to/auth/files            # Directory with .pypowerwall.auth/.site
 PW_TIMEZONE=America/Los_Angeles
 ```
 
@@ -389,7 +389,7 @@ PW_GW_PWD=gateway_password
 PW_HOST=192.168.91.1
 PW_GW_PWD=gateway_password
 PW_EMAIL=tesla@email.com
-PW_AUTHPATH=/path/to/auth  # Directory with .pypowerwall.auth/.site files
+PW_AUTH_PATH=/path/to/auth  # Directory with .pypowerwall.auth/.site files
 ```
 
 ### Async + Sync Library Integration

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ Standard Configuration (TEDAPI):
     For control operations, authenticate with Tesla Cloud:
         python3 -m pypowerwall setup
         PW_EMAIL=tesla@email.com
-        PW_AUTHPATH=/path/to/auth/files
+        PW_AUTH_PATH=/path/to/auth/files
 
 Routing Structure:
     Routes are organized to avoid conflicts:
@@ -662,7 +662,7 @@ Environment Variables:
   PW_GW_PWD          Gateway Wi-Fi password (required for TEDAPI)
   PW_EMAIL           Tesla account email (for Cloud/FleetAPI)
   PW_PASSWORD        Tesla account password (deprecated, use setup)
-  PW_AUTHPATH        Path to store authentication files (default: .)
+  PW_AUTH_PATH        Path to store authentication files (default: .)
   PW_STYLE           Theme style (default: clear)
   PW_SITEID          Specific site ID (for multiple sites)
   PW_CACHE_EXPIRE    Polling interval in seconds (default: 5)
@@ -721,7 +721,7 @@ For more information, visit: https://github.com/jasonacox/pypowerwall-server
             print()
             print("✓ Setup complete!")
             print()
-            print("Auth files created. You can now use PW_EMAIL and PW_AUTHPATH")
+            print("Auth files created. You can now use PW_EMAIL and PW_AUTH_PATH")
             print("to enable Cloud mode control operations.")
             sys.exit(result.returncode)
         except subprocess.CalledProcessError as e:
@@ -743,7 +743,7 @@ For more information, visit: https://github.com/jasonacox/pypowerwall-server
     if args.password:
         os.environ["PW_PASSWORD"] = args.password
     if args.authpath:
-        os.environ["PW_AUTHPATH"] = args.authpath
+        os.environ["PW_AUTH_PATH"] = args.authpath
     if args.style:
         os.environ["PW_STYLE"] = args.style
     if args.siteid:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       # Optional: Add cloud auth for control operations
       # First run: python3 -m pypowerwall setup (generates auth files)
       # - PW_EMAIL=your-tesla-account@email.com
-      # - PW_AUTHPATH=/auth
+      # - PW_AUTH_PATH=/auth
       
       - PW_TIMEZONE=America/Los_Angeles
       


### PR DESCRIPTION
Fixes #40.

The Pydantic config in `app/config.py` reads `PW_AUTH_PATH`, but README.md, `app/main.py`, and `docker-compose.yml` all documented/used `PW_AUTHPATH` (no underscore). This caused silent broken cloud control for anyone following the README.

Changes:
- README.md: 3 occurrences
- app/main.py: 4 occurrences (including the critical `os.environ["PW_AUTHPATH"]` which meant CLI `--authpath` was also broken)
- docker-compose.yml: 1 commented occurrence

Verified: `PW_AUTH_PATH` is the correct name that `config.py` actually reads via `alias="PW_AUTH_PATH"`.

— Sam 🔌