### PR TITLE
fix: add HA discovery payloads for solar string sensors (#57)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,15 @@
 
 ## Version History
 
+### [0.3.7] - 2026-06-28
+
+**Added:**
+- **HA MQTT discovery for solar string sensors** — `ha_discovery.py` now publishes Home Assistant auto-discovery configs for all solar string MPPT metrics added in v0.3.5. Per-string sensors (voltage, current, power for strings A–F) and paired-rollup sensors (AB, CD, EF) are auto-discovered in HA when string data is present on the gateway. Multi-PW3 setups with numbered strings (A1–F2, etc.) are also supported. Previously, the string MQTT topics were publishing correctly but HA never received discovery payloads for them (#57, #59).
+
+**Fixed:**
+- **Fan speeds not fetched from TEDAPI** — `pw.vitals()` fan speed fields were silently dropped because the TEDAPI client lacked the `get_fan_speeds()` call path. Fan RPM is now included in vitals data for PW3 systems on TEDAPI (#58).
+- **v1r local mode write routing** — control endpoints (`reserve`, `mode`, `grid_charging`) were skipped entirely when no cloud credentials were configured, even in v1r local mode. The `cloud_control_map` check is now split from the `_cloud_control` availability check so that mapped paths fall through to a direct `call_api` POST for local v1r control. Thanks @wabbitro (#60).
+
 ### [0.3.6] - 2026-06-27
 
 **Changed:**

--- a/app/config.py
+++ b/app/config.py
@@ -176,7 +176,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.3.6"
+SERVER_VERSION = "0.3.7"
 
 
 class GatewayConfig(BaseSettings):

--- a/app/mqtt/ha_discovery.py
+++ b/app/mqtt/ha_discovery.py
@@ -21,6 +21,14 @@ Sensors (numeric):
     powerwall   — Powerwall power (W, device_class=power, positive=discharging)
     reserve     — Backup reserve target (%)
 
+Solar string sensors (when string_ids provided):
+    strings/{id}/voltage  — String voltage (V, per string A–F or multi-PW3 A1–F2…)
+    strings/{id}/current  — String current (A)
+    strings/{id}/power    — String power (W)
+    strings/{AB}/voltage  — Paired-string voltage (V, from first string in pair)
+    strings/{AB}/current  — Paired-string current (A, sum of pair)
+    strings/{AB}/power    — Paired-string power (W, sum of pair)
+
 Text sensors:
     grid_status — "UP" | "DOWN" | "unknown"
     mode        — Operation mode string (e.g. "self_consumption", "backup")
@@ -41,7 +49,9 @@ References
 """
 import json
 import logging
-from typing import Optional
+from typing import Optional, Sequence
+
+logger = logging.getLogger(__name__)
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +73,7 @@ def build_discovery_payloads(
     topic_prefix: str,
     ha_prefix: str,
     version: Optional[str] = None,
+    string_ids: Optional[Sequence[str]] = None,
 ) -> list[tuple[str, str]]:
     """Build all HA auto-discovery (topic, payload) pairs for a gateway.
 
@@ -72,6 +83,11 @@ def build_discovery_payloads(
         topic_prefix:  MQTT topic prefix (e.g. "pypowerwall").
         ha_prefix:     Home Assistant discovery prefix (e.g. "homeassistant").
         version:       Powerwall firmware version string (optional).
+        string_ids:    Solar string identifiers present on this gateway (e.g.
+                       ["A", "B", "C", "D", "E", "F"] for a single PW3, or
+                       ["A1", "B1", …, "F2"] for a multi-PW3 setup).  When
+                       provided, per-string and paired-rollup sensors are added
+                       to the discovery payloads so HA auto-discovers them.
 
     Returns:
         List of (topic, json_payload_str) tuples, one per sensor/binary sensor.
@@ -245,4 +261,60 @@ def build_discovery_payloads(
             icon="mdi:lan-connect",
         ),
     ]
+
+    # --- Solar string sensors (per-string + paired rollups) ---
+    if string_ids:
+        strings_prefix = f"{data_prefix}/strings"
+        _STRING_METRICS = [
+            ("voltage", "Voltage", "V",  "voltage", "mdi:lightning-bolt"),
+            ("current", "Current", "A",  "current", "mdi:current-ac"),
+            ("power",   "Power",   "W",  "power",   "mdi:solar-power-variant"),
+        ]
+        _PAIR_BASES = [("A", "B", "AB"), ("C", "D", "CD"), ("E", "F", "EF")]
+
+        # Per-string sensors (A–F, A1–F1, A2–F2, …)
+        for sid in string_ids:
+            s_prefix = f"{strings_prefix}/{sid}"
+            sid_slug = sid.lower()
+            for metric, label, unit, dc, icon in _STRING_METRICS:
+                results.append(sensor(
+                    f"string_{sid_slug}_{metric}",
+                    f"String {sid} {label}",
+                    f"{s_prefix}/{metric}",
+                    unit=unit,
+                    device_class=dc,
+                    state_class="measurement",
+                    icon=icon,
+                    entity_category="diagnostic",
+                ))
+
+        # Paired-string rollup sensors (AB, CD, EF + numbered variants)
+        sid_set = set(string_ids)
+        suffixes: set[str] = set()
+        for sid in string_ids:
+            base = sid.rstrip("0123456789")
+            if base in ("A", "B", "C", "D", "E", "F"):
+                suffixes.add(sid[len(base):])
+
+        for suffix in sorted(suffixes):
+            for first, second, pair_base in _PAIR_BASES:
+                a_key = first + suffix
+                b_key = second + suffix
+                if a_key not in sid_set or b_key not in sid_set:
+                    continue
+                pair_name = pair_base + suffix.upper()
+                p_prefix = f"{strings_prefix}/{pair_name}"
+                pair_slug = pair_name.lower()
+                for metric, label, unit, dc, icon in _STRING_METRICS:
+                    results.append(sensor(
+                        f"string_{pair_slug}_{metric}",
+                        f"String {pair_name} {label}",
+                        f"{p_prefix}/{metric}",
+                        unit=unit,
+                        device_class=dc,
+                        state_class="measurement",
+                        icon=icon,
+                        entity_category="diagnostic",
+                    ))
+
     return results

--- a/app/mqtt/ha_discovery.py
+++ b/app/mqtt/ha_discovery.py
@@ -53,8 +53,6 @@ from typing import Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
-logger = logging.getLogger(__name__)
-
 
 def _device_block(gateway_id: str, gateway_name: str, version: Optional[str]) -> dict:
     """Build the shared HA device block for all sensors on this gateway."""

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -137,12 +137,17 @@ class MqttPublisher:
             )
             version = status.data.version if status.data else None
 
+            string_ids = None
+            if status.data and status.data.strings and isinstance(status.data.strings, dict):
+                string_ids = list(status.data.strings.keys())
+
             payloads = build_discovery_payloads(
                 gateway_id=gateway_id,
                 gateway_name=gateway_name,
                 topic_prefix=settings.mqtt_topic_prefix,
                 ha_prefix=settings.mqtt_ha_prefix,
                 version=version,
+                string_ids=string_ids,
             )
             for topic, payload in payloads:
                 await self._safe_publish(topic, payload, retain=True, qos=settings.mqtt_qos)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.3.6"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.3.7"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [

--- a/tests/test_mqtt_ha_discovery.py
+++ b/tests/test_mqtt_ha_discovery.py
@@ -199,6 +199,85 @@ class TestBuildDiscoveryPayloads:
             p = json.loads(payload_str)
             assert p["device"]["sw_version"] == "unknown"
 
+    def test_no_string_sensors_when_string_ids_absent(self):
+        """When string_ids is not supplied, no string sensors are added."""
+        results = build_discovery_payloads(
+            gateway_id="home",
+            gateway_name="Home",
+            topic_prefix="pypowerwall",
+            ha_prefix="homeassistant",
+        )
+        string_topics = [t for t, _ in results if "/string_" in t]
+        assert string_topics == []
+        assert len(results) == 11
+
+    def test_string_sensors_single_pw3(self):
+        """Six strings A–F → 6×3 per-string + 3×3 paired rollup = 27 extra entries."""
+        string_ids = ["A", "B", "C", "D", "E", "F"]
+        results = build_discovery_payloads(
+            gateway_id="home",
+            gateway_name="Home",
+            topic_prefix="pypowerwall",
+            ha_prefix="homeassistant",
+            string_ids=string_ids,
+        )
+        payloads = {t: json.loads(p) for t, p in results}
+        # 11 base + 6 strings × 3 metrics + 3 pairs × 3 metrics = 11 + 18 + 9 = 38
+        assert len(results) == 38
+
+        # Spot-check string A voltage
+        topic = "homeassistant/sensor/pypowerwall_home_string_a_voltage/config"
+        assert topic in payloads
+        p = payloads[topic]
+        assert p["unit_of_measurement"] == "V"
+        assert p["device_class"] == "voltage"
+        assert p["state_topic"] == "pypowerwall/home/strings/A/voltage"
+        assert p["entity_category"] == "diagnostic"
+
+        # Spot-check paired rollup AB power
+        topic = "homeassistant/sensor/pypowerwall_home_string_ab_power/config"
+        assert topic in payloads
+        p = payloads[topic]
+        assert p["unit_of_measurement"] == "W"
+        assert p["device_class"] == "power"
+        assert p["state_topic"] == "pypowerwall/home/strings/AB/power"
+
+    def test_string_sensors_partial_strings(self):
+        """Only strings present are discovered — no entities for missing strings."""
+        string_ids = ["A", "B"]
+        results = build_discovery_payloads(
+            gateway_id="home",
+            gateway_name="Home",
+            topic_prefix="pypowerwall",
+            ha_prefix="homeassistant",
+            string_ids=string_ids,
+        )
+        payloads = {t: json.loads(p) for t, p in results}
+        # 11 base + 2×3 per-string + 1 pair (AB) × 3 = 11 + 6 + 3 = 20
+        assert len(results) == 20
+        # AB pair present
+        assert "homeassistant/sensor/pypowerwall_home_string_ab_voltage/config" in payloads
+        # CD and EF pairs must NOT be present (C/D/E/F not in string_ids)
+        assert "homeassistant/sensor/pypowerwall_home_string_cd_power/config" not in payloads
+
+    def test_string_sensors_multi_pw3(self):
+        """Multi-PW3 numbered strings (A1–F2) generate correct paired rollups."""
+        string_ids = ["A1", "B1", "C1", "D1", "E1", "F1",
+                      "A2", "B2", "C2", "D2", "E2", "F2"]
+        results = build_discovery_payloads(
+            gateway_id="home",
+            gateway_name="Home",
+            topic_prefix="pypowerwall",
+            ha_prefix="homeassistant",
+            string_ids=string_ids,
+        )
+        payloads = {t: json.loads(p) for t, p in results}
+        # 11 base + 12×3 per-string + 6 pairs × 3 = 11 + 36 + 18 = 65
+        assert len(results) == 65
+        # Spot-check numbered pair AB1
+        assert "homeassistant/sensor/pypowerwall_home_string_ab1_voltage/config" in payloads
+        assert "homeassistant/sensor/pypowerwall_home_string_ab2_power/config" in payloads
+
 
 # ---------------------------------------------------------------------------
 # Integration tests for MqttPublisher._publish_ha_discovery()

--- a/tests/test_mqtt_ha_discovery.py
+++ b/tests/test_mqtt_ha_discovery.py
@@ -207,7 +207,7 @@ class TestBuildDiscoveryPayloads:
             topic_prefix="pypowerwall",
             ha_prefix="homeassistant",
         )
-        string_topics = [t for t, _ in results if "/string_" in t]
+        string_topics = [t for t, _ in results if "_string_" in t]
         assert string_topics == []
         assert len(results) == 11
 


### PR DESCRIPTION
## Problem

 was not updated when PR #49 added solar string MQTT topics. Home Assistant's auto-discovery never received config payloads for the new  topics or the paired rollups (), so HA couldn't create those entities automatically — even though the data was publishing correctly (as @Kahn-htp confirmed in #57 via MQTT Explorer).

## Changes

****
-  gains an optional  parameter
- When provided, emits per-string sensor entries (, , ) and paired-rollup entries (, , , plus numbered suffixes for multi-PW3 setups like , )
- No change to baseline behavior when  is not passed (still 11 entities)

****
-  extracts string IDs from  and forwards them to 

****
- 4 new tests: no-string baseline (11 entities unchanged), single PW3 A–F (38 entities), partial strings, multi-PW3 A1–F2 (65 entities)
- All 195 tests pass

## HA entity names

For a standard PW3 (strings A–F), HA will now auto-discover:
- String A Voltage / Current / Power
- String B Voltage / Current / Power
- … through String F …
- String AB Voltage / Current / Power (pair rollup)
- String CD Voltage / Current / Power
- String EF Voltage / Current / Power

All string entities are grouped under the same Powerwall device card and marked .

Fixes #57
