### PR TITLE
fix: use Debian-slim for all Docker platforms + add tini (avoid Alpine/musl TLS issue)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-# Base images per platform — arm/v7 and arm/v8 (32-bit ARM, Raspberry Pi) need
-# slim-bookworm; amd64 and arm64 use the smaller alpine image.
-FROM python:3.12-alpine AS base-amd64
-FROM python:3.12-alpine AS base-arm64
+# Base images per platform — all targets use Debian-slim (not Alpine) to avoid
+# the musl libc TLS fingerprint that Tesla rejects on long-running token
+# refresh (see RELEASE.md v0.15.13 and pypowerwall#344). This matches the
+# base image strategy used by the pypowerwall proxy's own Dockerfile.
+FROM python:3.12-slim-bookworm AS base-amd64
+FROM python:3.12-slim-bookworm AS base-arm64
 FROM python:3.12-slim-bookworm AS base-armv7
 FROM python:3.12-slim-bookworm AS base-armv8
 FROM base-${TARGETARCH}${TARGETVARIANT}
@@ -18,38 +20,25 @@ FROM base-${TARGETARCH}${TARGETVARIANT}
 WORKDIR /app
 
 # Install build dependencies, pip packages, then clean up.
-# wget is kept as a runtime dependency for the HEALTHCHECK below.
-# Package manager differs by base image (apk on Alpine, apt on Debian).
+# wget is kept as a runtime dependency for the HEALTHCHECK below; tini is kept
+# as the PID 1 entrypoint (see ENTRYPOINT below) for correct signal forwarding
+# and zombie reaping.
 COPY requirements.txt .
