### PR TITLE
Guard TEDAPI multi-PW cache snapshots

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,17 @@
 
 ## Version History
 
+### [0.3.4] - 2026-06-07
+
+**Fixed:**
+- **Multi-Powerwall visibility in TEDAPI full mode** — in WiFi-only TEDAPI mode (no v1r RSA key), follower Powerwalls were invisible in the `/freq` endpoint because their TEDAPI endpoints are unreachable without a WiFi session. The endpoint now uses `tedapi_config` (from gateway `config.json`, which always lists all registered units) as the authoritative Powerwall list and matches per-Powerwall data by serial number rather than sequential index. Follower units now appear with whatever data is available; fields not reachable without v1r are `null` (#47).
+- **MQTT entities stuck "unavailable" on broker reconnect** — the global `{prefix}/availability` topic was never published as `"online"` after (re)connecting to the broker. Home Assistant entities therefore remained unavailable even while data was flowing. Fixed by publishing `"online"` (retained) to the global availability topic immediately after each successful connection (#33).
+- **Orphan "Unknown Device" in Home Assistant** — HA discovery payloads included a `via_device: "pypowerwall-server"` field that referenced a device never registered with HA, creating a phantom device entry. Removed the field entirely (#34).
+- **`grid_charging` control accepts only explicit booleans** — `POST /control/grid_charging` now returns HTTP 400 if `value` is absent or not a boolean, preventing silent state changes from malformed payloads (#29).
+
+**Changed:**
+- **Transient multi-PW TEDAPI snapshot guard** — if a single poll cycle drops follower vitals or `battery_blocks` (e.g., a momentary TEDAPI timeout), the cache layer now preserves the previous complete multi-Powerwall snapshot rather than replacing it with a degraded single-Powerwall view. Applies to all cache consumers (MQTT, WebSocket, `/pod`, `/freq`, etc.).
+
 ### [0.3.3] - 2026-05-26
 
 **Added:**

--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -278,38 +278,80 @@ async def get_freq():
         return {"freq": None}
 
     fcv = {}
-    idx = 1
-
-    # Pull freq, current, voltage of each Powerwall via system_status
-    system_status = status.data.system_status or {}
-    if "battery_blocks" in system_status:
-        for block in system_status["battery_blocks"]:
-            fcv[f"PW{idx}_name"] = None  # Placeholder for vitals
-            fcv[f"PW{idx}_PINV_Fout"] = block.get("f_out")
-            fcv[f"PW{idx}_PINV_VSplit1"] = None  # Placeholder for vitals
-            fcv[f"PW{idx}_PINV_VSplit2"] = None  # Placeholder for vitals
-            fcv[f"PW{idx}_PackagePartNumber"] = block.get("PackagePartNumber")
-            fcv[f"PW{idx}_PackageSerialNumber"] = block.get("PackageSerialNumber")
-            fcv[f"PW{idx}_p_out"] = block.get("p_out")
-            fcv[f"PW{idx}_q_out"] = block.get("q_out")
-            fcv[f"PW{idx}_v_out"] = block.get("v_out")
-            fcv[f"PW{idx}_f_out"] = block.get("f_out")
-            fcv[f"PW{idx}_i_out"] = block.get("i_out")
-            idx += 1
-
-    # Pull freq, current, voltage of each Powerwall via vitals if available
     vitals = status.data.vitals or {}
-    idx = 1
+    system_status = status.data.system_status or {}
+
+    # --- Build serial-keyed lookup maps ---
+
+    # Map PackageSerialNumber → system_status battery block
+    ss_block_map: dict = {}
+    for block in (system_status.get("battery_blocks") or []):
+        serial = block.get("PackageSerialNumber")
+        if serial:
+            ss_block_map[serial] = block
+
+    # Map PackageSerialNumber → (TEPINV device key, TEPINV vitals data)
+    # Key format: TEPINV--{partno}--{serial}  (TEDAPI / PW3)
+    #         or: TEPINV--{serial}              (local API / older PW)
+    # rsplit on "--" with maxsplit=1 extracts the serial from both formats.
+    tepinv_map: dict = {}
     for device, d in vitals.items():
-        if device.startswith("TEPINV"):
-            # PW freq
-            fcv[f"PW{idx}_name"] = device
-            fcv[f"PW{idx}_PINV_Fout"] = d.get("PINV_Fout")
-            fcv[f"PW{idx}_PINV_VSplit1"] = d.get("PINV_VSplit1")
-            fcv[f"PW{idx}_PINV_VSplit2"] = d.get("PINV_VSplit2")
-            idx += 1
+        if device.startswith("TEPINV--"):
+            serial = device.rsplit("--", 1)[1]
+            tepinv_map[serial] = (device, d)
+
+    # --- Determine authoritative ordering of Powerwalls ---
+    # Use tedapi_config (fetched from gateway config.json) as the authoritative source.
+    # In TEDAPI full mode (WiFi only), vitals and system_status only cover the primary
+    # Powerwall because the follower's TEDAPI endpoint is unreachable without v1r/WiFi.
+    # config.json is served by the primary and lists all registered units including followers.
+    pw_serials: list = []
+    config_part_map: dict = {}  # serial → part number (from VIN field)
+
+    tedapi_config = status.data.tedapi_config
+    if isinstance(tedapi_config, dict):
+        for cb in (tedapi_config.get("battery_blocks") or []):
+            vin = cb.get("vin", "")
+            if "--" in vin:
+                part, serial = vin.rsplit("--", 1)
+                if serial and serial not in pw_serials:
+                    pw_serials.append(serial)
+                    config_part_map[serial] = part
+
+    # Fall back to system_status ordering (non-TEDAPI modes, or when config unavailable)
+    if not pw_serials:
+        for block in (system_status.get("battery_blocks") or []):
+            serial = block.get("PackageSerialNumber")
+            if serial and serial not in pw_serials:
+                pw_serials.append(serial)
+
+    # Last resort: derive from vitals TEPINV ordering (tepinv_map already keyed by serial)
+    if not pw_serials:
+        pw_serials = list(tepinv_map.keys())
+
+    # --- Populate per-Powerwall fields ---
+    for idx, serial in enumerate(pw_serials, 1):
+        block = ss_block_map.get(serial, {})
+        tepinv_device, tepinv_data = tepinv_map.get(serial, (None, {}))
+
+        fcv[f"PW{idx}_name"] = tepinv_device
+        # PINV frequency/voltage from vitals (preferred); fall back to system_status f_out
+        fcv[f"PW{idx}_PINV_Fout"] = (
+            tepinv_data.get("PINV_Fout") if tepinv_data else None
+        ) or block.get("f_out")
+        fcv[f"PW{idx}_PINV_VSplit1"] = tepinv_data.get("PINV_VSplit1") if tepinv_data else None
+        fcv[f"PW{idx}_PINV_VSplit2"] = tepinv_data.get("PINV_VSplit2") if tepinv_data else None
+        fcv[f"PW{idx}_PackagePartNumber"] = block.get("PackagePartNumber") or config_part_map.get(serial)
+        fcv[f"PW{idx}_PackageSerialNumber"] = serial
+        fcv[f"PW{idx}_p_out"] = block.get("p_out")
+        fcv[f"PW{idx}_q_out"] = block.get("q_out")
+        fcv[f"PW{idx}_v_out"] = block.get("v_out")
+        fcv[f"PW{idx}_f_out"] = block.get("f_out")
+        fcv[f"PW{idx}_i_out"] = block.get("i_out")
+
+    # ISLAND and METER metrics from Backup Gateway (TESYNC) or Backup Switch (TEMSA)
+    for device, d in vitals.items():
         if device.startswith("TESYNC") or device.startswith("TEMSA"):
-            # Island and Meter Metrics from Backup Gateway or Backup Switch
             for i, value in d.items():
                 if i.startswith("ISLAND") or i.startswith("METER"):
                     fcv[i] = value

--- a/app/config.py
+++ b/app/config.py
@@ -176,7 +176,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.3.3"
+SERVER_VERSION = "0.3.4"
 
 
 class GatewayConfig(BaseSettings):

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -284,7 +284,7 @@ class GatewayManager:
                         "To see all Powerwalls, either: "
                         "(a) set PW_WIFI_HOST=<gateway-ip> to enable WiFi fallback "
                         "for follower queries while keeping v1r, or "
-                        "(b) remove PW_RSA_KEY_PATH to use TEDAPI full mode.",
+                        "(b) remove PW_RSA_KEY_PATH to use TEDAPI WiFi mode.",
                         config.id,
                     )
 

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -96,6 +96,7 @@ class GatewayManager:
         self._pending_configs: Dict[
             str, GatewayConfig
         ] = {}  # Gateways waiting for lazy initialization
+        self._preserve_stale_count: Dict[str, int] = {}  # Multi-PW snapshot preservation staleness tracker
 
         # Dedicated thread pool for blocking pypowerwall operations
         # Will be sized during initialize() based on gateway count
@@ -131,6 +132,10 @@ class GatewayManager:
         battery_blocks = system_status.get("battery_blocks") or []
         return len(battery_blocks) if isinstance(battery_blocks, list) else 0
 
+    # Max consecutive polls a preserved snapshot is promoted before letting
+    # partial data through.  Prevents stale follower data from living forever.
+    _PRESERVE_STALENESS_CAP = 3
+
     def _preserve_complete_multi_pw_snapshot(
         self, gateway_id: str, data: PowerwallData
     ) -> PowerwallData:
@@ -139,17 +144,45 @@ class GatewayManager:
         TEDAPI multi-PW data is synthesized in pypowerwall from follower vitals.
         If a single poll cycle drops follower data, the server can otherwise cache a
         one-PW snapshot even though the gateway config still reports multiple blocks.
+
+        The guard is capped at ``_PRESERVE_STALENESS_CAP`` consecutive polls — after
+        that, the partial data passes through so downstream consumers see reality.
         """
         previous = self._last_successful_data.get(gateway_id)
         if not previous:
             return data
 
-        expected_blocks = max(
-            self._expected_battery_block_count(data),
-            self._expected_battery_block_count(previous),
-        )
+        current_config_count = self._expected_battery_block_count(data)
+        previous_config_count = self._expected_battery_block_count(previous)
+
+        # Trust the current TEDAPI config when it is present and non-zero.
+        # Only fall back to the previous (larger) count when the current config
+        # is missing — that indicates a transient read failure, not a legitimate
+        # transition from multi-PW to single-PW.
+        if current_config_count > 0:
+            expected_blocks = current_config_count
+        else:
+            expected_blocks = previous_config_count
+
         if expected_blocks < 2:
+            # Not a multi-PW system (or no longer one) — reset staleness counter.
+            self._preserve_stale_count.pop(gateway_id, None)
             return data
+
+        # --- Staleness cap ---
+        stale_key = gateway_id
+        stale_count = self._preserve_stale_count.get(stale_key, 0)
+        if stale_count >= self._PRESERVE_STALENESS_CAP:
+            logger.warning(
+                "Preservation guard for %s hit staleness cap (%d polls) — "
+                "letting partial data through",
+                gateway_id,
+                self._PRESERVE_STALENESS_CAP,
+            )
+            self._preserve_stale_count.pop(stale_key, None)
+            return data
+
+        preserved_any = False
 
         current_vitals_count = self._count_tepinv_devices(data.vitals)
         previous_vitals_count = self._count_tepinv_devices(previous.vitals)
@@ -161,27 +194,41 @@ class GatewayManager:
             and previous_vitals_count >= expected_blocks
         ):
             logger.warning(
-                "Preserving prior complete vitals snapshot for %s: expected %d TEPINV blocks, got %d in current poll",
+                "Preserving prior complete vitals snapshot for %s: "
+                "expected %d TEPINV blocks, got %d in current poll (stale %d/%d)",
                 gateway_id,
                 expected_blocks,
                 current_vitals_count,
+                stale_count + 1,
+                self._PRESERVE_STALENESS_CAP,
             )
             data.vitals = deepcopy(previous.vitals)
+            preserved_any = True
 
         if (
             current_status_count < expected_blocks
             and previous_status_count >= expected_blocks
         ):
             logger.warning(
-                "Preserving prior complete system_status snapshot for %s: expected %d battery blocks, got %d in current poll",
+                "Preserving prior complete system_status snapshot for %s: "
+                "expected %d battery blocks, got %d in current poll (stale %d/%d)",
                 gateway_id,
                 expected_blocks,
                 current_status_count,
+                stale_count + 1,
+                self._PRESERVE_STALENESS_CAP,
             )
             data.system_status = deepcopy(previous.system_status)
+            preserved_any = True
 
         if not data.tedapi_config and previous.tedapi_config:
             data.tedapi_config = deepcopy(previous.tedapi_config)
+
+        if preserved_any:
+            self._preserve_stale_count[stale_key] = stale_count + 1
+        else:
+            # Current poll was complete — reset staleness.
+            self._preserve_stale_count.pop(stale_key, None)
 
         return data
 

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -62,6 +62,7 @@ Performance:
 import asyncio
 import json
 import logging
+from copy import deepcopy
 from typing import Any, Dict, List, Optional
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor
@@ -106,6 +107,83 @@ class GatewayManager:
         # alongside a TEDAPI gateway. This enables hybrid operation:
         # TEDAPI for fast local reads, cloud for control writes.
         self._cloud_control: Optional[pypowerwall.Powerwall] = None
+
+    @staticmethod
+    def _expected_battery_block_count(data: Optional[PowerwallData]) -> int:
+        """Return expected battery block count from cached TEDAPI config when available."""
+        if not data or not isinstance(data.tedapi_config, dict):
+            return 0
+        battery_blocks = data.tedapi_config.get("battery_blocks") or []
+        return len(battery_blocks) if isinstance(battery_blocks, list) else 0
+
+    @staticmethod
+    def _count_tepinv_devices(vitals: Optional[Dict[str, Any]]) -> int:
+        """Count Powerwall inverter entries in vitals payload."""
+        if not isinstance(vitals, dict):
+            return 0
+        return sum(1 for key in vitals if key.startswith("TEPINV--"))
+
+    @staticmethod
+    def _count_system_status_blocks(system_status: Optional[Dict[str, Any]]) -> int:
+        """Count battery blocks in cached system status payload."""
+        if not isinstance(system_status, dict):
+            return 0
+        battery_blocks = system_status.get("battery_blocks") or []
+        return len(battery_blocks) if isinstance(battery_blocks, list) else 0
+
+    def _preserve_complete_multi_pw_snapshot(
+        self, gateway_id: str, data: PowerwallData
+    ) -> PowerwallData:
+        """Avoid downgrading a complete multi-PW TEDAPI snapshot with a partial one.
+
+        TEDAPI multi-PW data is synthesized in pypowerwall from follower vitals.
+        If a single poll cycle drops follower data, the server can otherwise cache a
+        one-PW snapshot even though the gateway config still reports multiple blocks.
+        """
+        previous = self._last_successful_data.get(gateway_id)
+        if not previous:
+            return data
+
+        expected_blocks = max(
+            self._expected_battery_block_count(data),
+            self._expected_battery_block_count(previous),
+        )
+        if expected_blocks < 2:
+            return data
+
+        current_vitals_count = self._count_tepinv_devices(data.vitals)
+        previous_vitals_count = self._count_tepinv_devices(previous.vitals)
+        current_status_count = self._count_system_status_blocks(data.system_status)
+        previous_status_count = self._count_system_status_blocks(previous.system_status)
+
+        if (
+            current_vitals_count < expected_blocks
+            and previous_vitals_count >= expected_blocks
+        ):
+            logger.warning(
+                "Preserving prior complete vitals snapshot for %s: expected %d TEPINV blocks, got %d in current poll",
+                gateway_id,
+                expected_blocks,
+                current_vitals_count,
+            )
+            data.vitals = deepcopy(previous.vitals)
+
+        if (
+            current_status_count < expected_blocks
+            and previous_status_count >= expected_blocks
+        ):
+            logger.warning(
+                "Preserving prior complete system_status snapshot for %s: expected %d battery blocks, got %d in current poll",
+                gateway_id,
+                expected_blocks,
+                current_status_count,
+            )
+            data.system_status = deepcopy(previous.system_status)
+
+        if not data.tedapi_config and previous.tedapi_config:
+            data.tedapi_config = deepcopy(previous.tedapi_config)
+
+        return data
 
     async def initialize(
         self, gateway_configs: List[GatewayConfig], poll_interval: int = 5
@@ -687,6 +765,10 @@ class GatewayManager:
                         pass
             except (asyncio.TimeoutError, Exception) as e:
                 logger.debug(f"Powerwalls not available for {gateway_id}: {e}")
+
+            # Guard against partial TEDAPI follower snapshots replacing a complete
+            # multi-Powerwall view for a single poll cycle.
+            data = self._preserve_complete_multi_pw_snapshot(gateway_id, data)
 
             # Update cache
             gateway = self.gateways[gateway_id]

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -272,6 +272,22 @@ class GatewayManager:
                     )
                     continue
 
+                # Warn when both gw_pwd and rsa_key_path are set alongside host.
+                # pypowerwall selects TEDAPI v1r (RSA auth) in this case, which
+                # limits follower Powerwall data to primary-only unless a wifi_host
+                # is also provided for the follower WiFi fallback path.
+                if config.host and config.gw_pwd and config.rsa_key_path and not config.wifi_host:
+                    logger.warning(
+                        "Gateway %s: PW_HOST + PW_GW_PWD + PW_RSA_KEY_PATH are "
+                        "all set — TEDAPI v1r mode is active but follower "
+                        "Powerwall data will be limited to the primary unit only. "
+                        "To see all Powerwalls, either: "
+                        "(a) set PW_WIFI_HOST=<gateway-ip> to enable WiFi fallback "
+                        "for follower queries while keeping v1r, or "
+                        "(b) remove PW_RSA_KEY_PATH to use TEDAPI full mode.",
+                        config.id,
+                    )
+
                 # Auto-enable cloud_mode if email is set but no host
                 if config.email and not config.host:
                     config.cloud_mode = True
@@ -506,11 +522,16 @@ class GatewayManager:
 
                     # Try to get site_id for cloud mode gateways
                     gateway = self.gateways[gateway_id]
-                    mode_label = (
-                        "FleetAPI"
-                        if gateway.fleetapi
-                        else ("Cloud" if gateway.cloud_mode else "TEDAPI")
-                    )
+                    if gateway.fleetapi:
+                        mode_label = "FleetAPI"
+                    elif gateway.cloud_mode:
+                        mode_label = "Cloud"
+                    elif config.rsa_key_path and config.wifi_host:
+                        mode_label = "TEDAPI v1r + WiFi"
+                    elif config.rsa_key_path:
+                        mode_label = "TEDAPI v1r"
+                    else:
+                        mode_label = "TEDAPI WiFi"
 
                     if gateway.cloud_mode or gateway.fleetapi:
                         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.3.3"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.3.4"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.12
 uvicorn[standard]==0.29.0
 pydantic==2.11.3
 pydantic-settings==2.9.1
-pypowerwall==0.15.7
+pypowerwall==0.15.10
 aiohttp==3.12.15
 websockets==13.1
 psutil==6.1.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def mock_pypowerwall():
             "POD_nom_energy_to_be_charged": 1500,
             "POD_nom_full_pack_energy": 13500
         },
-        "TEPINV--1234": {
+        "TEPINV--1234567-00-A--TG1234567890AB": {
             "PINV_Fout": 60.0,
             "PINV_VSplit1": 120.0,
             "PINV_VSplit2": 120.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,8 @@ def mock_gateway_manager(monkeypatch, mock_pypowerwall):
     gateway_manager.gateways.clear()
     gateway_manager.connections.clear()
     gateway_manager.cache.clear()
+    gateway_manager._last_successful_data.clear()
+    gateway_manager._preserve_stale_count.clear()
     
     # Mock the Powerwall constructor
     def mock_powerwall_init(*args, **kwargs):

--- a/tests/test_api_legacy.py
+++ b/tests/test_api_legacy.py
@@ -141,7 +141,7 @@ def test_freq_endpoint(client, connected_gateway):
     assert data["PW1_PackageSerialNumber"] == "TG1234567890AB"
     
     # Verify values from vitals TEPINV
-    assert data["PW1_name"] == "TEPINV--1234"
+    assert data["PW1_name"] == "TEPINV--1234567-00-A--TG1234567890AB"
     assert data["PW1_PINV_Fout"] == 60.0
     assert data["PW1_PINV_VSplit1"] == 120.0
     assert data["PW1_PINV_VSplit2"] == 120.0
@@ -556,7 +556,7 @@ def test_pw_vitals(client, connected_gateway):
     assert response.status_code == 200
     data = response.json()
     assert "TEPOD--1234" in data
-    assert "TEPINV--1234" in data
+    assert "TEPINV--1234567-00-A--TG1234567890AB" in data
 
 
 def test_pw_temps(client, connected_gateway):

--- a/tests/test_gateway_manager.py
+++ b/tests/test_gateway_manager.py
@@ -306,6 +306,191 @@ async def test_rsa_key_path_passed_to_powerwall_constructor(monkeypatch, mock_py
     assert call_kwargs.get("rsa_key_path") == "/keys/tedapi_rsa_private.pem"
     assert call_kwargs.get("host") == "192.168.91.1"
 # ---------------------------------------------------------------------------
+# Multi-PW snapshot guard — config convergence & staleness cap
+# ---------------------------------------------------------------------------
+
+
+def test_preserve_guard_trusts_current_config_over_stale_previous(
+    mock_gateway_manager,
+):
+    """When current TEDAPI config says 1 block but previous says 2, trust current.
+
+    This prevents the max() latch problem: a gateway that legitimately transitions
+    from multi-PW to single-PW should converge immediately, not be stuck preserving
+    old multi-PW snapshots.
+    """
+    from app.models.gateway import PowerwallData
+
+    gateway_id = "config-convergence-test"
+    previous = PowerwallData(
+        vitals={
+            "TEPINV--leader": {"PINV_Fout": 60.0},
+            "TEPINV--follower": {"PINV_Fout": 60.1},
+        },
+        system_status={
+            "battery_blocks": [
+                {"PackageSerialNumber": "PW1"},
+                {"PackageSerialNumber": "PW2"},
+            ]
+        },
+        tedapi_config={"battery_blocks": [{"type": "PW3"}, {"type": "PW3Follower"}]},
+    )
+    current = PowerwallData(
+        vitals={"TEPINV--leader": {"PINV_Fout": 59.9}},
+        system_status={"battery_blocks": [{"PackageSerialNumber": "PW1-new"}]},
+        tedapi_config={"battery_blocks": [{"type": "Powerwall3"}]},  # now single-PW
+    )
+    mock_gateway_manager._last_successful_data[gateway_id] = previous
+
+    result = mock_gateway_manager._preserve_complete_multi_pw_snapshot(
+        gateway_id, current
+    )
+
+    # Current config says 1 block — no preservation should occur
+    assert result.vitals["TEPINV--leader"]["PINV_Fout"] == 59.9
+    assert len(result.system_status["battery_blocks"]) == 1
+    assert result.system_status["battery_blocks"][0]["PackageSerialNumber"] == "PW1-new"
+
+
+def test_preserve_guard_uses_previous_config_when_current_is_missing(
+    mock_gateway_manager,
+):
+    """When current TEDAPI config is empty, fall back to previous count."""
+    from app.models.gateway import PowerwallData
+
+    gateway_id = "missing-config-test"
+    previous = PowerwallData(
+        vitals={
+            "TEPINV--leader": {"PINV_Fout": 60.0},
+            "TEPINV--follower": {"PINV_Fout": 60.1},
+        },
+        system_status={
+            "battery_blocks": [
+                {"PackageSerialNumber": "PW1"},
+                {"PackageSerialNumber": "PW2"},
+            ]
+        },
+        tedapi_config={"battery_blocks": [{"type": "PW3"}, {"type": "PW3Follower"}]},
+    )
+    current = PowerwallData(
+        vitals={"TEPINV--leader": {"PINV_Fout": 59.9}},
+        system_status={"battery_blocks": [{"PackageSerialNumber": "PW1-new"}]},
+        tedapi_config=None,  # transient read failure
+    )
+    mock_gateway_manager._last_successful_data[gateway_id] = previous
+
+    result = mock_gateway_manager._preserve_complete_multi_pw_snapshot(
+        gateway_id, current
+    )
+
+    # Should preserve previous multi-PW snapshot (previous config used as fallback)
+    assert len(result.vitals) == 2
+    assert len(result.system_status["battery_blocks"]) == 2
+
+
+def test_preserve_guard_staleness_cap_lets_partial_data_through(
+    mock_gateway_manager,
+):
+    """After _PRESERVE_STALENESS_CAP consecutive preserved polls, partial data passes."""
+    from app.models.gateway import PowerwallData
+
+    gateway_id = "stale-cap-test"
+    cap = mock_gateway_manager._PRESERVE_STALENESS_CAP
+
+    previous = PowerwallData(
+        vitals={
+            "TEPINV--leader": {"PINV_Fout": 60.0},
+            "TEPINV--follower": {"PINV_Fout": 60.1},
+        },
+        system_status={
+            "battery_blocks": [
+                {"PackageSerialNumber": "PW1"},
+                {"PackageSerialNumber": "PW2"},
+            ]
+        },
+        tedapi_config={"battery_blocks": [{"type": "PW3"}, {"type": "PW3Follower"}]},
+    )
+
+    # Simulate (cap) preserved polls to fill the staleness counter
+    for i in range(cap):
+        mock_gateway_manager._preserve_stale_count[gateway_id] = i
+        mock_gateway_manager._last_successful_data[gateway_id] = previous
+        current = PowerwallData(
+            vitals={"TEPINV--leader": {"PINV_Fout": float(59 + i)}},
+            system_status={"battery_blocks": [{"PackageSerialNumber": "PW1"}]},
+            tedapi_config={"battery_blocks": [{"type": "PW3"}, {"type": "PW3Follower"}]},
+        )
+        result = mock_gateway_manager._preserve_complete_multi_pw_snapshot(
+            gateway_id, current
+        )
+        # Should still be preserved
+        assert len(result.vitals) == 2, f"Failed at iteration {i}"
+
+    # Now the cap-th poll — staleness counter should be at cap-1, this push hits cap
+    mock_gateway_manager._last_successful_data[gateway_id] = previous
+    current = PowerwallData(
+        vitals={"TEPINV--leader": {"PINV_Fout": 55.0}},
+        system_status={"battery_blocks": [{"PackageSerialNumber": "PW1"}]},
+        tedapi_config={"battery_blocks": [{"type": "PW3"}, {"type": "PW3Follower"}]},
+    )
+    result = mock_gateway_manager._preserve_complete_multi_pw_snapshot(
+        gateway_id, current
+    )
+
+    # Cap reached — partial data should pass through
+    assert len(result.vitals) == 1
+    assert result.vitals["TEPINV--leader"]["PINV_Fout"] == 55.0
+    assert len(result.system_status["battery_blocks"]) == 1
+
+
+def test_preserve_guard_resets_staleness_on_complete_poll(
+    mock_gateway_manager,
+):
+    """A complete poll resets the staleness counter to zero."""
+    from app.models.gateway import PowerwallData
+
+    gateway_id = "reset-stale-test"
+    mock_gateway_manager._preserve_stale_count[gateway_id] = 2
+
+    previous = PowerwallData(
+        vitals={
+            "TEPINV--leader": {"PINV_Fout": 60.0},
+            "TEPINV--follower": {"PINV_Fout": 60.1},
+        },
+        system_status={
+            "battery_blocks": [
+                {"PackageSerialNumber": "PW1"},
+                {"PackageSerialNumber": "PW2"},
+            ]
+        },
+        tedapi_config={"battery_blocks": [{"type": "PW3"}, {"type": "PW3Follower"}]},
+    )
+    # Current poll has complete data (2 blocks)
+    current = PowerwallData(
+        vitals={
+            "TEPINV--leader": {"PINV_Fout": 59.9},
+            "TEPINV--follower": {"PINV_Fout": 60.0},
+        },
+        system_status={
+            "battery_blocks": [
+                {"PackageSerialNumber": "PW1-new"},
+                {"PackageSerialNumber": "PW2-new"},
+            ]
+        },
+        tedapi_config={"battery_blocks": [{"type": "PW3"}, {"type": "PW3Follower"}]},
+    )
+    mock_gateway_manager._last_successful_data[gateway_id] = previous
+
+    result = mock_gateway_manager._preserve_complete_multi_pw_snapshot(
+        gateway_id, current
+    )
+
+    # No preservation needed — current data is complete
+    assert result.vitals["TEPINV--leader"]["PINV_Fout"] == 59.9
+    assert gateway_id not in mock_gateway_manager._preserve_stale_count
+
+
+# ---------------------------------------------------------------------------
 # cloud_control() method tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_gateway_manager.py
+++ b/tests/test_gateway_manager.py
@@ -129,10 +129,11 @@ async def test_polling_with_missing_optional_data(mock_gateway_manager, mock_pyp
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("expected_blocks", [2, 10])
 async def test_polling_preserves_complete_multi_pw_snapshot_on_partial_tedapi_drop(
-    mock_gateway_manager, mock_pypowerwall
+    mock_gateway_manager, mock_pypowerwall, expected_blocks
 ):
-    """Keep the richer multi-PW TEDAPI snapshot when one poll transiently drops a follower."""
+    """Keep the richer multi-PW TEDAPI snapshot when one poll transiently drops followers."""
     from app.models.gateway import Gateway, GatewayStatus, PowerwallData
 
     gateway = Gateway(
@@ -143,19 +144,22 @@ async def test_polling_preserves_complete_multi_pw_snapshot_on_partial_tedapi_dr
     )
 
     previous_vitals = {
-        "TEPINV--leader": {"PINV_Fout": 60.0},
-        "TEPINV--follower": {"PINV_Fout": 60.1},
+        f"TEPINV--pw{idx}": {"PINV_Fout": 60.0 + (idx * 0.01)}
+        for idx in range(1, expected_blocks + 1)
     }
     previous_system_status = {
         "battery_blocks": [
-            {"PackageSerialNumber": "PW1", "f_out": 60.0},
-            {"PackageSerialNumber": "PW2", "f_out": 60.1},
+            {
+                "PackageSerialNumber": f"PW{idx}",
+                "f_out": 60.0 + (idx * 0.01),
+            }
+            for idx in range(1, expected_blocks + 1)
         ]
     }
     previous_tedapi_config = {
         "battery_blocks": [
-            {"type": "Powerwall3"},
-            {"type": "Powerwall3Follower"},
+            {"type": "Powerwall3" if idx == 1 else "Powerwall3Follower"}
+            for idx in range(1, expected_blocks + 1)
         ]
     }
 
@@ -175,11 +179,11 @@ async def test_polling_preserves_complete_multi_pw_snapshot_on_partial_tedapi_dr
     )
 
     mock_pypowerwall.vitals.return_value = {
-        "TEPINV--leader": {"PINV_Fout": 60.0},
+        "TEPINV--pw1": {"PINV_Fout": 60.01},
     }
     mock_pypowerwall.system_status.return_value = {
         "battery_blocks": [
-            {"PackageSerialNumber": "PW1", "f_out": 60.0},
+            {"PackageSerialNumber": "PW1", "f_out": 60.01},
         ]
     }
     mock_pypowerwall.tedapi.get_config.return_value = previous_tedapi_config
@@ -188,15 +192,16 @@ async def test_polling_preserves_complete_multi_pw_snapshot_on_partial_tedapi_dr
 
     status = mock_gateway_manager.get_gateway("multi-pw-test")
     assert status.online is True
-    assert len(status.data.tedapi_config["battery_blocks"]) == 2
+    assert len(status.data.tedapi_config["battery_blocks"]) == expected_blocks
     assert list(status.data.vitals.keys()) == list(previous_vitals.keys())
     assert (
         len(status.data.system_status["battery_blocks"])
         == len(previous_system_status["battery_blocks"])
-        == 2
+        == expected_blocks
     )
     assert (
-        status.data.system_status["battery_blocks"][1]["PackageSerialNumber"] == "PW2"
+        status.data.system_status["battery_blocks"][-1]["PackageSerialNumber"]
+        == f"PW{expected_blocks}"
     )
 
 

--- a/tests/test_gateway_manager.py
+++ b/tests/test_gateway_manager.py
@@ -128,6 +128,105 @@ async def test_polling_with_missing_optional_data(mock_gateway_manager, mock_pyp
     assert status.data.strings is None
 
 
+@pytest.mark.asyncio
+async def test_polling_preserves_complete_multi_pw_snapshot_on_partial_tedapi_drop(
+    mock_gateway_manager, mock_pypowerwall
+):
+    """Keep the richer multi-PW TEDAPI snapshot when one poll transiently drops a follower."""
+    from app.models.gateway import Gateway, GatewayStatus, PowerwallData
+
+    gateway = Gateway(
+        id="multi-pw-test",
+        name="Multi PW Test",
+        host="192.168.1.100",
+        gw_pwd="password123",
+    )
+
+    previous_vitals = {
+        "TEPINV--leader": {"PINV_Fout": 60.0},
+        "TEPINV--follower": {"PINV_Fout": 60.1},
+    }
+    previous_system_status = {
+        "battery_blocks": [
+            {"PackageSerialNumber": "PW1", "f_out": 60.0},
+            {"PackageSerialNumber": "PW2", "f_out": 60.1},
+        ]
+    }
+    previous_tedapi_config = {
+        "battery_blocks": [
+            {"type": "Powerwall3"},
+            {"type": "Powerwall3Follower"},
+        ]
+    }
+
+    mock_gateway_manager.gateways["multi-pw-test"] = gateway
+    mock_gateway_manager.connections["multi-pw-test"] = mock_pypowerwall
+    mock_gateway_manager.cache["multi-pw-test"] = GatewayStatus(
+        gateway=gateway, online=False
+    )
+    mock_gateway_manager._last_successful_data["multi-pw-test"] = PowerwallData(
+        aggregates=mock_pypowerwall.poll.return_value,
+        soe_raw=85.5,
+        soe=raw_to_tesla_battery_percent(85.5),
+        vitals=previous_vitals,
+        system_status=previous_system_status,
+        tedapi_config=previous_tedapi_config,
+        timestamp=1111.0,
+    )
+
+    mock_pypowerwall.vitals.return_value = {
+        "TEPINV--leader": {"PINV_Fout": 60.0},
+    }
+    mock_pypowerwall.system_status.return_value = {
+        "battery_blocks": [
+            {"PackageSerialNumber": "PW1", "f_out": 60.0},
+        ]
+    }
+    mock_pypowerwall.tedapi.get_config.return_value = previous_tedapi_config
+
+    await mock_gateway_manager._poll_gateway("multi-pw-test")
+
+    status = mock_gateway_manager.get_gateway("multi-pw-test")
+    assert status.online is True
+    assert len(status.data.tedapi_config["battery_blocks"]) == 2
+    assert list(status.data.vitals.keys()) == list(previous_vitals.keys())
+    assert (
+        len(status.data.system_status["battery_blocks"])
+        == len(previous_system_status["battery_blocks"])
+        == 2
+    )
+    assert (
+        status.data.system_status["battery_blocks"][1]["PackageSerialNumber"] == "PW2"
+    )
+
+
+def test_preserve_complete_multi_pw_snapshot_ignores_single_pw_system(
+    mock_gateway_manager,
+):
+    """Single-PW systems should not trigger the multi-PW preservation guard."""
+    from app.models.gateway import PowerwallData
+
+    gateway_id = "single-pw-test"
+    previous = PowerwallData(
+        vitals={"TEPINV--leader": {"PINV_Fout": 60.0}},
+        system_status={"battery_blocks": [{"PackageSerialNumber": "PW1"}]},
+        tedapi_config={"battery_blocks": [{"type": "Powerwall3"}]},
+    )
+    current = PowerwallData(
+        vitals={"TEPINV--leader": {"PINV_Fout": 59.9}},
+        system_status={"battery_blocks": [{"PackageSerialNumber": "PW1-new"}]},
+        tedapi_config={"battery_blocks": [{"type": "Powerwall3"}]},
+    )
+    mock_gateway_manager._last_successful_data[gateway_id] = previous
+
+    result = mock_gateway_manager._preserve_complete_multi_pw_snapshot(
+        gateway_id, current
+    )
+
+    assert result.vitals["TEPINV--leader"]["PINV_Fout"] == 59.9
+    assert result.system_status["battery_blocks"][0]["PackageSerialNumber"] == "PW1-new"
+
+
 def test_gateway_rsa_key_configured():
     """Test rsa_key_configured flag and path disclosure prevention."""
     from app.models.gateway import Gateway


### PR DESCRIPTION
## Summary
- preserve the last complete multi-Powerwall TEDAPI snapshot when a single poll transiently drops follower vitals or battery blocks
- keep the richer cached `vitals` and `system_status` payloads when TEDAPI config still expects multiple battery blocks
- add regression tests for the transient follower-drop case and a single-PW no-op case

## Testing
- `pytest -q tests/test_gateway_manager.py`
- `pytest -q tests/test_api_legacy.py -k freq`