### PR TITLE
fix: return None instead of 0 in JSON endpoints when gateway unavailable

### DIFF
--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -764,18 +764,18 @@ async def get_json():
 
     if not status or not status.data:
         return {
-            "grid": 0,
-            "home": 0,
-            "solar": 0,
-            "battery": 0,
-            "soe": 0,
-            "soe_raw": 0,
-            "grid_status": 0,
-            "reserve": 0,
-            "time_remaining_hours": 0,
-            "full_pack_energy": 0,
-            "energy_remaining": 0,
-            "strings": {},
+            "grid": None,
+            "home": None,
+            "solar": None,
+            "battery": None,
+            "soe": None,
+            "soe_raw": None,
+            "grid_status": None,
+            "reserve": None,
+            "time_remaining_hours": None,
+            "full_pack_energy": None,
+            "energy_remaining": None,
+            "strings": None,
         }
 
     # Extract power values from aggregates (neg_solar correction applied at fetch time)
@@ -833,7 +833,7 @@ async def get_battery_power():
     status = gateway_manager.get_gateway(gateway_id)
 
     if not status or not status.data:
-        return {"power": 0}
+        return {"power": None}
 
     aggregates = status.data.aggregates or {}
     battery_power = aggregates.get("battery", {}).get("instant_power", 0)


### PR DESCRIPTION
## Summary

Fixes #42 (follow-up to #43)

When  returns  (gateway not cached or offline), the JSON API endpoints ( and ) now return  for all fields instead of .

### Why this matters

Returning  implies a reading of zero watts/percent, which is misleading.  clearly communicates "no data available" — especially important for:
- **MQTT consumers** that poll  and publish to Home Assistant
- **sphen13's issue #42**: zero-value spikes in graphs were partly caused by this — a brief offline moment returned 0 instead of None, creating fake zero-readings in time series data

### Changes

- : all 12 fields return  instead of  when gateway has no data
- : returns  instead of 
- **CSV endpoints unchanged** — they correctly use  for numeric output expectations

### Other endpoints checked

All other JSON endpoints (, , , etc.) already return  or empty dicts when no data is available. The MQTT publisher already guards with  checks. This fix was only needed in  and .

---

— Sam 🔌