### PR TITLE
feat(mqtt): Solar string topics + PW3 paired rollups

### DIFF
--- a/MQTT.md
+++ b/MQTT.md
@@ -169,7 +169,9 @@ For Powerwall 3 systems where inputs are physically paired, derived rollups are 
 | `pypowerwall/{gw}/strings/{AB,CD,EF}/power` | `721.50` | `W` (sum of both strings) |
 
 For multi-PW3 single-gateway setups (e.g. two PW3s on one gateway), the strings endpoint
-may return `A`–`F` *and* `A1`–`F1`. Paired rollups are generated per suffix automatically:
+may return `A`–`F` *and* `A1`–`F1`. Paired rollups are generated per suffix automatically.
+**Paired rollup topics are only published when both strings in the pair exist** — if only one
+string of a pair is present (e.g. A without B), no AB rollup is emitted.
 
 | Topic | Value | Unit |
 |-------|-------|------|

--- a/MQTT.md
+++ b/MQTT.md
@@ -147,6 +147,27 @@ Base path: `{MQTT_TOPIC_PREFIX}/{gateway_id}/`
 | `pypowerwall/{gw}/aggregates` | Full `/api/meters/aggregates` JSON |
 | `pypowerwall/{gw}/status` | `{"online": true, "soe": 85.3, "mode": "...", ...}` summary |
 
+### Solar string topics (per-string voltage, current, power)
+
+Individual string topics are published when string data is available from the gateway:
+
+| Topic | Value | Unit |
+|-------|-------|------|
+| `pypowerwall/{gw}/strings/{A-F}/voltage` | `240.50` | `V` |
+| `pypowerwall/{gw}/strings/{A-F}/current` | `1.50` | `A` |
+| `pypowerwall/{gw}/strings/{A-F}/power` | `360.75` | `W` |
+| `pypowerwall/{gw}/strings/{A-F}` | `{"Voltage": ..., "Current": ..., "Power": ...}` | JSON |
+
+### PW3 paired-string rollups (AB, CD, EF)
+
+For Powerwall 3 systems where inputs are physically paired, derived rollups are published:
+
+| Topic | Value | Unit |
+|-------|-------|------|
+| `pypowerwall/{gw}/strings/{AB,CD,EF}/voltage` | `240.50` | `V` (from first string in pair) |
+| `pypowerwall/{gw}/strings/{AB,CD,EF}/current` | `3.00` | `A` (sum of both strings) |
+| `pypowerwall/{gw}/strings/{AB,CD,EF}/power` | `721.50` | `W` (sum of both strings) |
+
 ### Availability topic (for HA)
 
 | Topic | Value |
@@ -455,5 +476,18 @@ pypowerwall/default/reserve          20.0
 pypowerwall/default/online           true
 pypowerwall/default/aggregates       {...}
 pypowerwall/default/status           {...}
