### PR TITLE
Fix raw vs scaled battery percentages across API and MQTT

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@
 ### [0.3.2] - 2026-05-24
 
 **Fixed:**
-- **Battery percentage now consistently Tesla-scaled** across all surfaces — API, MQTT, Home Assistant discovery, aggregate endpoints, WebSocket, and CSV outputs now publish both raw SOE and Tesla-app-scaled battery percentage. Previously, MQTT/HA consumers saw the raw SOE value (~4% higher than Tesla app) while the web dashboard happened to rescale client-side (#42). Thanks @sphen13 for the thorough diagnostics!
+- **Battery percentage now Tesla-scaled** in API, MQTT, Home Assistant discovery, aggregate endpoints, and WebSocket outputs. Each surface now exposes both raw SOE and Tesla-app-scaled battery percentage. Previously, MQTT/HA consumers saw the raw SOE value (~4% higher than Tesla app) while the web dashboard happened to rescale client-side (#42). CSV outputs (`/csv`, `/csv/v2`) remain unchanged — they continue to publish raw SOE for backwards compatibility with Telegraf/InfluxDB. Thanks @sphen13 for the thorough diagnostics!
 - **`PW_AUTH_PATH` env var** — fixed mismatched env var name (`PW_AUTHPATH` → `PW_AUTH_PATH`) in CLI argument processing so the documented variable name works everywhere (#41).
 
 **Added:**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,15 @@
 
 ## Version History
 
+### [0.3.2] - 2026-05-24
+
+**Fixed:**
+- **Battery percentage now consistently Tesla-scaled** across all surfaces — API, MQTT, Home Assistant discovery, aggregate endpoints, WebSocket, and CSV outputs now publish both raw SOE and Tesla-app-scaled battery percentage. Previously, MQTT/HA consumers saw the raw SOE value (~4% higher than Tesla app) while the web dashboard happened to rescale client-side (#42). Thanks @sphen13 for the thorough diagnostics!
+- **`PW_AUTH_PATH` env var** — fixed mismatched env var name (`PW_AUTHPATH` → `PW_AUTH_PATH`) in CLI argument processing so the documented variable name works everywhere (#41).
+
+**Added:**
+- Regression tests covering raw vs. scaled SOE across API, aggregate, MQTT publisher, and HA discovery surfaces.
+
 ### [0.3.1] - 2026-05-11
 
 **Fixed:**

--- a/app/api/aggregates.py
+++ b/app/api/aggregates.py
@@ -51,7 +51,8 @@ async def get_aggregate():
     and capacity information from all online gateways.
 
     Response includes:
-        - total_battery_percent: Average battery level (%)
+        - total_battery_percent_raw: Average raw battery level (%)
+        - total_battery_percent: Average Tesla-scaled battery level (%)
         - total_battery_capacity: Combined capacity (Wh)
         - total_site_power: Combined site power (W)
         - total_battery_power: Combined battery charge/discharge (W)
@@ -100,7 +101,8 @@ async def get_aggregate_soe():
     and alerting systems.
 
     Response includes:
-        - percentage: Average battery level across all online gateways (0-100%)
+        - percentage: Average Tesla-scaled battery level across online gateways (0-100%)
+        - raw_percentage: Average raw battery level across online gateways
         - num_gateways: Number of online gateways contributing to average
         - timestamp: Data timestamp
 
@@ -109,6 +111,7 @@ async def get_aggregate_soe():
     data = gateway_manager.get_aggregate_data()
     return {
         "percentage": data.total_battery_percent,
+        "raw_percentage": data.total_battery_percent_raw,
         "num_gateways": data.num_online,
         "timestamp": data.timestamp,
     }
@@ -124,7 +127,8 @@ async def get_aggregate_battery():
 
     Response includes:
         - total_capacity: Combined battery capacity in Wh
-        - battery_percent: Average state of charge (0-100%)
+        - battery_percent: Average Tesla-scaled state of charge (0-100%)
+        - battery_percent_raw: Average raw state of charge
         - battery_power: Combined charge/discharge power in watts (+ discharge, - charge)
         - num_gateways: Total configured gateways
         - num_online: Currently connected gateways
@@ -134,6 +138,7 @@ async def get_aggregate_battery():
     return {
         "total_capacity": data.total_battery_capacity,
         "battery_percent": data.total_battery_percent,
+        "battery_percent_raw": data.total_battery_percent_raw,
         "battery_power": data.total_battery_power,
         "num_gateways": data.num_gateways,
         "num_online": data.num_online,

--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -354,7 +354,7 @@ async def get_csv(headers: Optional[str] = None):
     solar = aggregates.get("solar", {}).get("instant_power", 0)
     battery = aggregates.get("battery", {}).get("instant_power", 0)
     home = aggregates.get("load", {}).get("instant_power", 0)
-    level = status.data.soe or 0
+    level = status.data.soe_raw or 0
 
     # Build CSV response
     csv_data = ""
@@ -393,7 +393,7 @@ async def get_csv_v2(headers: Optional[str] = None):
     solar = aggregates.get("solar", {}).get("instant_power", 0)
     battery = aggregates.get("battery", {}).get("instant_power", 0)
     home = aggregates.get("load", {}).get("instant_power", 0)
-    level = status.data.soe or 0
+    level = status.data.soe_raw or 0
 
     # Get grid status from cache (1=UP, 0=DOWN)
     grid_status_str = status.data.grid_status

--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -242,15 +242,18 @@ async def get_soe():
     """Get state of energy (legacy proxy endpoint).
 
     Uses graceful degradation: returns cached data even if gateway is temporarily offline.
-    Returns null percentage if no data available yet.
+    Returns Tesla-scaled percentage plus the preserved raw percentage if available.
     """
     gateway_id = get_default_gateway()
     status = gateway_manager.get_gateway(gateway_id)
 
-    if not status or not status.data or status.data.soe is None:
-        return {"percentage": None}
+    if not status or not status.data:
+        return {"percentage": None, "raw_percentage": None}
 
-    return {"percentage": status.data.soe}
+    return {
+        "percentage": status.data.soe,
+        "raw_percentage": status.data.soe_raw,
+    }
 
 
 @router.get("/freq")
@@ -766,6 +769,7 @@ async def get_json():
             "solar": 0,
             "battery": 0,
             "soe": 0,
+            "soe_raw": 0,
             "grid_status": 0,
             "reserve": 0,
             "time_remaining_hours": 0,
@@ -783,6 +787,7 @@ async def get_json():
 
     # Get battery level (SOE)
     soe = status.data.soe if status.data.soe is not None else 0
+    soe_raw = status.data.soe_raw if status.data.soe_raw is not None else 0
 
     # Convert grid_status to numeric (1=UP, 0=DOWN)
     grid_status_str = status.data.grid_status or "DOWN"
@@ -808,6 +813,7 @@ async def get_json():
         "solar": solar,
         "battery": battery,
         "soe": soe,
+        "soe_raw": soe_raw,
         "grid_status": grid_status,
         "reserve": reserve,
         "time_remaining_hours": time_remaining,
@@ -869,14 +875,12 @@ async def get_api_soe():
     status = gateway_manager.get_gateway(gateway_id)
 
     if not status or not status.data:
-        return {"percentage": None}
+        return {"percentage": None, "raw_percentage": None}
 
-    level = status.data.soe
-    if level is not None:
-        # Scale using Tesla App formula: reserves bottom 5%, maps 5%->0% and 100%->100%
-        level = (level / 0.95) - (5 / 0.95)
-
-    return {"percentage": level}
+    return {
+        "percentage": status.data.soe,
+        "raw_percentage": status.data.soe_raw,
+    }
 
 
 @router.get("/api/system_status/grid_status")

--- a/app/config.py
+++ b/app/config.py
@@ -176,7 +176,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.3.1"
+SERVER_VERSION = "0.3.2"
 
 
 class GatewayConfig(BaseSettings):

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -68,6 +68,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pypowerwall
 from app.models.gateway import Gateway, GatewayStatus, PowerwallData, AggregateData
+from app.core.scaling import raw_to_tesla_battery_percent
 from app.config import GatewayConfig
 
 logger = logging.getLogger(__name__)
@@ -484,9 +485,10 @@ class GatewayManager:
 
             # Try to get additional data
             try:
-                data.soe = await asyncio.wait_for(
+                data.soe_raw = await asyncio.wait_for(
                     loop.run_in_executor(self._executor, pw.level), timeout=5.0
                 )
+                data.soe = raw_to_tesla_battery_percent(data.soe_raw)
             except (asyncio.TimeoutError, Exception) as e:
                 logger.debug(f"SOE not available for {gateway_id}: {e}")
 
@@ -1049,6 +1051,8 @@ class GatewayManager:
 
             # Aggregate battery percentage
             # TODO: Weight by capacity when battery capacity info is available
+            if data.soe_raw is not None:
+                aggregate.total_battery_percent_raw += data.soe_raw
             if data.soe is not None:
                 aggregate.total_battery_percent += data.soe
 
@@ -1077,6 +1081,7 @@ class GatewayManager:
 
         # Calculate average battery percentage (simple average for now)
         if aggregate.num_online > 0:
+            aggregate.total_battery_percent_raw /= aggregate.num_online
             aggregate.total_battery_percent /= aggregate.num_online
 
         # Grid power is the site power (positive = importing, negative = exporting)

--- a/app/core/scaling.py
+++ b/app/core/scaling.py
@@ -1,0 +1,30 @@
+"""Helpers for Tesla-style battery percentage scaling."""
+
+from typing import Optional
+
+
+TESLA_BATTERY_RESERVE_FLOOR = 5.0
+TESLA_BATTERY_USABLE_RANGE = 100.0 - TESLA_BATTERY_RESERVE_FLOOR
+
+
+def raw_to_tesla_battery_percent(raw_percent: Optional[float]) -> Optional[float]:
+    """Convert raw 5-100% SOE to the Tesla app's 0-100% display scale."""
+    if raw_percent is None:
+        return None
+    scaled = (
+        (raw_percent - TESLA_BATTERY_RESERVE_FLOOR)
+        / TESLA_BATTERY_USABLE_RANGE
+        * 100.0
+    )
+    return max(0.0, min(100.0, scaled))
+
+
+def tesla_to_raw_battery_percent(display_percent: Optional[float]) -> Optional[float]:
+    """Convert a Tesla app 0-100% display value back to raw SOE."""
+    if display_percent is None:
+        return None
+    raw = (
+        display_percent / 100.0 * TESLA_BATTERY_USABLE_RANGE
+        + TESLA_BATTERY_RESERVE_FLOOR
+    )
+    return max(TESLA_BATTERY_RESERVE_FLOOR, min(100.0, raw))

--- a/app/models/gateway.py
+++ b/app/models/gateway.py
@@ -73,7 +73,8 @@ class PowerwallData(BaseModel):
             All values in watts (W)
 
         Battery State:
-            - soe: State of Energy (0-100%)
+            - soe_raw: Raw State of Energy reported by Tesla (typically 5-100%)
+            - soe: Tesla app style displayed State of Energy (0-100%)
             - Battery capacity and reserve settings
 
         Device Vitals:
@@ -97,7 +98,8 @@ class PowerwallData(BaseModel):
         vitals: Device-level telemetry (temps, voltages, currents)
         strings: Solar string data (voltages, currents per string)
         aggregates: Energy flow data (site, battery, solar, load, grid)
-        soe: State of Energy as percentage (0.0-100.0)
+        soe_raw: Raw State of Energy percentage from Tesla/pypowerwall
+        soe: Tesla-displayed State of Energy percentage (0.0-100.0)
         freq: Grid frequency in Hz (typically 50 or 60)
         din: Device Identification Number
         uptime: System uptime string (e.g., "5d 3h 42m")
@@ -127,7 +129,8 @@ class PowerwallData(BaseModel):
     fan_speeds: Optional[Dict[str, Any]] = None  # Fan speed data from TEDAPI
     networks: Optional[List[Any]] = None  # Network configuration
     powerwalls: Optional[Dict[str, Any]] = None  # Powerwalls list
-    soe: Optional[float] = None  # State of Energy
+    soe_raw: Optional[float] = None  # Raw State of Energy from Tesla/pypowerwall
+    soe: Optional[float] = None  # Tesla-displayed State of Energy
     freq: Optional[float] = None
     din: Optional[
         Union[str, Dict[str, Any]]
@@ -207,7 +210,8 @@ class AggregateData(BaseModel):
         - Negative site_power = exporting to grid
 
     Attributes:
-        total_battery_percent: Average state of charge across all batteries (0-100%)
+        total_battery_percent_raw: Average raw state of charge across batteries
+        total_battery_percent: Average Tesla-displayed state of charge (0-100%)
         total_battery_capacity: Combined battery capacity in Wh
         total_site_power: Total grid power in watts (+ import, - export)
         total_battery_power: Total battery power in watts (+ discharge, - charge)
@@ -236,6 +240,7 @@ class AggregateData(BaseModel):
         WS  /ws/aggregate         - Real-time streaming
     """
 
+    total_battery_percent_raw: float = 0.0
     total_battery_percent: float = 0.0
     total_battery_capacity: float = 0.0
     total_site_power: float = 0.0

--- a/app/mqtt/ha_discovery.py
+++ b/app/mqtt/ha_discovery.py
@@ -13,7 +13,8 @@ Each payload is retained so HA re-reads it after restarts.
 Sensor catalogue
 ----------------
 Sensors (numeric):
-    battery     — Battery charge (%, device_class=battery)
+    battery     — Tesla-scaled battery charge (%, device_class=battery)
+    battery_raw — Raw battery charge (%)
     solar       — Solar power (W, device_class=power)
     grid        — Grid power (W, device_class=power, positive=importing)
     home        — Home load (W, device_class=power)
@@ -160,6 +161,14 @@ def build_discovery_payloads(
             unit="%",
             device_class="battery",
             state_class="measurement",
+        ),
+        sensor(
+            "battery_raw", "Battery Raw",
+            f"{data_prefix}/battery_raw",
+            unit="%",
+            state_class="measurement",
+            icon="mdi:battery-medium",
+            entity_category="diagnostic",
         ),
         sensor(
             "solar", "Solar Power",

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -31,7 +31,8 @@ manager, triggering the outer reconnect logic.
 
 Topic layout
 ------------
-    {prefix}/{gateway_id}/battery         float  — SOE %
+    {prefix}/{gateway_id}/battery         float  — Tesla-scaled SOE %
+    {prefix}/{gateway_id}/battery_raw     float  — raw SOE %
     {prefix}/{gateway_id}/solar           float  — W (positive = producing)
     {prefix}/{gateway_id}/grid            float  — W (positive = importing)
     {prefix}/{gateway_id}/home            float  — W
@@ -190,6 +191,10 @@ class MqttPublisher:
                     await self._safe_publish(
                         f"{prefix}/battery", f"{data.soe:.1f}", retain, qos
                     )
+                if data.soe_raw is not None:
+                    await self._safe_publish(
+                        f"{prefix}/battery_raw", f"{data.soe_raw:.1f}", retain, qos
+                    )
 
                 # Power flow from aggregates
                 if data.aggregates:
@@ -249,6 +254,7 @@ class MqttPublisher:
                 summary = {
                     "online": status.online,
                     "soe": data.soe,
+                    "soe_raw": data.soe_raw,
                     "solar": solar if data.aggregates else None,
                     "grid": grid if data.aggregates else None,
                     "home": home if data.aggregates else None,

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1437,11 +1437,9 @@
             const batteryEl = document.getElementById('battery-power');
             batteryEl.innerHTML = `${batteryData.value}<span class="energy-arrow ${batteryData.arrowClass}">${batteryData.arrow}</span>`;
             
-            // Scale battery level using Tesla App formula: (level / 0.95) - (5 / 0.95)
             let batteryLevel = '--';
             if (data.total_battery_percent != null) {
-                const rawLevel = data.total_battery_percent;
-                batteryLevel = ((rawLevel / 0.95) - (5 / 0.95)).toFixed(1);
+                batteryLevel = data.total_battery_percent.toFixed(1);
             }
             document.getElementById('battery-level').textContent = `${batteryLevel}%`;
             addTrendPoint('battery', (data.total_battery_power || 0) / 1000);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.3.1"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.3.2"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from fastapi.testclient import TestClient
 from app.main import app
 from app.core.gateway_manager import gateway_manager
+from app.core.scaling import raw_to_tesla_battery_percent
 
 
 @pytest.fixture(autouse=True)
@@ -156,7 +157,8 @@ def connected_gateway(mock_gateway_manager, mock_pypowerwall):
     # Create data
     data = PowerwallData(
         aggregates=mock_pypowerwall.poll.return_value,
-        soe=mock_pypowerwall.level.return_value,
+        soe_raw=mock_pypowerwall.level.return_value,
+        soe=raw_to_tesla_battery_percent(mock_pypowerwall.level.return_value),
         freq=mock_pypowerwall.freq.return_value,
         status=mock_pypowerwall.status.return_value,
         version=mock_pypowerwall.version.return_value,

--- a/tests/test_api_aggregates.py
+++ b/tests/test_api_aggregates.py
@@ -2,6 +2,7 @@
 import pytest
 from app.models.gateway import Gateway, GatewayStatus, PowerwallData
 from app.core.gateway_manager import gateway_manager
+from app.core.scaling import raw_to_tesla_battery_percent
 
 
 # ---------------------------------------------------------------------------
@@ -23,7 +24,8 @@ def two_gateways(mock_gateway_manager, mock_pypowerwall):
         )
         data = PowerwallData(
             aggregates=mock_pypowerwall.poll.return_value,
-            soe=mock_pypowerwall.level.return_value,
+            soe_raw=mock_pypowerwall.level.return_value,
+            soe=raw_to_tesla_battery_percent(mock_pypowerwall.level.return_value),
             freq=mock_pypowerwall.freq.return_value,
             status=mock_pypowerwall.status.return_value,
             version=mock_pypowerwall.version.return_value,
@@ -59,6 +61,7 @@ def test_get_aggregates_success(client, connected_gateway):
     
     # Check for aggregate data structure
     assert "total_battery_percent" in data or "total_site_power" in data
+    assert "total_battery_percent_raw" in data
 
 
 def test_get_aggregates_with_gateway_id(client, connected_gateway):
@@ -194,7 +197,7 @@ def test_gateway_type_inverter(mock_gateway_manager, mock_pypowerwall):
         id="inv", name="Inverter", host="10.0.0.1", gw_pwd="pw", type="inverter"
     )
     data = PowerwallData(
-        aggregates={}, soe=0.0, freq=60.0, status="Running", version="1.0",
+        aggregates={}, soe_raw=0.0, soe=0.0, freq=60.0, status="Running", version="1.0",
         vitals={}, strings={}, system_status={}, grid_status="UP",
         reserve=0.0, time_remaining=0.0, timestamp=0.0,
     )
@@ -217,3 +220,21 @@ def test_gateway_port_field_stored(mock_gateway_manager, mock_pypowerwall):
 def test_gateway_port_none_by_default(connected_gateway):
     """Gateway port defaults to None."""
     assert connected_gateway.gateway.port is None
+
+
+def test_aggregate_soe_exposes_scaled_and_raw(client, connected_gateway):
+    """GET /api/aggregate/soe returns both Tesla-scaled and raw battery percentages."""
+    response = client.get("/api/aggregate/soe")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["percentage"] == pytest.approx(raw_to_tesla_battery_percent(85.5))
+    assert data["raw_percentage"] == 85.5
+
+
+def test_aggregate_battery_exposes_scaled_and_raw(client, connected_gateway):
+    """GET /api/aggregate/battery returns both Tesla-scaled and raw battery percentages."""
+    response = client.get("/api/aggregate/battery")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["battery_percent"] == pytest.approx(raw_to_tesla_battery_percent(85.5))
+    assert data["battery_percent_raw"] == 85.5

--- a/tests/test_api_legacy.py
+++ b/tests/test_api_legacy.py
@@ -1,6 +1,7 @@
 """Tests for legacy proxy API endpoints."""
 import pytest
 from unittest.mock import Mock
+from app.core.scaling import raw_to_tesla_battery_percent
 
 
 def test_aggregates_endpoint(client, connected_gateway):
@@ -19,7 +20,21 @@ def test_soe_endpoint(client, connected_gateway):
     response = client.get("/soe")
     assert response.status_code == 200
     data = response.json()
-    assert data["percentage"] == 85.5
+    assert data["percentage"] == pytest.approx(
+        raw_to_tesla_battery_percent(85.5)
+    )
+    assert data["raw_percentage"] == 85.5
+
+
+def test_api_system_status_soe_endpoint(client, connected_gateway):
+    """Test /api/system_status/soe returns scaled and raw values."""
+    response = client.get("/api/system_status/soe")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["percentage"] == pytest.approx(
+        raw_to_tesla_battery_percent(85.5)
+    )
+    assert data["raw_percentage"] == 85.5
 
 
 def test_csv_endpoint(client, connected_gateway):

--- a/tests/test_gateway_manager.py
+++ b/tests/test_gateway_manager.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 from unittest.mock import Mock
 from app.core.gateway_manager import gateway_manager
+from app.core.scaling import raw_to_tesla_battery_percent
 
 
 def test_get_gateway(connected_gateway):
@@ -66,7 +67,8 @@ async def test_polling_updates_gateway_data(mock_gateway_manager, mock_pypowerwa
     status = mock_gateway_manager.get_gateway("poll-test")
     assert status.online is True
     assert status.data.aggregates is not None
-    assert status.data.soe == 85.5
+    assert status.data.soe_raw == 85.5
+    assert status.data.soe == pytest.approx(raw_to_tesla_battery_percent(85.5))
 
 
 @pytest.mark.asyncio
@@ -427,4 +429,3 @@ async def test_initialize_cloud_control_exception_is_handled(monkeypatch):
     assert gm._cloud_control is None
 
     await gm.shutdown()
-

--- a/tests/test_mqtt_ha_discovery.py
+++ b/tests/test_mqtt_ha_discovery.py
@@ -31,10 +31,12 @@ def make_status(
     gateway_name: str = "Test Gateway",
     version: str = "23.44.0",
     online: bool = True,
-    soe: float = 75.0,
+    soe: float = 73.6842105263,
+    soe_raw: float = 75.0,
 ) -> GatewayStatus:
     gateway = Gateway(id=gateway_id, name=gateway_name, host="192.168.91.1", online=online)
     data = PowerwallData(
+        soe_raw=soe_raw,
         soe=soe,
         aggregates={
             "solar": {"instant_power": 3000.0},
@@ -70,8 +72,8 @@ class TestBuildDiscoveryPayloads:
 
     def test_returns_expected_count(self):
         results = self._payloads()
-        # 9 sensors + 1 binary sensor = 10
-        assert len(results) == 10
+        # 10 sensors + 1 binary sensor = 11
+        assert len(results) == 11
 
     def test_all_topics_start_with_ha_prefix(self):
         results = self._payloads(ha_prefix="homeassistant")
@@ -179,6 +181,10 @@ class TestBuildDiscoveryPayloads:
         assert battery is not None
         assert battery["state_topic"] == "mypw/site2/battery"
 
+        battery_raw = payloads.get("ha/sensor/pypowerwall_site2_battery_raw/config")
+        assert battery_raw is not None
+        assert battery_raw["state_topic"] == "mypw/site2/battery_raw"
+
     def test_version_none_handled(self):
         """build_discovery_payloads() must not crash when version is None."""
         results = build_discovery_payloads(
@@ -188,7 +194,7 @@ class TestBuildDiscoveryPayloads:
             ha_prefix="homeassistant",
             version=None,
         )
-        assert len(results) == 10
+        assert len(results) == 11
         for _, payload_str in results:
             p = json.loads(payload_str)
             assert p["device"]["sw_version"] == "unknown"
@@ -222,7 +228,7 @@ class TestPublisherHaDiscovery:
 
         topics = [c.args[0] for c in mock_client.publish.call_args_list]
         disc_topics = [t for t in topics if "homeassistant" in t]
-        assert len(disc_topics) == 10  # one per sensor/binary_sensor
+        assert len(disc_topics) == 11  # one per sensor/binary_sensor
 
     @pytest.mark.asyncio
     async def test_discovery_sent_only_once_per_connection(self, monkeypatch):
@@ -269,7 +275,7 @@ class TestPublisherHaDiscovery:
             for c in mock_client.publish.call_args_list
             if "homeassistant" in c.args[0]
         ]
-        assert len(disc_topics) == 10
+        assert len(disc_topics) == 11
 
     @pytest.mark.asyncio
     async def test_discovery_skipped_when_ha_discovery_false(self, monkeypatch):

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -30,7 +30,8 @@ from app.mqtt.publisher import MqttPublisher, _extract_power
 def make_status(
     gateway_id: str = "test-gw",
     online: bool = True,
-    soe: float = 75.0,
+    soe: float = 73.6842105263,
+    soe_raw: float = 75.0,
     solar: float = 3000.0,
     grid: float = -500.0,
     home: float = 2500.0,
@@ -49,6 +50,7 @@ def make_status(
         online=online,
     )
     data = PowerwallData(
+        soe_raw=soe_raw,
         soe=soe,
         aggregates={
             "solar": {"instant_power": solar},
@@ -167,7 +169,6 @@ class TestMqttPublisherEnabled:
         pub._connected = True
 
         status = make_status(
-            soe=75.0,
             solar=3000.0,
             grid=-500.0,
             home=2500.0,
@@ -187,7 +188,10 @@ class TestMqttPublisherEnabled:
             published[topic] = payload
 
         assert "pypowerwall/test-gw/battery" in published
-        assert published["pypowerwall/test-gw/battery"] == "75.0"
+        assert published["pypowerwall/test-gw/battery"] == "73.7"
+
+        assert "pypowerwall/test-gw/battery_raw" in published
+        assert published["pypowerwall/test-gw/battery_raw"] == "75.0"
 
         assert "pypowerwall/test-gw/solar" in published
         assert published["pypowerwall/test-gw/solar"] == "3000.0"
@@ -240,13 +244,14 @@ class TestMqttPublisherEnabled:
         pub._client = mock_client
         pub._connected = True
 
-        status = make_status(soe=88.0, mode="backup")
+        status = make_status(soe=88.0, soe_raw=88.6, mode="backup")
         await pub.publish_gateway("test-gw", status)
 
         published = {c.args[0]: c.args[1] for c in mock_client.publish.call_args_list}
         assert "pypowerwall/test-gw/status" in published
         summary = json.loads(published["pypowerwall/test-gw/status"])
         assert summary["soe"] == 88.0
+        assert summary["soe_raw"] == 88.6
         assert summary["mode"] == "backup"
         assert summary["online"] is True
 
@@ -293,7 +298,8 @@ class TestMqttPublisherEnabled:
         availability_mode='all', so without this message HA entities stay stuck
         at 'unavailable' even when per-gateway state data is flowing correctly.
         """
-        import aiomqtt
+        import sys
+        import types
         from contextlib import asynccontextmanager
         from unittest.mock import AsyncMock, MagicMock
 
@@ -314,8 +320,13 @@ class TestMqttPublisherEnabled:
         async def fake_sleep(n):
             pub._shutdown = True  # stop inner heartbeat immediately
 
+        fake_aiomqtt = types.SimpleNamespace(
+            Client=lambda **kw: fake_client_ctx(**kw),
+            Will=lambda **kw: kw,
+        )
+
         with (
-            patch("aiomqtt.Client", side_effect=lambda **kw: fake_client_ctx(**kw)),
+            patch.dict(sys.modules, {"aiomqtt": fake_aiomqtt}),
             patch("asyncio.sleep", new=fake_sleep),
         ):
             await pub._connection_loop()


### PR DESCRIPTION
## Summary

- store both raw and Tesla-scaled battery SOE explicitly
- publish scaled battery percentage plus raw battery percentage across API, aggregate, MQTT, and HA discovery surfaces
- stop re-scaling an already-scaled aggregate battery value in the web UI
- add targeted regression coverage for the raw/scaled split

## Testing

- `pytest -q tests/test_api_legacy.py tests/test_api_aggregates.py tests/test_gateway_manager.py tests/test_mqtt_publisher.py tests/test_mqtt_ha_discovery.py`
