### PR TITLE
fix: fan speeds not fetched from TEDAPI client

### DIFF
--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -808,10 +808,12 @@ class GatewayManager:
                 logger.debug(f"System status not available for {gateway_id}: {e}")
 
             # Try to get fan speeds for /fans endpoint (TEDAPI only)
+            # get_fan_speeds() lives on the TEDAPI client (pw.tedapi),
+            # not on the top-level Powerwall object itself
             try:
-                if hasattr(pw, "get_fan_speeds"):
+                if pw.tedapi and hasattr(pw.tedapi, "get_fan_speeds"):
                     data.fan_speeds = await asyncio.wait_for(
-                        loop.run_in_executor(self._executor, pw.get_fan_speeds),
+                        loop.run_in_executor(self._executor, pw.tedapi.get_fan_speeds),
                         timeout=5.0,
                     )
             except (asyncio.TimeoutError, Exception) as e:

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -811,7 +811,7 @@ class GatewayManager:
             # get_fan_speeds() lives on the TEDAPI client (pw.tedapi),
             # not on the top-level Powerwall object itself
             try:
-                if pw.tedapi and hasattr(pw.tedapi, "get_fan_speeds"):
+                if hasattr(pw, "tedapi") and pw.tedapi and hasattr(pw.tedapi, "get_fan_speeds"):
                     data.fan_speeds = await asyncio.wait_for(
                         loop.run_in_executor(self._executor, pw.tedapi.get_fan_speeds),
                         timeout=5.0,


### PR DESCRIPTION
## Fix: Fan speeds not fetched from TEDAPI client (#51)

### Problem

The `/fans` and `/fans/pw` endpoints return empty data (`{}`) even when TEDAPI is connected and fan speed data is available.

### Root Cause

In `gateway_manager.py`, the fan speed polling checks:

```python
if hasattr(pw, "get_fan_speeds"):
    data.fan_speeds = ... pw.get_fan_speeds() ...
```

But `get_fan_speeds()` is a method on the **TEDAPI client** (`pw.tedapi`), not on the top-level `Powerwall` object (`pw`). The `hasattr` check silently returns `False`, so fan data is never fetched.

For reference, the original pypowerwall proxy accesses this correctly via `pw.tedapi.get_fan_speeds()`.

### Fix

Check `pw.tedapi` (which is `False` when TEDAPI is off, or a `TEDAPI` instance when connected) and call `pw.tedapi.get_fan_speeds()`:

```python
if pw.tedapi and hasattr(pw.tedapi, "get_fan_speeds"):
    data.fan_speeds = ... pw.tedapi.get_fan_speeds() ...
```

### Testing

- With TEDAPI connected: `/fans` and `/fans/pw` will now return actual fan RPM data
- Without TEDAPI (cloud/FleetAPI mode): `pw.tedapi` is `False`, so the check is skipped as before — no behavior change

Fixes #51
