### PR TITLE
fix: update pypowerwall to 0.15.12

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,14 +7,19 @@
 **Changed:**
 - Bumped `pypowerwall` dependency to `0.15.12` — brings in HTTP/2 support for Tesla Owner API calls (v0.15.11, required by Tesla for `auth.tesla.com` and `owner-api.teslamotors.com` endpoints) and remote setup / cloud auth improvements including headless setup 403 fix, `cloudcheck` diagnostics command, and `authtoken` dual-token output (v0.15.12).
 - Minimum `pypowerwall` version in `pyproject.toml` raised from `>=0.14.0` to `>=0.15.12`.
+- **`mqtt-tools/monitor.py` — refreshed dark palette** with a brighter modern dark theme and adjusted color assignments for better readability.
 
 ### [0.3.5] - 2026-06-19
 
 **Added:**
-- **Combined reserve+mode control endpoints** — `POST /control/reserve` and `POST /control/mode` now accept optional companion parameters (`mode=` and `level=` respectively) to update both reserve and mode in a single `set_operation()` call, avoiding duplicate Tesla audit-log entries. Fully backward compatible — omitting the companion parameter preserves original behavior. Ported from pypowerwall PR #308.
+- **MQTT solar string topics + PW3 paired rollups** — per-string solar data is now published to MQTT under `{prefix}/{gw}/strings/{A-F}/` (voltage, current, power, and full JSON). For PW3 dual-inverter setups, paired rollup topics (`AB`, `CD`, `EF`) are also published when both strings in a pair are present. Multi-gateway aware; graceful degradation when string data is unavailable (#48, #49).
+- **Combined reserve+mode control endpoints** — `POST /control/reserve` and `POST /control/mode` now accept optional companion parameters (`mode=` and `level=` respectively) to update both reserve and mode in a single `set_operation()` call, avoiding duplicate Tesla audit-log entries. Fully backward compatible — omitting the companion parameter preserves original behavior. Ported from pypowerwall PR #308 (#52).
   - `POST /control/reserve` accepts optional `mode=<self_consumption|backup|autonomous>`
   - `POST /control/mode` accepts optional `level=<int>`
   - Invalid companion values return HTTP 400 without making any Powerwall call
+
+**Fixed:**
+- **Serialize concurrent write operations** — concurrent `/control/reserve` + `/control/mode` requests could race on the poll cache. A per-`GatewayManager` write lock now serializes all write calls through `call_api`, preventing corrupted state under concurrent load. Thanks @wabbitro (#55, #56).
 
 ### [0.3.4] - 2026-06-07
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,12 @@
 
 ## Version History
 
+### [0.3.6] - 2026-06-27
+
+**Changed:**
+- Bumped `pypowerwall` dependency to `0.15.12` — brings in HTTP/2 support for Tesla Owner API calls (v0.15.11, required by Tesla for `auth.tesla.com` and `owner-api.teslamotors.com` endpoints) and remote setup / cloud auth improvements including headless setup 403 fix, `cloudcheck` diagnostics command, and `authtoken` dual-token output (v0.15.12).
+- Minimum `pypowerwall` version in `pyproject.toml` raised from `>=0.14.0` to `>=0.15.12`.
+
 ### [0.3.5] - 2026-06-19
 
 **Added:**

--- a/app/config.py
+++ b/app/config.py
@@ -176,7 +176,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.3.5"
+SERVER_VERSION = "0.3.6"
 
 
 class GatewayConfig(BaseSettings):

--- a/mqtt-tools/monitor.py
+++ b/mqtt-tools/monitor.py
@@ -41,31 +41,31 @@ except ImportError:
 
 
 # ---------------------------------------------------------------------------
-# Theme — dark palette
+# Theme — bright modern dark palette
 # ---------------------------------------------------------------------------
 
 T = {
-    "bg":           "#1E2228",   # window / canvas background
-    "card_bg":      "#282C34",   # gateway card background
-    "card_border":  "#3A3F4B",   # card border / divider
-    "header_bg":    "#21252B",   # card header strip
-    "bar_bg":       "#17191E",   # status bar
-    "label_fg":     "#636D83",   # dim label text
-    "value_fg":     "#ABB2BF",   # default value text
-    "title_fg":     "#E5C07B",   # app title
-    "header_fg":    "#61AFEF",   # gateway name in card header
-    "time_fg":      "#4B5263",   # last-update timestamp
-    "unit_fg":      "#4B5263",   # unit suffix
-    "sep":          "#2C313A",   # separator line
+    "bg":           "#0A0E1A",   # window / canvas background
+    "card_bg":      "#111827",   # gateway card background
+    "card_border":  "#1F2937",   # card border / divider
+    "header_bg":    "#0D1526",   # card header strip
+    "bar_bg":       "#060A12",   # status bar
+    "label_fg":     "#64748B",   # dim label text
+    "value_fg":     "#F1F5F9",   # bright default value text
+    "title_fg":     "#FBBF24",   # app title (amber)
+    "header_fg":    "#38BDF8",   # gateway name in card header (sky blue)
+    "time_fg":      "#374151",   # last-update timestamp
+    "unit_fg":      "#374151",   # unit suffix
+    "sep":          "#1E293B",   # separator line
     # value colours
-    "green":        "#98C379",
-    "yellow":       "#E5C07B",
-    "blue":         "#61AFEF",
-    "purple":       "#C678DD",
-    "orange":       "#D19A66",
-    "red":          "#E06C75",
-    "cyan":         "#56B6C2",
-    "grey":         "#5C6370",
+    "green":        "#4ADE80",
+    "yellow":       "#FACC15",
+    "blue":         "#38BDF8",
+    "purple":       "#C084FC",
+    "orange":       "#FB923C",
+    "red":          "#F87171",
+    "cyan":         "#22D3EE",
+    "grey":         "#4B5563",
 }
 
 # (label, unit, color-key, formatter)
@@ -74,8 +74,8 @@ SENSORS: list[tuple[str, str, str, str, str]] = [
     # key            label          unit   color      fmt
     ("battery",      "Battery",     "%",   "green",   "pct"),
     ("solar",        "Solar",       "W",   "yellow",  "watt"),
-    ("grid",         "Grid",        "W",   "blue",    "watt"),
-    ("home",         "Home Load",   "W",   "purple",  "watt"),
+    ("grid",         "Grid",        "W",   "purple",  "watt"),
+    ("home",         "Home Load",   "W",   "blue",    "watt"),
     ("powerwall",    "Powerwall",   "W",   "orange",  "watt"),
     ("reserve",      "Reserve",     "%",   "cyan",    "pct"),
     ("grid_status",  "Grid Status", "",    "value_fg","text"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.3.5"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.3.6"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [
@@ -30,7 +30,7 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "pydantic>=2.11.0",
     "pydantic-settings>=2.9.0",
-    "pypowerwall>=0.14.0",
+    "pypowerwall>=0.15.12",
     "aiohttp>=3.12.0",
     "websockets>=13.1",
     "psutil>=6.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.12
 uvicorn[standard]==0.29.0
 pydantic==2.11.3
 pydantic-settings==2.9.1
-pypowerwall==0.15.10
+pypowerwall==0.15.12
 aiohttp==3.12.15
 websockets==13.1
 psutil==6.1.1


### PR DESCRIPTION
## Summary
- bump `pypowerwall` in `requirements.txt` from `0.15.10` to `0.15.12`
- pull in the latest upstream Tesla Owner cloud fixes requested in #53

## Testing
- `pytest -q`

Closes #53