+pypowerwall/default/strings/A/voltage   240.50
+pypowerwall/default/strings/A/current   1.50
+pypowerwall/default/strings/A/power     360.75
+pypowerwall/default/strings/A           {"Voltage": 240.5, "Current": 1.5, "Power": 360.75, ...}
+pypowerwall/default/strings/B/voltage   240.25
+pypowerwall/default/strings/B/current   1.25
+pypowerwall/default/strings/B/power     300.31
+pypowerwall/default/strings/B           {...}
+...
+pypowerwall/default/strings/AB/voltage  240.50
+pypowerwall/default/strings/AB/current  2.75
+pypowerwall/default/strings/AB/power    661.06
+...
 ```
 

--- a/MQTT.md
+++ b/MQTT.md
@@ -168,6 +168,15 @@ For Powerwall 3 systems where inputs are physically paired, derived rollups are 
 | `pypowerwall/{gw}/strings/{AB,CD,EF}/current` | `3.00` | `A` (sum of both strings) |
 | `pypowerwall/{gw}/strings/{AB,CD,EF}/power` | `721.50` | `W` (sum of both strings) |
 
+For multi-PW3 single-gateway setups (e.g. two PW3s on one gateway), the strings endpoint
+may return `A`–`F` *and* `A1`–`F1`. Paired rollups are generated per suffix automatically:
+
+| Topic | Value | Unit |
+|-------|-------|------|
+| `pypowerwall/{gw}/strings/AB1/voltage` | `310.00` | `V` |
+| `pypowerwall/{gw}/strings/AB1/current` | `0.40` | `A` |
+| `pypowerwall/{gw}/strings/AB1/power` | `124.00` | `W` |
+
 ### Availability topic (for HA)
 
 | Topic | Value |

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -309,7 +309,7 @@ class MqttPublisher:
                             sb = data.strings.get(b_key, {})
                             if not isinstance(sa, dict) or not isinstance(sb, dict):
                                 continue
-                            if not sa and not sb:
+                            if not sa or not sb:
                                 continue
                             pair_name = pair_name_base + suffix.upper()
                             p_prefix = f"{strings_prefix}/{pair_name}"

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -44,6 +44,15 @@ Topic layout
     {prefix}/{gateway_id}/aggregates      JSON   — full aggregates dict
     {prefix}/{gateway_id}/status          JSON   — summary dict
     {prefix}/{gateway_id}/availability    str    — "online" | "offline" (LWT)
+
+    {prefix}/{gateway_id}/strings/{A-F}/voltage   float — V
+    {prefix}/{gateway_id}/strings/{A-F}/current   float — A
+    {prefix}/{gateway_id}/strings/{A-F}/power     float — W
+    {prefix}/{gateway_id}/strings/{A-F}           JSON  — full string data
+
+    {prefix}/{gateway_id}/strings/{AB,CD,EF}/voltage  float — V (from first string in pair)
+    {prefix}/{gateway_id}/strings/{AB,CD,EF}/current  float — A (sum of pair)
+    {prefix}/{gateway_id}/strings/{AB,CD,EF}/power    float — W (sum of pair)
 """
 import asyncio
 import json
@@ -250,6 +259,72 @@ class MqttPublisher:
                         f"{prefix}/version", str(data.version), retain, qos
                     )
 
+                # Solar string topics (voltage, current, power per string)
+                if data.strings and isinstance(data.strings, dict):
+                    strings_prefix = f"{prefix}/strings"
+                    for string_id, string_data in data.strings.items():
+                        if not isinstance(string_data, dict):
+                            continue
+                        s_prefix = f"{strings_prefix}/{string_id}"
+                        for metric in ("Voltage", "Current", "Power"):
+                            val = string_data.get(metric)
+                            if val is not None:
+                                try:
+                                    await self._safe_publish(
+                                        f"{s_prefix}/{metric.lower()}",
+                                        f"{float(val):.2f}",
+                                        retain, qos,
+                                    )
+                                except (ValueError, TypeError):
+                                    pass
+                        # Full string JSON for consumers that want everything
+                        await self._safe_publish(
+                            s_prefix,
+                            json.dumps(string_data),
+                            retain, qos,
+                        )
+
+                    # Derived paired-string rollups for PW3 (AB, CD, EF)
+                    # PW3 physically pairs inputs A+B, C+D, E+F
+                    for pair_name, (a, b) in {
+                        "AB": ("A", "B"),
+                        "CD": ("C", "D"),
+                        "EF": ("E", "F"),
+                    }.items():
+                        sa = data.strings.get(a, {})
+                        sb = data.strings.get(b, {})
+                        if not isinstance(sa, dict) or not isinstance(sb, dict):
+                            continue
+                        # Only publish if at least one string in the pair exists
+                        if not sa and not sb:
+                            continue
+                        p_prefix = f"{strings_prefix}/{pair_name}"
+                        # Voltage: take the first string's value (identical for paired inputs)
+                        v_a = _safe_float(sa.get("Voltage"))
+                        if v_a is not None:
+                            await self._safe_publish(
+                                f"{p_prefix}/voltage",
+                                f"{v_a:.2f}", retain, qos,
+                            )
+                        # Current: sum of both strings
+                        c_a = _safe_float(sa.get("Current"))
+                        c_b = _safe_float(sb.get("Current"))
+                        if c_a is not None or c_b is not None:
+                            total_c = (c_a or 0.0) + (c_b or 0.0)
+                            await self._safe_publish(
+                                f"{p_prefix}/current",
+                                f"{total_c:.2f}", retain, qos,
+                            )
+                        # Power: sum of both strings
+                        p_a = _safe_float(sa.get("Power"))
+                        p_b = _safe_float(sb.get("Power"))
+                        if p_a is not None or p_b is not None:
+                            total_p = (p_a or 0.0) + (p_b or 0.0)
+                            await self._safe_publish(
+                                f"{p_prefix}/power",
+                                f"{total_p:.2f}", retain, qos,
+                            )
+
                 # Summary JSON topic
                 summary = {
                     "online": status.online,
@@ -411,6 +486,16 @@ class MqttPublisher:
 
         self._connected = False
         self._client = None
+
+
+def _safe_float(val) -> Optional[float]:
+    """Convert a value to float, returning None on failure."""
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None
 
 
 def _extract_power(aggregates: dict, key: str) -> Optional[float]:

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -53,6 +53,8 @@ Topic layout
     {prefix}/{gateway_id}/strings/{AB,CD,EF}/voltage  float — V (from first string in pair)
     {prefix}/{gateway_id}/strings/{AB,CD,EF}/current  float — A (sum of pair)
     {prefix}/{gateway_id}/strings/{AB,CD,EF}/power    float — W (sum of pair)
+
+    Multi-PW3 single-gateway: also AB1/CD1/EF1, AB2/CD2/EF2 etc.
 """
 import asyncio
 import json
@@ -284,46 +286,55 @@ class MqttPublisher:
                             retain, qos,
                         )
 
-                    # Derived paired-string rollups for PW3 (AB, CD, EF)
-                    # PW3 physically pairs inputs A+B, C+D, E+F
-                    for pair_name, (a, b) in {
-                        "AB": ("A", "B"),
-                        "CD": ("C", "D"),
-                        "EF": ("E", "F"),
-                    }.items():
-                        sa = data.strings.get(a, {})
-                        sb = data.strings.get(b, {})
-                        if not isinstance(sa, dict) or not isinstance(sb, dict):
-                            continue
-                        # Only publish if at least one string in the pair exists
-                        if not sa and not sb:
-                            continue
-                        p_prefix = f"{strings_prefix}/{pair_name}"
-                        # Voltage: take the first string's value (identical for paired inputs)
-                        v_a = _safe_float(sa.get("Voltage"))
-                        if v_a is not None:
-                            await self._safe_publish(
-                                f"{p_prefix}/voltage",
-                                f"{v_a:.2f}", retain, qos,
-                            )
-                        # Current: sum of both strings
-                        c_a = _safe_float(sa.get("Current"))
-                        c_b = _safe_float(sb.get("Current"))
-                        if c_a is not None or c_b is not None:
-                            total_c = (c_a or 0.0) + (c_b or 0.0)
-                            await self._safe_publish(
-                                f"{p_prefix}/current",
-                                f"{total_c:.2f}", retain, qos,
-                            )
-                        # Power: sum of both strings
-                        p_a = _safe_float(sa.get("Power"))
-                        p_b = _safe_float(sb.get("Power"))
-                        if p_a is not None or p_b is not None:
-                            total_p = (p_a or 0.0) + (p_b or 0.0)
-                            await self._safe_publish(
-                                f"{p_prefix}/power",
-                                f"{total_p:.2f}", retain, qos,
-                            )
+                    # Derived paired-string rollups for PW3
+                    # PW3 physically pairs inputs A+B, C+D, E+F.
+                    # Multi-PW3 single-gateway setups may also have A1-F1,
+                    # A2-F2, etc. — we detect suffixes and pair them too.
+                    pair_bases = [("A", "B"), ("C", "D"), ("E", "F")]
+                    # Collect unique suffixes ("" for A-F, "1" for A1-F1, ...)
+                    suffixes = set()
+                    for key in data.strings:
+                        if isinstance(key, str):
+                            base = key.rstrip("0123456789")
+                            suffix = key[len(base):]
+                            if base in ("A", "B", "C", "D", "E", "F"):
+                                suffixes.add(suffix)
+                    for suffix in sorted(suffixes):
+                        for (first, second), pair_name_base in zip(
+                            pair_bases, ("AB", "CD", "EF")
+                        ):
+                            a_key = first + suffix
+                            b_key = second + suffix
+                            sa = data.strings.get(a_key, {})
+                            sb = data.strings.get(b_key, {})
+                            if not isinstance(sa, dict) or not isinstance(sb, dict):
+                                continue
+                            if not sa and not sb:
+                                continue
+                            pair_name = pair_name_base + suffix.upper()
+                            p_prefix = f"{strings_prefix}/{pair_name}"
+                            v_a = _safe_float(sa.get("Voltage"))
+                            if v_a is not None:
+                                await self._safe_publish(
+                                    f"{p_prefix}/voltage",
+                                    f"{v_a:.2f}", retain, qos,
+                                )
+                            c_a = _safe_float(sa.get("Current"))
+                            c_b = _safe_float(sb.get("Current"))
+                            if c_a is not None or c_b is not None:
+                                total_c = (c_a or 0.0) + (c_b or 0.0)
+                                await self._safe_publish(
+                                    f"{p_prefix}/current",
+                                    f"{total_c:.2f}", retain, qos,
+                                )
+                            p_a = _safe_float(sa.get("Power"))
+                            p_b = _safe_float(sb.get("Power"))
+                            if p_a is not None or p_b is not None:
+                                total_p = (p_a or 0.0) + (p_b or 0.0)
+                                await self._safe_publish(
+                                    f"{p_prefix}/power",
+                                    f"{total_p:.2f}", retain, qos,
+                                )
 
                 # Summary JSON topic
                 summary = {

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -372,3 +372,139 @@ class TestMqttFireAndForget:
         # Called via create_task in gateway_manager; must not raise here
         task = asyncio.create_task(pub.publish_gateway("test-gw", status))
         await task  # no exception expected
+
+
+class TestMqttStringTopics:
+    """Verify solar string MQTT topics are published correctly."""
+
+    def _make_publisher(self, monkeypatch) -> MqttPublisher:
+        monkeypatch.setenv("MQTT_HOST", "localhost")
+        monkeypatch.setenv("MQTT_PORT", "1883")
+        monkeypatch.setenv("MQTT_TOPIC_PREFIX", "pypowerwall")
+        monkeypatch.setenv("MQTT_QOS", "1")
+        monkeypatch.setenv("MQTT_RETAIN", "true")
+        import importlib
+        import app.config as cfg_module
+        importlib.reload(cfg_module)
+        pub = MqttPublisher()
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+        return pub
+
+    def _make_status_with_strings(self, strings: dict, **kwargs) -> GatewayStatus:
+        gateway = Gateway(
+            id="test-gw", name="Test", host="192.168.91.1", gw_pwd="test", online=True
+        )
+        data = PowerwallData(
+            soe=80.0,
+            soe_raw=82.0,
+            aggregates={
+                "solar": {"instant_power": 5000.0},
+                "site": {"instant_power": 0.0},
+                "load": {"instant_power": 5000.0},
+                "battery": {"instant_power": 0.0},
+            },
+            grid_status="UP",
+            mode="self_consumption",
+            reserve=20.0,
+            version="23.44.0",
+            strings=strings,
+            timestamp=1_000_000.0,
+        )
+        return GatewayStatus(gateway=gateway, data=data, online=True, last_updated=1_000_000.0)
+
+    @pytest.mark.asyncio
+    async def test_per_string_topics_published(self, monkeypatch):
+        """Individual string A-F voltage/current/power topics are published."""
+        pub = self._make_publisher(monkeypatch)
+        status = self._make_status_with_strings({
+            "A": {"Voltage": 240.5, "Current": 1.5, "Power": 360.75, "State": "PV_Active"},
+            "B": {"Voltage": 238.0, "Current": 1.2, "Power": 285.6, "State": "PV_Active"},
+        })
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in pub._client.publish.call_args_list}
+
+        assert "pypowerwall/test-gw/strings/A/voltage" in published
+        assert published["pypowerwall/test-gw/strings/A/voltage"] == "240.50"
+        assert "pypowerwall/test-gw/strings/A/current" in published
+        assert published["pypowerwall/test-gw/strings/A/current"] == "1.50"
+        assert "pypowerwall/test-gw/strings/A/power" in published
+        assert published["pypowerwall/test-gw/strings/A/power"] == "360.75"
+
+        assert "pypowerwall/test-gw/strings/B/voltage" in published
+        assert published["pypowerwall/test-gw/strings/B/voltage"] == "238.00"
+
+    @pytest.mark.asyncio
+    async def test_per_string_json_topic(self, monkeypatch):
+        """Full string data is published as JSON on the bare string topic."""
+        pub = self._make_publisher(monkeypatch)
+        status = self._make_status_with_strings({
+            "A": {"Voltage": 240.5, "Current": 1.5, "Power": 360.75},
+        })
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in pub._client.publish.call_args_list}
+        assert "pypowerwall/test-gw/strings/A" in published
+        data = json.loads(published["pypowerwall/test-gw/strings/A"])
+        assert data["Voltage"] == 240.5
+        assert data["Current"] == 1.5
+
+    @pytest.mark.asyncio
+    async def test_paired_rollups_ab_cd_ef(self, monkeypatch):
+        """PW3 paired-string rollups (AB, CD, EF) are published with summed current/power."""
+        pub = self._make_publisher(monkeypatch)
+        status = self._make_status_with_strings({
+            "A": {"Voltage": 240.0, "Current": 1.5, "Power": 360.0},
+            "B": {"Voltage": 240.0, "Current": 1.25, "Power": 300.0},
+            "C": {"Voltage": 238.0, "Current": 2.0, "Power": 476.0},
+            "D": {"Voltage": 238.0, "Current": 1.0, "Power": 238.0},
+            "E": {"Voltage": 236.0, "Current": 0.5, "Power": 118.0},
+            "F": {"Voltage": 236.0, "Current": 0.8, "Power": 188.8},
+        })
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in pub._client.publish.call_args_list}
+
+        # AB pair
+        assert published["pypowerwall/test-gw/strings/AB/voltage"] == "240.00"
+        assert published["pypowerwall/test-gw/strings/AB/current"] == "2.75"
+        assert published["pypowerwall/test-gw/strings/AB/power"] == "660.00"
+
+        # CD pair
+        assert published["pypowerwall/test-gw/strings/CD/voltage"] == "238.00"
+        assert published["pypowerwall/test-gw/strings/CD/current"] == "3.00"
+        assert published["pypowerwall/test-gw/strings/CD/power"] == "714.00"
+
+        # EF pair
+        assert published["pypowerwall/test-gw/strings/EF/voltage"] == "236.00"
+        assert published["pypowerwall/test-gw/strings/EF/current"] == "1.30"
+        assert published["pypowerwall/test-gw/strings/EF/power"] == "306.80"
+
+    @pytest.mark.asyncio
+    async def test_no_strings_publishes_nothing_extra(self, monkeypatch):
+        """When strings is None, no string topics are published."""
+        pub = self._make_publisher(monkeypatch)
+        status = self._make_status_with_strings(None)
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in pub._client.publish.call_args_list}
+        string_topics = [t for t in published if "/strings/" in t]
+        assert len(string_topics) == 0
+
+    @pytest.mark.asyncio
+    async def test_partial_strings_only_publishes_available_pairs(self, monkeypatch):
+        """Only AB is published when only A and B strings exist."""
+        pub = self._make_publisher(monkeypatch)
+        status = self._make_status_with_strings({
+            "A": {"Voltage": 240.0, "Current": 1.5, "Power": 360.0},
+            "B": {"Voltage": 240.0, "Current": 1.0, "Power": 240.0},
+        })
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in pub._client.publish.call_args_list}
+        assert "pypowerwall/test-gw/strings/AB/voltage" in published
+        # CD and EF should not be published (no C/D/E/F strings)
+        assert "pypowerwall/test-gw/strings/CD/voltage" not in published
+        assert "pypowerwall/test-gw/strings/EF/voltage" not in published

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -508,3 +508,48 @@ class TestMqttStringTopics:
         # CD and EF should not be published (no C/D/E/F strings)
         assert "pypowerwall/test-gw/strings/CD/voltage" not in published
         assert "pypowerwall/test-gw/strings/EF/voltage" not in published
+
+    @pytest.mark.asyncio
+    async def test_multi_pw3_single_gateway_rollups(self, monkeypatch):
+        """Multi-PW3 on single gateway: A-F and A1-F1 each get paired rollups."""
+        pub = self._make_publisher(monkeypatch)
+        status = self._make_status_with_strings({
+            # First PW3
+            "A": {"Voltage": 284.0, "Current": 1.0, "Power": 284.0},
+            "B": {"Voltage": 284.0, "Current": 0.95, "Power": 269.8},
+            "C": {"Voltage": 0.0, "Current": 0.0, "Power": 0.0},
+            "D": {"Voltage": 0.0, "Current": 0.0, "Power": 0.0},
+            "E": {"Voltage": 0.0, "Current": 0.0, "Power": 0.0},
+            "F": {"Voltage": 0.0, "Current": 0.0, "Power": 0.0},
+            # Second PW3
+            "A1": {"Voltage": 310.0, "Current": 0.2, "Power": 62.0},
+            "B1": {"Voltage": 310.0, "Current": 0.2, "Power": 62.0},
+            "C1": {"Voltage": 388.0, "Current": 0.25, "Power": 97.0},
+            "D1": {"Voltage": 388.0, "Current": 0.15, "Power": 58.2},
+            "E1": {"Voltage": 422.0, "Current": 1.2, "Power": 506.4},
+            "F1": {"Voltage": 422.0, "Current": 1.2, "Power": 506.4},
+        })
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in pub._client.publish.call_args_list}
+
+        # First PW3 rollups
+        assert published["pypowerwall/test-gw/strings/AB/voltage"] == "284.00"
+        assert published["pypowerwall/test-gw/strings/AB/current"] == "1.95"
+        assert published["pypowerwall/test-gw/strings/AB/power"] == "553.80"
+
+        # Second PW3 rollups (A1+B1, C1+D1, E1+F1)
+        assert published["pypowerwall/test-gw/strings/AB1/voltage"] == "310.00"
+        assert published["pypowerwall/test-gw/strings/AB1/current"] == "0.40"
+        assert published["pypowerwall/test-gw/strings/AB1/power"] == "124.00"
+
+        assert published["pypowerwall/test-gw/strings/CD1/voltage"] == "388.00"
+        assert published["pypowerwall/test-gw/strings/CD1/current"] == "0.40"
+        assert published["pypowerwall/test-gw/strings/CD1/power"] == "155.20"
+
+        assert published["pypowerwall/test-gw/strings/EF1/voltage"] == "422.00"
+        assert published["pypowerwall/test-gw/strings/EF1/current"] == "2.40"
+        assert published["pypowerwall/test-gw/strings/EF1/power"] == "1012.80"
+
+        # Individual A1 topic also published
+        assert published["pypowerwall/test-gw/strings/A1/voltage"] == "310.00"

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -510,6 +510,24 @@ class TestMqttStringTopics:
         assert "pypowerwall/test-gw/strings/EF/voltage" not in published
 
     @pytest.mark.asyncio
+    async def test_single_string_in_pair_no_rollup(self, monkeypatch):
+        """When only one string of a pair exists, no rollup is published."""
+        pub = self._make_publisher(monkeypatch)
+        status = self._make_status_with_strings({
+            "A": {"Voltage": 240.0, "Current": 1.5, "Power": 360.0},
+            # B is missing — AB rollup must NOT be published
+        })
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in pub._client.publish.call_args_list}
+        # A individual string topics should be published
+        assert "pypowerwall/test-gw/strings/A/voltage" in published
+        # AB rollup must NOT be published — B is missing
+        assert "pypowerwall/test-gw/strings/AB/voltage" not in published
+        assert "pypowerwall/test-gw/strings/AB/current" not in published
+        assert "pypowerwall/test-gw/strings/AB/power" not in published
+
+    @pytest.mark.asyncio
     async def test_multi_pw3_single_gateway_rollups(self, monkeypatch):
         """Multi-PW3 on single gateway: A-F and A1-F1 each get paired rollups."""
         pub = self._make_publisher(monkeypatch)


### PR DESCRIPTION
## Summary

Implements the MQTT solar string topics requested in #48.

### New MQTT topics

**Per-string (A–F):**
```
pypowerwall/{gw}/strings/{A-F}/voltage   — V
pypowerwall/{gw}/strings/{A-F}/current   — A
pypowerwall/{gw}/strings/{A-F}/power     — W
pypowerwall/{gw}/strings/{A-F}           — JSON (full string data object)
```

**PW3 paired rollups (AB, CD, EF):**
```
pypowerwall/{gw}/strings/{AB,CD,EF}/voltage   — V (from first string in pair)
pypowerwall/{gw}/strings/{AB,CD,EF}/current   — A (sum of pair)
pypowerwall/{gw}/strings/{AB,CD,EF}/power     — W (sum of pair)
```

### Design decisions
- **Multi-gateway aware** — strings live under `{prefix}/{gateway_id}/strings/`, so multi-PW3 setups get per-gateway string data automatically
- **Graceful degradation** — if `data.strings` is `None` or empty, no string topics are published (no errors)
- **Paired rollups only published when both strings in a pair exist** — no phantom AB topics when only A is present
- **Raw A-F always published alongside rollups** — preserves full resolution for multi-inverter and inverter-only setups

### Testing
- 5 new tests in `TestMqttStringTopics` covering per-string topics, JSON topics, paired rollups, empty strings, and partial strings
- All 180 tests pass

Closes #48