-RUN if command -v apk > /dev/null; then \
-      apk add --no-cache --virtual .build-deps \
-          gcc \
-          python3-dev \
-          make \
-          automake \
-          autoconf \
-          libtool \
-          musl-dev \
-          linux-headers && \
-      apk add --no-cache wget && \
-      pip install --no-cache-dir -r requirements.txt && \
-      apk del .build-deps; \
-    else \
-      apt-get update && \
-      apt-get install -y --no-install-recommends \
-          gcc \
-          python3-dev \
-          make \
-          automake \
-          autoconf \
-          libtool \
-          libffi-dev \
-          wget && \
-      pip install --no-cache-dir -r requirements.txt && \
-      apt-get purge -y gcc python3-dev make automake autoconf libtool libffi-dev && \
-      apt-get autoremove -y && \
-      rm -rf /var/lib/apt/lists/*; \
-    fi
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        python3-dev \
+        make \
+        automake \
+        autoconf \
+        libtool \
+        libffi-dev \
+        wget \
+        tini && \
+    pip install --no-cache-dir -r requirements.txt && \
+    apt-get purge -y gcc python3-dev make automake autoconf libtool libffi-dev && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy application
 COPY app/ ./app/
@@ -64,5 +53,7 @@ EXPOSE 8675
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD wget --spider -q http://localhost:8675/health || exit 1
 
-# Run the application
+# Run under tini as PID 1 so signals (e.g. SIGTERM) are forwarded correctly to
+# uvicorn for graceful shutdown, and any orphaned child processes are reaped.
+ENTRYPOINT ["tini", "--"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8675"]

--- a/Dockerfile.beta
+++ b/Dockerfile.beta
@@ -7,10 +7,12 @@
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-# Base images per platform — arm/v7 and arm/v8 (32-bit ARM, Raspberry Pi) need
-# slim-bookworm; amd64 and arm64 use the smaller alpine image.
-FROM python:3.12-alpine AS base-amd64
-FROM python:3.12-alpine AS base-arm64
+# Base images per platform — all targets use Debian-slim (not Alpine) to avoid
+# the musl libc TLS fingerprint that Tesla rejects on long-running token
+# refresh (see RELEASE.md v0.15.13 and pypowerwall#344). This matches the
+# base image strategy used by the pypowerwall proxy's own Dockerfile.
+FROM python:3.12-slim-bookworm AS base-amd64
+FROM python:3.12-slim-bookworm AS base-arm64
 FROM python:3.12-slim-bookworm AS base-armv7
 FROM python:3.12-slim-bookworm AS base-armv8
 FROM base-${TARGETARCH}${TARGETVARIANT}
@@ -20,43 +22,25 @@ WORKDIR /app
 # Install all requirements including pypowerwall (to pull in its transitive deps),
 # then install the local pypowerwall's own deps (may be ahead of the pinned release).
 # Copy the local pypowerwall source tree and shadow it via PYTHONPATH.
-# Package manager differs by base image (apk on Alpine, apt on Debian).
+# tini is kept as the PID 1 entrypoint (see ENTRYPOINT below).
 COPY requirements.txt .
-RUN if command -v apk > /dev/null; then \
-      apk add --no-cache --virtual .build-deps \
-          gcc \
-          python3-dev \
-          make \
-          automake \
-          autoconf \
-          libtool \
-          musl-dev \
-          linux-headers \
-          libffi-dev && \
-      apk add --no-cache wget && \
-      pip install --no-cache-dir -r requirements.txt && \
-      pip install --no-cache-dir \
-          "protobuf>=3.20.0" python-dotenv pyroute2 \
-          python-dateutil requests-oauthlib websocket-client cryptography && \
-      apk del .build-deps; \
-    else \
-      apt-get update && \
-      apt-get install -y --no-install-recommends \
-          gcc \
-          python3-dev \
-          libffi-dev \
-          make \
-          automake \
-          autoconf \
-          libtool && \
-      pip install --no-cache-dir -r requirements.txt && \
-      pip install --no-cache-dir \
-          "protobuf>=3.20.0" python-dotenv pyroute2 \
-          python-dateutil requests-oauthlib websocket-client cryptography && \
-      apt-get purge -y gcc python3-dev libffi-dev make automake autoconf libtool && \
-      apt-get autoremove -y && \
-      rm -rf /var/lib/apt/lists/*; \
-    fi
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        python3-dev \
+        libffi-dev \
+        make \
+        automake \
+        autoconf \
+        libtool \
+        tini && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir \
+        "protobuf>=3.20.0" python-dotenv pyroute2 \
+        python-dateutil requests-oauthlib websocket-client cryptography && \
+    apt-get purge -y gcc python3-dev libffi-dev make automake autoconf libtool && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy local pypowerwall source tree — shadows the pip-installed version via PYTHONPATH
 COPY pypowerwall/ ./pypowerwall/
@@ -70,5 +54,7 @@ COPY app/ ./app/
 # Expose port
 EXPOSE 8675
 
-# Run the application
+# Run under tini as PID 1 so signals (e.g. SIGTERM) are forwarded correctly to
+# uvicorn for graceful shutdown, and any orphaned child processes are reaped.
+ENTRYPOINT ["tini", "--"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8675"]


### PR DESCRIPTION
## Summary

`Dockerfile` and `Dockerfile.beta` only used `python:3.12-slim-bookworm` for `arm/v7`/`arm/v8`, while `amd64`/`arm64` still used `python:3.12-alpine`. The musl libc TLS fingerprint issue that motivated the `arm/v7`/`arm/v8` base image choice is **not architecture-specific** — it affects any musl-based image, including the `amd64`/`arm64` Alpine builds most users actually run in production.

Our own `RELEASE.md` already documents this exact issue from the `pypowerwall` 0.15.13 changelog:

> "Docker base image switched from Alpine to Debian-slim to avoid musl libc TLS fingerprint rejection by Tesla after long-running token expiry."

The sibling `pypowerwall` proxy project's own Dockerfile already applies this fix across all 4 platforms (references `pypowerwall#344`). This PR brings `pypowerwall-server` in line with that.

## Changes

- All 4 platforms (`amd64`, `arm64`, `arm/v7`, `arm/v8`) now use `python:3.12-slim-bookworm` instead of splitting alpine/slim-bookworm.
- Removed the now-dead Alpine/`apk` install branch in both Dockerfiles, simplifying to a single `apt-get` path.
- Added `tini` as `ENTRYPOINT` (PID 1) for correct `SIGTERM` forwarding and zombie reaping, matching the proxy project's Dockerfile.

## Testing

Verified locally with `docker build --platform linux/amd64`:
- Build succeeds, image starts, `/health` responds correctly.
- `tini` confirmed as PID 1 via `/proc/1/comm`.
- `docker stop` completes in **~0.36s** with clean `Gateway manager shutdown complete` logs, even while the gateway was mid backoff-retry — confirms this works well together with the `shutdown()` task-cancellation fix from `53d1b79` (PR #66).

Not yet verified: full multi-arch build (`arm/v7`/`arm/v8`) via `upload.sh`, since this changes the production image base for all platforms.

## Risk

This changes the base OS for the production Docker image on `amd64`/`arm64` (Alpine → Debian-slim), which increases image size (~51MB → ~73MB) but removes a known Tesla-cloud-connectivity risk after long uptimes. Flagging for review before merge given it affects the published `latest`/production tags.