### PR TITLE
feat: port companion param control endpoints from pypowerwall #308

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,14 @@
 
 ## Version History
 
+### [0.3.5] - 2026-06-19
+
+**Added:**
+- **Combined reserve+mode control endpoints** — `POST /control/reserve` and `POST /control/mode` now accept optional companion parameters (`mode=` and `level=` respectively) to update both reserve and mode in a single `set_operation()` call, avoiding duplicate Tesla audit-log entries. Fully backward compatible — omitting the companion parameter preserves original behavior. Ported from pypowerwall PR #308.
+  - `POST /control/reserve` accepts optional `mode=<self_consumption|backup|autonomous>`
+  - `POST /control/mode` accepts optional `level=<int>`
+  - Invalid companion values return HTTP 400 without making any Powerwall call
+
 ### [0.3.4] - 2026-06-07
 
 **Fixed:**

--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -94,11 +94,13 @@ async def control_api(
     Routes to cloud control connection for write operations (set_reserve, set_mode,
     set_grid_charging) when available, since TEDAPI doesn't support POST/write APIs.
     Falls back to direct post for cloud-mode or FleetAPI gateways.
+
+    Optional companion parameters (ported from pypowerwall PR #308):
+    - POST /control/reserve with mode=<mode> calls set_operation(level, mode)
+    - POST /control/mode with level=<int> calls set_operation(level, mode)
     """
     verify_control_token(authorization)
 
-    # Map control paths to pypowerwall cloud control methods.
-    # Used for TEDAPI gateways with cloud credentials (hybrid mode).
     # Validate grid_charging requires an explicit boolean value to prevent
     # silent state changes from malformed or empty payloads.
     if path == "grid_charging":
@@ -108,6 +110,89 @@ async def control_api(
                 detail="'value' must be a boolean (true or false)",
             )
 
+    # Optional companion parameters for combined reserve+mode writes.
+    # When a caller wants to change both reserve and mode, sending them in a
+    # single request avoids duplicate Tesla audit-log entries caused by
+    # set_reserve() + set_mode() each calling set_operation() internally.
+    # Omitting the companion parameter preserves the original behaviour.
+    valid_modes = ["self_consumption", "backup", "autonomous"]
+
+    if path == "reserve" and "mode" in data:
+        mode_val = data["mode"]
+        if mode_val not in valid_modes:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid 'mode' companion value. Must be one of: "
+                       + ", ".join(valid_modes),
+            )
+        level = data.get("value", 0)
+        if not isinstance(level, int):
+            raise HTTPException(
+                status_code=400,
+                detail="'value' must be an integer reserve level",
+            )
+        if gateway_manager._cloud_control:
+            result = await gateway_manager.cloud_control(
+                "set_operation", level, mode_val, timeout=10.0
+            )
+            if result is None:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Control operation failed via cloud",
+                )
+            return result
+        # Fallback for cloud-mode/FleetAPI gateways
+        gateway_id = get_default_gateway()
+        result = await gateway_manager.call_api(
+            gateway_id, "post", "/api/operation",
+            {"level": level, "mode": mode_val}, timeout=10.0
+        )
+        if result is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Control operation failed or gateway not available",
+            )
+        return result
+
+    if path == "mode" and "level" in data:
+        level_val = data["level"]
+        if not isinstance(level_val, int):
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid 'level' companion value. Must be an integer.",
+            )
+        mode = data.get("value", "self_consumption")
+        if mode not in valid_modes:
+            raise HTTPException(
+                status_code=400,
+                detail="'value' must be a valid mode: "
+                       + ", ".join(valid_modes),
+            )
+        if gateway_manager._cloud_control:
+            result = await gateway_manager.cloud_control(
+                "set_operation", level_val, mode, timeout=10.0
+            )
+            if result is None:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Control operation failed via cloud",
+                )
+            return result
+        # Fallback for cloud-mode/FleetAPI gateways
+        gateway_id = get_default_gateway()
+        result = await gateway_manager.call_api(
+            gateway_id, "post", "/api/operation",
+            {"level": level_val, "mode": mode}, timeout=10.0
+        )
+        if result is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Control operation failed or gateway not available",
+            )
+        return result
+
+    # Map control paths to pypowerwall cloud control methods.
+    # Used for TEDAPI gateways with cloud credentials (hybrid mode).
     cloud_control_map = {
         "reserve": ("set_reserve", lambda d: [d.get("value", 0)]),
         "mode": ("set_mode", lambda d: [d.get("value", "self_consumption")]),

--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -126,7 +126,7 @@ async def control_api(
                        + ", ".join(valid_modes),
             )
         level = data.get("value", 0)
-        if not isinstance(level, int):
+        if not isinstance(level, int) or isinstance(level, bool):
             raise HTTPException(
                 status_code=400,
                 detail="'value' must be an integer reserve level",
@@ -156,7 +156,7 @@ async def control_api(
 
     if path == "mode" and "level" in data:
         level_val = data["level"]
-        if not isinstance(level_val, int):
+        if not isinstance(level_val, int) or isinstance(level_val, bool):
             raise HTTPException(
                 status_code=400,
                 detail="Invalid 'level' companion value. Must be an integer.",

--- a/app/config.py
+++ b/app/config.py
@@ -176,7 +176,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.3.4"
+SERVER_VERSION = "0.3.5"
 
 
 class GatewayConfig(BaseSettings):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.3.4"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.3.5"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [

--- a/tests/test_api_legacy.py
+++ b/tests/test_api_legacy.py
@@ -505,6 +505,46 @@ def test_control_mode_with_invalid_level_returns_400(
     mock_cloud.set_operation.assert_not_called()
 
 
+def test_control_reserve_with_boolean_value_returns_400(
+    control_client, connected_gateway
+):
+    """POST /control/reserve with boolean value should return 400, no cloud call."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/reserve",
+        json={"value": True, "mode": "backup"},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 400
+    mock_cloud.set_reserve.assert_not_called()
+    mock_cloud.set_operation.assert_not_called()
+
+
+def test_control_mode_with_boolean_level_returns_400(
+    control_client, connected_gateway
+):
+    """POST /control/mode with boolean level= should return 400, no cloud call."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/mode",
+        json={"value": "backup", "level": False},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 400
+    mock_cloud.set_mode.assert_not_called()
+    mock_cloud.set_operation.assert_not_called()
+
+
 def test_control_reserve_companion_fallback_without_cloud(
     control_client, connected_gateway, mock_pypowerwall
 ):

--- a/tests/test_api_legacy.py
+++ b/tests/test_api_legacy.py
@@ -415,6 +415,135 @@ def test_control_rejects_wrong_token(control_client, connected_gateway):
         headers={"Authorization": "wrong-token"},
     )
     assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /control companion parameter tests (ported from pypowerwall PR #308)
+# ---------------------------------------------------------------------------
+
+def test_control_reserve_with_valid_mode_calls_set_operation(
+    control_client, connected_gateway
+):
+    """POST /control/reserve with mode= companion should call set_operation."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    mock_cloud.set_operation.return_value = {"result": "Updated"}
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/reserve",
+        json={"value": 5, "mode": "self_consumption"},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    mock_cloud.set_operation.assert_called_once_with(5, "self_consumption")
+    mock_cloud.set_reserve.assert_not_called()
+    mock_cloud.set_mode.assert_not_called()
+
+
+def test_control_mode_with_valid_level_calls_set_operation(
+    control_client, connected_gateway
+):
+    """POST /control/mode with level= companion should call set_operation."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    mock_cloud.set_operation.return_value = {"result": "Updated"}
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/mode",
+        json={"value": "backup", "level": 80},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    mock_cloud.set_operation.assert_called_once_with(80, "backup")
+    mock_cloud.set_mode.assert_not_called()
+    mock_cloud.set_reserve.assert_not_called()
+
+
+def test_control_reserve_with_invalid_mode_returns_400(
+    control_client, connected_gateway
+):
+    """POST /control/reserve with invalid mode= should return 400, no cloud call."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/reserve",
+        json={"value": 5, "mode": "garbage"},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 400
+    mock_cloud.set_reserve.assert_not_called()
+    mock_cloud.set_operation.assert_not_called()
+
+
+def test_control_mode_with_invalid_level_returns_400(
+    control_client, connected_gateway
+):
+    """POST /control/mode with non-integer level= should return 400, no cloud call."""
+    from app.core.gateway_manager import gateway_manager
+
+    mock_cloud = Mock()
+    gateway_manager._cloud_control = mock_cloud
+
+    response = control_client.post(
+        "/control/mode",
+        json={"value": "backup", "level": "not-a-number"},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 400
+    mock_cloud.set_mode.assert_not_called()
+    mock_cloud.set_operation.assert_not_called()
+
+
+def test_control_reserve_companion_fallback_without_cloud(
+    control_client, connected_gateway, mock_pypowerwall
+):
+    """POST /control/reserve with mode= falls back to call_api when no cloud control."""
+    from app.core.gateway_manager import gateway_manager
+
+    gateway_manager._cloud_control = None
+    mock_pypowerwall.post.return_value = {"result": "Updated"}
+
+    response = control_client.post(
+        "/control/reserve",
+        json={"value": 5, "mode": "self_consumption"},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    mock_pypowerwall.post.assert_called_once()
+
+
+def test_control_mode_companion_fallback_without_cloud(
+    control_client, connected_gateway, mock_pypowerwall
+):
+    """POST /control/mode with level= falls back to call_api when no cloud control."""
+    from app.core.gateway_manager import gateway_manager
+
+    gateway_manager._cloud_control = None
+    mock_pypowerwall.post.return_value = {"result": "Updated"}
+
+    response = control_client.post(
+        "/control/mode",
+        json={"value": "backup", "level": 80},
+        headers={"Authorization": _CONTROL_TOKEN},
+    )
+
+    assert response.status_code == 200
+    mock_pypowerwall.post.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # /api/operation tests (issue #14 — mode caching)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

pypowerwall PR #308 added optional companion parameters to `/control/reserve` and `/control/mode` in the legacy proxy (`proxy/server.py`) so a caller can update both reserve and mode in a single `set_operation()` call. The pypowerwall-server legacy handler (`app/api/legacy.py`) does not yet support these companion parameters, creating an API compatibility gap.

## Change

Ports the same feature to the pypowerwall-server legacy handler:

- **`POST /control/reserve`** now accepts an optional `mode` parameter — when present and valid, calls `set_operation(level, mode)` instead of `set_reserve(level)`
- **`POST /control/mode`** now accepts an optional `level` parameter — when present and valid, calls `set_operation(level, mode)` instead of `set_mode(mode)`
- Invalid companion values return HTTP 400 without making any Powerwall call (no silent fallback)
- Fully backward compatible: omitting the companion parameter preserves the original `set_reserve` / `set_mode` behavior
- Works with both cloud control routing and the fallback `call_api` path

Requested by @jasonacox in [pypowerwall#308](https://github.com/jasonacox/pypowerwall/pull/308#issuecomment-4589973693).

## Test Coverage

6 new tests in `tests/test_api_legacy.py`:
- Reserve with valid mode → calls `set_operation` (not `set_reserve`)
- Mode with valid level → calls `set_operation` (not `set_mode`)
- Reserve with invalid mode → 400, no cloud call
- Mode with non-integer level → 400, no cloud call
- Reserve companion fallback without cloud control
- Mode companion fallback without cloud control

All 181 tests pass.

## Files Changed

- `app/api/legacy.py` — companion param handling in `control_api()`
- `app/config.py` — version bump 0.3.4 → 0.3.5
- `pyproject.toml` — version bump
- `RELEASE.md` — release notes
- `tests/test_api_legacy.py` — 6 new tests