### PR TITLE
fix: return None instead of 0 in /json and /battery when gateway offline

### DIFF
--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -764,17 +764,17 @@ async def get_json():
 
     if not status or not status.data:
         return {
-            "grid": 0,
-            "home": 0,
-            "solar": 0,
-            "battery": 0,
-            "soe": 0,
-            "soe_raw": 0,
-            "grid_status": 0,
-            "reserve": 0,
-            "time_remaining_hours": 0,
-            "full_pack_energy": 0,
-            "energy_remaining": 0,
+            "grid": None,
+            "home": None,
+            "solar": None,
+            "battery": None,
+            "soe": None,
+            "soe_raw": None,
+            "grid_status": None,
+            "reserve": None,
+            "time_remaining_hours": None,
+            "full_pack_energy": None,
+            "energy_remaining": None,
             "strings": {},
         }
 
@@ -833,10 +833,10 @@ async def get_battery_power():
     status = gateway_manager.get_gateway(gateway_id)
 
     if not status or not status.data:
-        return {"power": 0}
+        return {"power": None}
 
     aggregates = status.data.aggregates or {}
-    battery_power = aggregates.get("battery", {}).get("instant_power", 0)
+    battery_power = aggregates.get("battery", {}).get("instant_power")
 
     return {"power": battery_power}
 


### PR DESCRIPTION
## Summary

Fixes the `/json` and `/battery` endpoints to return `None`/`null` instead of `0` when `get_gateway()` returns `None` (no cached data available).

## Problem

Per #42 — when `get_gateway()` returns `None` (gateway has no cached data), the `/json` endpoint was returning an all-zero dict:

```json
{"grid": 0, "home": 0, "solar": 0, "battery": 0, "soe": 0, ...}
```

This makes it impossible for consumers to distinguish between "gateway is offline, no data" and "all readings are actually zero." The `/battery` endpoint had the same issue with `{"power": 0}`.

## Changes

- **`GET /json`** — returns `None` for all numeric fields when gateway data is unavailable
- **`GET /battery`** — returns `{"power": None}` when gateway data is unavailable

## Audit of other endpoints

| Endpoint | Offline behavior | Needs fix? |
|---|---|---|
| `/csv`, `/csv/v2` | Returns `0` values | ❌ No — numeric fields required for CSV format |
| `/soe` | Returns `{"percentage": None}` | ✅ Already correct |
| `/api/system_status/soe` | Returns `{"percentage": None}` | ✅ Already correct |
| `/aggregates` | Returns `{}` | ✅ Already correct (empty dict) |
| `/api/meters/aggregates` | Returns `{}` | ✅ Already correct |
| `/api/system_status` | Returns `{}` | ✅ Already correct |
| `/vitals`, `/strings`, etc. | Returns `{}` or `[]` | ✅ Already correct |
| **MQTT publisher** | Skips publish for `None` values | ✅ Already correct |
| **WebSocket `/ws/gateway/{id}`** | Sends `{"error": "Gateway not found"}` | ✅ Already correct |
| **WebSocket `/ws/aggregate`** | Sends `AggregateData` with defaults (0.0) | ⚠️ Could return None for 0-online case, but this is multi-gateway aggregation — 0.0 is semantically correct when no gateways are online |

## Testing

All 143 existing tests pass. The `/json` endpoint does not have a dedicated test for the no-gateway case (existing no-gateway tests cover other endpoints), but the behavior is verified by code inspection.

Fixes #42