### PR TITLE
fix(docs): PW_GW_PWD is required in v1r mode, not optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ docker run -d \
 
 #### TEDAPI v1r Mode (RSA Key Auth)
 ```bash
-# TEDAPI v1r uses an RSA-4096 private key instead of the gateway Wi-Fi password.
+# TEDAPI v1r uses an RSA-4096 private key for the encrypted channel,
+# but still requires PW_GW_PWD to derive the customer password.
 # Generate a key pair with pypowerwall, then mount it into the container.
 docker run -d \
   --name pypowerwall-server \
   --network host \
   -e PW_HOST=192.168.91.1 \
+  -e PW_GW_PWD=your_gateway_password \
   -e PW_RSA_KEY_PATH=/keys/tedapi_rsa_private.pem \
   -e PW_WIFI_HOST=192.168.91.1 \
   -v /path/to/keys:/keys \
@@ -143,7 +145,8 @@ PROXY_BASE_URL=/pypowerwall  # Optional: serve under a sub-path (see Reverse Pro
 **Single Gateway Mode (TEDAPI v1r — RSA Key Auth):**
 ```bash
 PW_HOST=192.168.91.1
-PW_RSA_KEY_PATH=/path/to/tedapi_rsa_private.pem  # RSA-4096 private key (alternative to PW_GW_PWD)
+PW_GW_PWD=your_gateway_password                  # Gateway password (last 5 chars used as customer password)
+PW_RSA_KEY_PATH=/path/to/tedapi_rsa_private.pem  # RSA-4096 private key for v1r encrypted channel
 PW_WIFI_HOST=192.168.91.1                         # WiFi fallback IP for v1r mode (default: 192.168.91.1)
 PW_TIMEZONE=America/Los_Angeles
 ```
@@ -228,6 +231,7 @@ gateways:
   - id: v1r-gateway
     name: TEDAPI v1r Gateway
     host: 192.168.91.1
+    gw_pwd: your_gateway_password                # Required even in v1r mode (used to derive customer password)
     rsa_key_path: /keys/tedapi_rsa_private.pem  # RSA-4096 private key (TEDAPI v1r mode)
     wifi_host: 192.168.91.1                     # WiFi fallback IP (optional, defaults to 192.168.91.1)
     timezone: America/Los_Angeles
@@ -235,20 +239,20 @@ gateways:
 
 **Authentication:**
 - `gw_pwd`: For TEDAPI local gateway access (standard mode)
-- `rsa_key_path`: Path to RSA-4096 private key PEM file for TEDAPI v1r LAN access (alternative to `gw_pwd`)
+- `rsa_key_path`: Path to RSA-4096 private key PEM file for TEDAPI v1r LAN access (requires `gw_pwd` — the RSA key handles the encrypted channel, but `gw_pwd` is still needed to derive the customer password)
 - `email` + `authpath`: For Tesla Cloud API (control operations)
   - Run `pypowerwall-server --setup` to authenticate and generate auth files
   - Specify directory containing `.pypowerwall.auth` and `.pypowerwall.site` files
 
 **TEDAPI connection modes:**
 - `host` + `gw_pwd` → TEDAPI (standard, uses gateway Wi-Fi password)
-- `host` + `rsa_key_path` → TEDAPI v1r (uses RSA-4096 private key; shown as "TEDAPI v1r" in console)
+- `host` + `gw_pwd` + `rsa_key_path` → TEDAPI v1r (RSA-4096 encrypted channel + customer password from gw_pwd; shown as "TEDAPI v1r" in console)
 - `wifi_host` → Optional WiFi fallback IP for v1r mode (default `192.168.91.1`; only needed when your gateway is on a non-standard IP)
 
 **Optional fields:**
 - `port`: Non-standard HTTPS port (e.g. `8443`) — use when the gateway is behind a travel router that forwards a custom port to `192.168.91.1:443`
 - `type`: Gateway device type — `powerwall` (default, has batteries) or `inverter` (solar-only; suppresses battery panels in the console)
-- `rsa_key_path`: RSA-4096 private key PEM path for TEDAPI v1r LAN authentication
+- `rsa_key_path`: RSA-4096 private key PEM path for TEDAPI v1r LAN authentication (requires `gw_pwd` — see above)
 - `wifi_host`: WiFi host IP for TEDAPI v1r WiFi fallback (default `192.168.91.1`; set this when your gateway's WiFi AP is on a different subnet, e.g. behind a travel router)
 
 ### Reverse Proxy / HTTPS Proxy

--- a/app/config.py
+++ b/app/config.py
@@ -76,8 +76,8 @@ Connection Modes:
         • Fastest, most reliable
         • Requires direct connection to gateway WiFi or local network
         • Configuration: PW_HOST + PW_GW_PWD  (password-based)
-        •            OR: PW_HOST + PW_RSA_KEY_PATH  (RSA key-based, v1r mode)
-        • Example: 192.168.91.1 with gateway password or RSA PEM key
+        •            OR: PW_HOST + PW_GW_PWD + PW_RSA_KEY_PATH  (RSA key + v1r mode)
+        • Example: 192.168.91.1 with gateway password (optionally with RSA PEM key for v1r mode)
     
     Cloud Mode:
         • Remote access from anywhere


### PR DESCRIPTION
## Summary

The v1r Docker example and environment variable docs implied the RSA key alone was sufficient for v1r mode ("uses an RSA-4096 private key **instead of** the gateway Wi-Fi password"). In practice, pypowerwall derives the customer password from `gw_pwd` (last 5 chars) even in v1r mode — the RSA key handles the encrypted channel, but authentication still requires the gateway password.

Without `PW_GW_PWD`, the gateway API shows `gw_pwd: null` and connection fails with a generic "failed to connect" error.

## Changes

- **README.md**: Added `PW_GW_PWD` to the v1r Docker example, env vars section, multi-gateway YAML, and corrected the connection mode / authentication descriptions
- **app/config.py**: Corrected the `--help` text connection mode description

## Context

Reported by [@GSV3MiaC](https://github.com/GSV3MiaC) in [discussion #312](https://github.com/jasonacox/pypowerwall/discussions/312#discussioncomment-17464284) — they followed the v1r Docker example which omitted `PW_GW_PWD`, resulting in connection failures.

— Sam ⚡