### PR TITLE
fix: serialize concurrent write operations in call_api

### DIFF
--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -80,10 +80,15 @@ logger = logging.getLogger(__name__)
 # reading the field it wasn't given from the 5-second poll cache. Two
 # concurrent writes both see the same stale cache value and the last one to
 # land on the gateway clobbers whichever field it didn't own.
-_WRITE_METHODS = frozenset({
-    "set_reserve", "set_mode", "set_operation",
-    "set_grid_charging", "set_grid_export",
-})
+_WRITE_METHODS = frozenset(
+    {
+        "set_reserve",
+        "set_mode",
+        "set_operation",
+        "set_grid_charging",
+        "set_grid_export",
+    }
+)
 
 class GatewayManager:
     """Manages multiple Powerwall gateway connections."""
@@ -1129,12 +1134,21 @@ class GatewayManager:
         try:
             method_func = getattr(self._cloud_control, method)
             loop = asyncio.get_running_loop()
-            result = await asyncio.wait_for(
-                loop.run_in_executor(
-                    self._executor, lambda: method_func(*args, **kwargs)
-                ),
-                timeout=timeout,
-            )
+            if method in _WRITE_METHODS:
+                async with self._write_lock:
+                    result = await asyncio.wait_for(
+                        loop.run_in_executor(
+                            self._executor, lambda: method_func(*args, **kwargs)
+                        ),
+                        timeout=timeout,
+                    )
+            else:
+                result = await asyncio.wait_for(
+                    loop.run_in_executor(
+                        self._executor, lambda: method_func(*args, **kwargs)
+                    ),
+                    timeout=timeout,
+                )
             logger.info(f"cloud_control({method}) completed successfully")
             return result
         except asyncio.TimeoutError:

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -48,7 +48,8 @@ Error Handling:
     - Automatic reconnection every poll cycle
 
 Thread Safety:
-    - All operations use asyncio (no threads/locks needed)
+    - All operations use asyncio (no threads/locks needed for reads)
+    - Write operations serialized via _write_lock to prevent set_operation() races
     - Single event loop handles all concurrency
     - Background task coordinated via asyncio.create_task()
     - Graceful shutdown via task cancellation
@@ -114,7 +115,7 @@ class GatewayManager:
         # Serializes concurrent write operations to prevent set_operation()
         # from reading stale cache when two control calls race.
         self._write_lock: asyncio.Lock = asyncio.Lock()
-        
+
         # Cloud connection for control operations (set_reserve, set_mode).
         # TEDAPI doesn't support POST/write APIs, so a separate cloud-mode
         # pypowerwall instance is created when cloud credentials are available
@@ -1089,7 +1090,6 @@ class GatewayManager:
                     ),
                     timeout=timeout,
                 )
-            )
             logger.debug(f"[{gateway_id}] call_api({method}) completed successfully")
             return result
         except asyncio.TimeoutError:

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -74,6 +74,15 @@ from app.config import GatewayConfig
 
 logger = logging.getLogger(__name__)
 
+# Methods that write gateway state and must not run concurrently.
+# set_operation() always writes backup_reserve_percent + real_mode together,
+# reading the field it wasn't given from the 5-second poll cache. Two
+# concurrent writes both see the same stale cache value and the last one to
+# land on the gateway clobbers whichever field it didn't own.
+_WRITE_METHODS = frozenset({
+    "set_reserve", "set_mode", "set_operation",
+    "set_grid_charging", "set_grid_export",
+})
 
 class GatewayManager:
     """Manages multiple Powerwall gateway connections."""
@@ -102,6 +111,10 @@ class GatewayManager:
         # Will be sized during initialize() based on gateway count
         self._executor: Optional[ThreadPoolExecutor] = None
 
+        # Serializes concurrent write operations to prevent set_operation()
+        # from reading stale cache when two control calls race.
+        self._write_lock: asyncio.Lock = asyncio.Lock()
+        
         # Cloud connection for control operations (set_reserve, set_mode).
         # TEDAPI doesn't support POST/write APIs, so a separate cloud-mode
         # pypowerwall instance is created when cloud credentials are available
@@ -1061,11 +1074,21 @@ class GatewayManager:
             logger.debug(
                 f"[{gateway_id}] call_api({method}) starting (timeout={timeout}s)"
             )
-            result = await asyncio.wait_for(
-                loop.run_in_executor(
-                    self._executor, lambda: method_func(*args, **kwargs)
-                ),
-                timeout=timeout,
+            if method in _WRITE_METHODS:
+                async with self._write_lock:
+                    result = await asyncio.wait_for(
+                        loop.run_in_executor(
+                            self._executor, lambda: method_func(*args, **kwargs)
+                        ),
+                        timeout=timeout,
+                    )
+            else:
+                result = await asyncio.wait_for(
+                    loop.run_in_executor(
+                        self._executor, lambda: method_func(*args, **kwargs)
+                    ),
+                    timeout=timeout,
+                )
             )
             logger.debug(f"[{gateway_id}] call_api({method}) completed successfully")
             return result

--- a/tests/test_gateway_manager.py
+++ b/tests/test_gateway_manager.py
@@ -508,6 +508,45 @@ async def test_cloud_control_success(mock_gateway_manager):
 
 
 @pytest.mark.asyncio
+async def test_cloud_control_serializes_concurrent_write_calls(mock_gateway_manager):
+    """Test cloud_control serializes concurrent write calls through the shared lock."""
+    events = []
+
+    def make_writer(name):
+        def writer(*args, **kwargs):
+            events.append(f"{name}-start")
+            if name == "reserve":
+                events.append("reserve-before-sleep")
+                import time
+
+                time.sleep(0.05)
+            events.append(f"{name}-end")
+            return True
+
+        return writer
+
+    mock_cloud = Mock()
+    mock_cloud.set_reserve.side_effect = make_writer("reserve")
+    mock_cloud.set_mode.side_effect = make_writer("mode")
+    mock_gateway_manager._cloud_control = mock_cloud
+
+    await asyncio.gather(
+        mock_gateway_manager.cloud_control("set_reserve", 20),
+        mock_gateway_manager.cloud_control("set_mode", "self_consumption"),
+    )
+
+    assert events == [
+        "reserve-start",
+        "reserve-before-sleep",
+        "reserve-end",
+        "mode-start",
+        "mode-end",
+    ]
+    mock_cloud.set_reserve.assert_called_once_with(20)
+    mock_cloud.set_mode.assert_called_once_with("self_consumption")
+
+
+@pytest.mark.asyncio
 async def test_cloud_control_no_connection(mock_gateway_manager):
     """Test cloud_control returns None immediately when _cloud_control is not set."""
     mock_gateway_manager._cloud_control = None


### PR DESCRIPTION
Fixes #55

Adds `_WRITE_METHODS` frozenset and `_write_lock` (`asyncio.Lock`) to 
`GatewayManager`. Write calls in `call_api` now acquire the lock before 
submitting to the executor, so concurrent `/control/reserve` + `/control/mode` 
requests are serialized and can't race on the poll cache.

Also updates the Thread Safety section in the module docstring to reflect 
that writes are now lock-protected.