### PR TITLE
fix: add curl to Docker image for Powerwall-Dashboard healthcheck compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,10 @@ FROM base-${TARGETARCH}${TARGETVARIANT}
 WORKDIR /app
 
 # Install build dependencies, pip packages, then clean up.
-# wget is kept as a runtime dependency for the HEALTHCHECK below; tini is kept
-# as the PID 1 entrypoint (see ENTRYPOINT below) for correct signal forwarding
-# and zombie reaping.
+# wget and curl are kept as runtime dependencies for health checks — the
+# Dockerfile HEALTHCHECK uses wget, but Powerwall-Dashboard's docker-compose
+# overrides the healthcheck with curl. tini is kept as the PID 1 entrypoint
+# (see ENTRYPOINT below) for correct signal forwarding and zombie reaping.
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -33,6 +34,7 @@ RUN apt-get update && \
         autoconf \
         libtool \
         libffi-dev \
+        curl \
         wget \
         tini && \
     pip install --no-cache-dir -r requirements.txt && \


### PR DESCRIPTION
## Problem

The Powerwall-Dashboard `docker-compose.yml` healthcheck for the pypowerwall service uses `curl`:

```yaml
healthcheck:
    test: curl -sf http://pypowerwall:8675/health > /dev/null || exit 1
```

When users deploy pypowerwall-server as a drop-in replacement for the pypowerwall proxy in Powerwall-Dashboard, this compose healthcheck **overrides** the Dockerfile `HEALTHCHECK` (which uses `wget`). However, `curl` was not installed in the image — only `wget`.

This causes the container to report `unhealthy` with:
```
/bin/sh: 1: curl: not found
```

Reported in #69 by @jgleigh. Thanks for the excellent `docker inspect` diagnostics that pinpointed the root cause!

## Fix

Add `curl` to the `apt-get install` block in the Dockerfile, alongside the existing `wget`. Both are small packages; `curl` adds ~1.5 MB to the image.

This makes pypowerwall-server compatible with:
- The built-in Dockerfile `HEALTHCHECK` (uses `wget --spider`)
- Powerwall-Dashboard compose healthcheck (uses `curl -sf`)
- Any user-defined healthcheck using either tool

## Testing

The Dockerfile HEALTHCHECK itself is unchanged (still uses `wget`). The addition of `curl` is purely additive — it just ensures the binary is present when a compose file or user overrides the healthcheck with `curl`.

Fixes #69