### PR TITLE
feat(mqtt): lifetime energy topics + HA energy sensors; bump pypowerwall 0.16.5

### DIFF
--- a/MQTT.md
+++ b/MQTT.md
@@ -140,6 +140,26 @@ Base path: `{MQTT_TOPIC_PREFIX}/{gateway_id}/`
 | `pypowerwall/{gw}/reserve` | `20.0` | `%` |
 | `pypowerwall/{gw}/online` | `true` or `false` | — |
 
+### Lifetime energy topics (Wh accumulators)
+
+Lifetime energy totals from `/api/meters/aggregates` — on PW3/TEDAPI these are
+populated by `pypowerwall>=0.16.5` (overlaid from the gateway's native local API,
+see pypowerwall PR #372); PW2/local mode has always carried them. Gateways whose
+firmware lacks the endpoint report `0`, mirroring the HTTP API.
+
+| Topic | Value | Unit |
+|-------|-------|------|
+| `pypowerwall/{gw}/grid_energy_imported` | `4902666` | `Wh` (lifetime grid import) |
+| `pypowerwall/{gw}/grid_energy_exported` | `1469391` | `Wh` (lifetime grid export) |
+| `pypowerwall/{gw}/home_energy_imported` | `11679089` | `Wh` (lifetime home consumption) |
+| `pypowerwall/{gw}/solar_energy_exported` | `8337073` | `Wh` (lifetime solar production) |
+| `pypowerwall/{gw}/battery_energy_imported` | `4803385` | `Wh` (lifetime battery charged) |
+| `pypowerwall/{gw}/battery_energy_exported` | `4712126` | `Wh` (lifetime battery discharged) |
+
+*These are lifetime totals (same semantics as PW2's counters) — daily-energy
+dashboards should delta them, or use the HA Energy dashboard which does this
+automatically via `state_class: total_increasing`.*
+
 ### Full JSON topics (for advanced consumers)
 
 | Topic | Value |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,14 @@
 
 ## Version History
 
+### [0.4.3] - 2026-08-16
+
+**Added:**
+- **Lifetime energy MQTT topics + Home Assistant sensors** — six lifetime energy accumulators (Wh) from `/api/meters/aggregates` are now published as scalar MQTT topics and exposed as HA auto-discovery sensors (`device_class: energy`, `state_class: total_increasing`): `grid_energy_imported`, `grid_energy_exported`, `home_energy_imported`, `solar_energy_exported`, `battery_energy_imported`, `battery_energy_exported`. Topic names follow the existing scalar convention (aggregates `site` → `grid`, `load` → `home`). With `state_class: total_increasing` the HA Energy dashboard charts them directly — daily stats are derived by delta, the same semantics as PW2's lifetime counters. Gateways whose firmware lacks the endpoint keep reporting `0`, mirroring the HTTP API.
+
+**Changed:**
+- **Bumped `pypowerwall` dependency to `0.16.5`** (from `0.16.2`). On PW3/TEDAPI this release overlays the lifetime `energy_imported` / `energy_exported` accumulators onto `/api/meters/aggregates` using the gateway's native local API (customer login), with thread-safety hardening (bounded lock acquisition, double-checked cache, host affinity) — see pypowerwall PR #372. This is what populates the new energy topics on PW3; PW2/local mode has always carried these fields.
+
 ### [0.4.2] - 2026-07-19
 
 **Changed:**

--- a/app/config.py
+++ b/app/config.py
@@ -178,7 +178,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.4.2"
+SERVER_VERSION = "0.4.3"
 
 
 class GatewayConfig(BaseModel):

--- a/app/mqtt/ha_discovery.py
+++ b/app/mqtt/ha_discovery.py
@@ -29,6 +29,14 @@ Solar string sensors (when string_ids provided):
     strings/{AB}/current  — Paired-string current (A, sum of pair)
     strings/{AB}/power    — Paired-string power (W, sum of pair)
 
+Lifetime energy sensors (Wh, device_class=energy, state_class=total_increasing):
+    grid_energy_imported     — Grid energy imported, lifetime (from aggregates site)
+    grid_energy_exported     — Grid energy exported, lifetime (from aggregates site)
+    home_energy_imported     — Home energy consumption, lifetime (from aggregates load)
+    solar_energy_exported    — Solar energy production, lifetime (from aggregates solar)
+    battery_energy_imported  — Battery energy charged, lifetime
+    battery_energy_exported  — Battery energy discharged, lifetime
+
 Text sensors:
     grid_status — "UP" | "DOWN" | "unknown"
     mode        — Operation mode string (e.g. "self_consumption", "backup")
@@ -222,6 +230,59 @@ def build_discovery_payloads(
             unit="%",
             state_class="measurement",
             icon="mdi:battery-lock",
+        ),
+        # --- Lifetime energy sensors (Wh, total_increasing) ---
+        # Lifetime accumulators from /api/meters/aggregates — on PW3/TEDAPI
+        # these are overlaid by pypowerwall>=0.16.5 from the gateway's native
+        # local API.  state_class=total_increasing lets the HA Energy dashboard
+        # chart them directly (daily stats are derived by delta, same as PW2).
+        sensor(
+            "grid_energy_imported", "Grid Energy Imported",
+            f"{data_prefix}/grid_energy_imported",
+            unit="Wh",
+            device_class="energy",
+            state_class="total_increasing",
+            icon="mdi:transmission-tower-import",
+        ),
+        sensor(
+            "grid_energy_exported", "Grid Energy Exported",
+            f"{data_prefix}/grid_energy_exported",
+            unit="Wh",
+            device_class="energy",
+            state_class="total_increasing",
+            icon="mdi:transmission-tower-export",
+        ),
+        sensor(
+            "home_energy_imported", "Home Energy Consumption",
+            f"{data_prefix}/home_energy_imported",
+            unit="Wh",
+            device_class="energy",
+            state_class="total_increasing",
+            icon="mdi:home-lightning-bolt",
+        ),
+        sensor(
+            "solar_energy_exported", "Solar Energy Production",
+            f"{data_prefix}/solar_energy_exported",
+            unit="Wh",
+            device_class="energy",
+            state_class="total_increasing",
+            icon="mdi:solar-power",
+        ),
+        sensor(
+            "battery_energy_imported", "Battery Energy Charged",
+            f"{data_prefix}/battery_energy_imported",
+            unit="Wh",
+            device_class="energy",
+            state_class="total_increasing",
+            icon="mdi:battery-charging",
+        ),
+        sensor(
+            "battery_energy_exported", "Battery Energy Discharged",
+            f"{data_prefix}/battery_energy_exported",
+            unit="Wh",
+            device_class="energy",
+            state_class="total_increasing",
+            icon="mdi:battery-minus",
         ),
         # --- Text sensors ---
         sensor(

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -45,6 +45,13 @@ Topic layout
     {prefix}/{gateway_id}/status          JSON   — summary dict
     {prefix}/{gateway_id}/availability    str    — "online" | "offline" (LWT)
 
+    {prefix}/{gateway_id}/grid_energy_imported     float — Wh, lifetime grid import
+    {prefix}/{gateway_id}/grid_energy_exported     float — Wh, lifetime grid export
+    {prefix}/{gateway_id}/home_energy_imported     float — Wh, lifetime home consumption
+    {prefix}/{gateway_id}/solar_energy_exported    float — Wh, lifetime solar production
+    {prefix}/{gateway_id}/battery_energy_imported  float — Wh, lifetime battery charged
+    {prefix}/{gateway_id}/battery_energy_exported  float — Wh, lifetime battery discharged
+
     {prefix}/{gateway_id}/strings/{A-F}/voltage   float — V
     {prefix}/{gateway_id}/strings/{A-F}/current   float — A
     {prefix}/{gateway_id}/strings/{A-F}/power     float — W
@@ -262,6 +269,29 @@ class MqttPublisher:
                         json.dumps(agg),
                         retain, qos,
                     )
+
+                    # Lifetime energy accumulators (Wh).  PW3/TEDAPI gateways
+                    # get these overlaid onto aggregates by pypowerwall>=0.16.5
+                    # (native gateway endpoint); PW2/local mode has always
+                    # carried them.  Topic names follow the server's scalar
+                    # power convention (site -> grid, load -> home) and mirror
+                    # exactly what /api/meters/aggregates reports — including
+                    # 0 on gateways whose firmware lacks the endpoint.
+                    for topic_suffix, section, field in (
+                        ("grid_energy_imported", "site", "energy_imported"),
+                        ("grid_energy_exported", "site", "energy_exported"),
+                        ("home_energy_imported", "load", "energy_imported"),
+                        ("solar_energy_exported", "solar", "energy_exported"),
+                        ("battery_energy_imported", "battery", "energy_imported"),
+                        ("battery_energy_exported", "battery", "energy_exported"),
+                    ):
+                        energy_val = _extract_energy(agg, section, field)
+                        if energy_val is not None:
+                            await self._safe_publish(
+                                f"{prefix}/{topic_suffix}",
+                                f"{energy_val:.0f}",
+                                retain, qos,
+                            )
 
                 if data.grid_status is not None:
                     await self._safe_publish(
@@ -544,6 +574,15 @@ def _extract_power(aggregates: dict, key: str) -> Optional[float]:
         return float(aggregates[key]["instant_power"])
     except (KeyError, TypeError, ValueError):
         return None
+
+
+def _extract_energy(aggregates: dict, section: str, field: str) -> Optional[float]:
+    """Safely extract a lifetime energy accumulator (Wh) from aggregates."""
+    try:
+        val = aggregates[section][field]
+    except (KeyError, TypeError):
+        return None
+    return _safe_float(val)
 
 
 # Module-level singleton — imported by gateway_manager and main.py

--- a/app/mqtt/publisher.py
+++ b/app/mqtt/publisher.py
@@ -45,12 +45,12 @@ Topic layout
     {prefix}/{gateway_id}/status          JSON   — summary dict
     {prefix}/{gateway_id}/availability    str    — "online" | "offline" (LWT)
 
-    {prefix}/{gateway_id}/grid_energy_imported     float — Wh, lifetime grid import
-    {prefix}/{gateway_id}/grid_energy_exported     float — Wh, lifetime grid export
-    {prefix}/{gateway_id}/home_energy_imported     float — Wh, lifetime home consumption
-    {prefix}/{gateway_id}/solar_energy_exported    float — Wh, lifetime solar production
-    {prefix}/{gateway_id}/battery_energy_imported  float — Wh, lifetime battery charged
-    {prefix}/{gateway_id}/battery_energy_exported  float — Wh, lifetime battery discharged
+    {prefix}/{gateway_id}/grid_energy_imported     int — Wh, lifetime grid import (whole Wh, no decimals)
+    {prefix}/{gateway_id}/grid_energy_exported     int — Wh, lifetime grid export (whole Wh, no decimals)
+    {prefix}/{gateway_id}/home_energy_imported     int — Wh, lifetime home consumption (whole Wh, no decimals)
+    {prefix}/{gateway_id}/solar_energy_exported    int — Wh, lifetime solar production (whole Wh, no decimals)
+    {prefix}/{gateway_id}/battery_energy_imported  int — Wh, lifetime battery charged (whole Wh, no decimals)
+    {prefix}/{gateway_id}/battery_energy_exported  int — Wh, lifetime battery discharged (whole Wh, no decimals)
 
     {prefix}/{gateway_id}/strings/{A-F}/voltage   float — V
     {prefix}/{gateway_id}/strings/{A-F}/current   float — A
@@ -576,7 +576,7 @@ def _extract_power(aggregates: dict, key: str) -> Optional[float]:
         return None
 
 
-def _extract_energy(aggregates: dict, section: str, field: str) -> Optional[float]:
+def _extract_energy(aggregates: Optional[dict], section: str, field: str) -> Optional[float]:
     """Safely extract a lifetime energy accumulator (Wh) from aggregates."""
     try:
         val = aggregates[section][field]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.4.2"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.4.3"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [
@@ -30,7 +30,7 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "pydantic>=2.11.0",
     "pydantic-settings>=2.9.0",
-    "pypowerwall>=0.15.12",
+    "pypowerwall>=0.16.5",
     "websockets>=13.1",
     "psutil>=6.1.0",
     "beautifulsoup4>=4.12.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.12
 uvicorn[standard]==0.29.0
 pydantic==2.11.3
 pydantic-settings==2.9.1
-pypowerwall==0.16.2
+pypowerwall==0.16.5
 websockets==13.1
 psutil==6.1.1
 beautifulsoup4==4.12.3

--- a/tests/test_mqtt_ha_discovery.py
+++ b/tests/test_mqtt_ha_discovery.py
@@ -72,8 +72,8 @@ class TestBuildDiscoveryPayloads:
 
     def test_returns_expected_count(self):
         results = self._payloads()
-        # 10 sensors + 1 binary sensor = 11
-        assert len(results) == 11
+        # 16 sensors + 1 binary sensor = 17
+        assert len(results) == 17
 
     def test_all_topics_start_with_ha_prefix(self):
         results = self._payloads(ha_prefix="homeassistant")
@@ -135,6 +135,35 @@ class TestBuildDiscoveryPayloads:
         assert p["unit_of_measurement"] == "W"
         assert p["device_class"] == "power"
 
+    def test_lifetime_energy_sensors_present(self):
+        """All six lifetime energy sensors are discovered."""
+        results = dict(self._payloads())
+        for uid in (
+            "grid_energy_imported", "grid_energy_exported",
+            "home_energy_imported", "solar_energy_exported",
+            "battery_energy_imported", "battery_energy_exported",
+        ):
+            assert f"homeassistant/sensor/pypowerwall_home_{uid}/config" in results
+
+    def test_energy_sensor_fields(self):
+        """Energy sensors carry Wh / energy / total_increasing for the HA Energy dashboard."""
+        results = dict(self._payloads())
+        checks = {
+            "grid_energy_imported": "pypowerwall/home/grid_energy_imported",
+            "grid_energy_exported": "pypowerwall/home/grid_energy_exported",
+            "home_energy_imported": "pypowerwall/home/home_energy_imported",
+            "solar_energy_exported": "pypowerwall/home/solar_energy_exported",
+            "battery_energy_imported": "pypowerwall/home/battery_energy_imported",
+            "battery_energy_exported": "pypowerwall/home/battery_energy_exported",
+        }
+        for uid, state_topic in checks.items():
+            p = results[f"homeassistant/sensor/pypowerwall_home_{uid}/config"]
+            assert p["unit_of_measurement"] == "Wh", uid
+            assert p["device_class"] == "energy", uid
+            assert p["state_class"] == "total_increasing", uid
+            assert p["state_topic"] == state_topic, uid
+            assert p["unique_id"] == f"pypowerwall_home_{uid}", uid
+
     def test_version_sensor_is_diagnostic(self):
         results = dict(self._payloads())
         topic = "homeassistant/sensor/pypowerwall_home_version/config"
@@ -194,7 +223,7 @@ class TestBuildDiscoveryPayloads:
             ha_prefix="homeassistant",
             version=None,
         )
-        assert len(results) == 11
+        assert len(results) == 17
         for _, payload_str in results:
             p = json.loads(payload_str)
             assert p["device"]["sw_version"] == "unknown"
@@ -209,7 +238,7 @@ class TestBuildDiscoveryPayloads:
         )
         string_topics = [t for t, _ in results if "_string_" in t]
         assert string_topics == []
-        assert len(results) == 11
+        assert len(results) == 17
 
     def test_string_sensors_single_pw3(self):
         """Six strings A–F → 6×3 per-string + 3×3 paired rollup = 27 extra entries."""
@@ -222,8 +251,8 @@ class TestBuildDiscoveryPayloads:
             string_ids=string_ids,
         )
         payloads = {t: json.loads(p) for t, p in results}
-        # 11 base + 6 strings × 3 metrics + 3 pairs × 3 metrics = 11 + 18 + 9 = 38
-        assert len(results) == 38
+        # 17 base + 6 strings × 3 metrics + 3 pairs × 3 metrics = 17 + 18 + 9 = 44
+        assert len(results) == 44
 
         # Spot-check string A voltage
         topic = "homeassistant/sensor/pypowerwall_home_string_a_voltage/config"
@@ -254,7 +283,7 @@ class TestBuildDiscoveryPayloads:
         )
         payloads = {t: json.loads(p) for t, p in results}
         # 11 base + 2×3 per-string + 1 pair (AB) × 3 = 11 + 6 + 3 = 20
-        assert len(results) == 20
+        assert len(results) == 26
         # AB pair present
         assert "homeassistant/sensor/pypowerwall_home_string_ab_voltage/config" in payloads
         # CD and EF pairs must NOT be present (C/D/E/F not in string_ids)
@@ -273,7 +302,7 @@ class TestBuildDiscoveryPayloads:
         )
         payloads = {t: json.loads(p) for t, p in results}
         # 11 base + 12×3 per-string + 6 pairs × 3 = 11 + 36 + 18 = 65
-        assert len(results) == 65
+        assert len(results) == 71
         # Spot-check numbered pair AB1
         assert "homeassistant/sensor/pypowerwall_home_string_ab1_voltage/config" in payloads
         assert "homeassistant/sensor/pypowerwall_home_string_ab2_power/config" in payloads
@@ -307,7 +336,7 @@ class TestPublisherHaDiscovery:
 
         topics = [c.args[0] for c in mock_client.publish.call_args_list]
         disc_topics = [t for t in topics if "homeassistant" in t]
-        assert len(disc_topics) == 11  # one per sensor/binary_sensor
+        assert len(disc_topics) == 17  # one per sensor/binary_sensor
 
     @pytest.mark.asyncio
     async def test_discovery_sent_only_once_per_connection(self, monkeypatch):
@@ -354,7 +383,7 @@ class TestPublisherHaDiscovery:
             for c in mock_client.publish.call_args_list
             if "homeassistant" in c.args[0]
         ]
-        assert len(disc_topics) == 11
+        assert len(disc_topics) == 17
 
     @pytest.mark.asyncio
     async def test_discovery_skipped_when_ha_discovery_false(self, monkeypatch):

--- a/tests/test_mqtt_ha_discovery.py
+++ b/tests/test_mqtt_ha_discovery.py
@@ -282,7 +282,7 @@ class TestBuildDiscoveryPayloads:
             string_ids=string_ids,
         )
         payloads = {t: json.loads(p) for t, p in results}
-        # 11 base + 2×3 per-string + 1 pair (AB) × 3 = 11 + 6 + 3 = 20
+        # 17 base + 2×3 per-string + 1 pair (AB) × 3 = 17 + 6 + 3 = 26
         assert len(results) == 26
         # AB pair present
         assert "homeassistant/sensor/pypowerwall_home_string_ab_voltage/config" in payloads
@@ -301,7 +301,7 @@ class TestBuildDiscoveryPayloads:
             string_ids=string_ids,
         )
         payloads = {t: json.loads(p) for t, p in results}
-        # 11 base + 12×3 per-string + 6 pairs × 3 = 11 + 36 + 18 = 65
+        # 17 base + 12×3 per-string + 6 pairs × 3 = 17 + 36 + 18 = 71
         assert len(results) == 71
         # Spot-check numbered pair AB1
         assert "homeassistant/sensor/pypowerwall_home_string_ab1_voltage/config" in payloads

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -666,4 +666,4 @@ class TestExtractEnergy:
         assert _extract_energy(agg, "solar", "energy_exported") is None
 
     def test_none_aggregates(self):
-        assert _extract_energy(None, "site", "energy_imported") is None  # type: ignore[arg-type]
+        assert _extract_energy(None, "site", "energy_imported") is None

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.models.gateway import Gateway, GatewayStatus, PowerwallData
-from app.mqtt.publisher import MqttPublisher, _extract_power
+from app.mqtt.publisher import MqttPublisher, _extract_energy, _extract_power
 
 
 # ---------------------------------------------------------------------------
@@ -574,3 +574,96 @@ class TestMqttStringTopics:
 
         # Individual A1 topic also published
         assert published["pypowerwall/test-gw/strings/A1/voltage"] == "310.00"
+
+
+# ---------------------------------------------------------------------------
+# Lifetime energy accumulator topics (Wh) — pypowerwall>=0.16.5 PW3 overlay
+# ---------------------------------------------------------------------------
+
+def _status_with_energy() -> GatewayStatus:
+    """Status whose aggregates carry lifetime energy fields (PW3, pypowerwall>=0.16.5)."""
+    status = make_status()
+    agg = status.data.aggregates
+    agg["site"]["energy_imported"] = 4902666.25
+    agg["site"]["energy_exported"] = 1469391.0
+    agg["load"]["energy_imported"] = 11679089.0
+    agg["solar"]["energy_exported"] = 8337073.0
+    agg["battery"]["energy_imported"] = 4803385.0
+    agg["battery"]["energy_exported"] = 4712126.0
+    return status
+
+
+class TestLifetimeEnergyTopics:
+    @pytest.mark.asyncio
+    async def test_energy_topics_published(self, monkeypatch):
+        """All six lifetime energy topics are published with integer-Wh payloads."""
+        pub = TestMqttPublisherEnabled()._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        await pub.publish_gateway("test-gw", _status_with_energy())
+
+        published = {c.args[0]: c.args[1] for c in mock_client.publish.call_args_list}
+        assert published["pypowerwall/test-gw/grid_energy_imported"] == "4902666"
+        assert published["pypowerwall/test-gw/grid_energy_exported"] == "1469391"
+        assert published["pypowerwall/test-gw/home_energy_imported"] == "11679089"
+        assert published["pypowerwall/test-gw/solar_energy_exported"] == "8337073"
+        assert published["pypowerwall/test-gw/battery_energy_imported"] == "4803385"
+        assert published["pypowerwall/test-gw/battery_energy_exported"] == "4712126"
+
+    @pytest.mark.asyncio
+    async def test_energy_topics_absent_when_fields_missing(self, monkeypatch):
+        """Legacy aggregates without energy fields publish no energy topics."""
+        pub = TestMqttPublisherEnabled()._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        await pub.publish_gateway("test-gw", make_status())
+
+        published = {c.args[0] for c in mock_client.publish.call_args_list}
+        for suffix in (
+            "grid_energy_imported", "grid_energy_exported",
+            "home_energy_imported", "solar_energy_exported",
+            "battery_energy_imported", "battery_energy_exported",
+        ):
+            assert f"pypowerwall/test-gw/{suffix}" not in published
+
+    @pytest.mark.asyncio
+    async def test_zero_energy_published_when_reported(self, monkeypatch):
+        """A gateway whose firmware lacks the endpoint reports 0 — mirrored verbatim."""
+        pub = TestMqttPublisherEnabled()._make_publisher(monkeypatch)
+        mock_client = AsyncMock()
+        pub._client = mock_client
+        pub._connected = True
+
+        status = make_status()
+        status.data.aggregates["site"]["energy_imported"] = 0
+        await pub.publish_gateway("test-gw", status)
+
+        published = {c.args[0]: c.args[1] for c in mock_client.publish.call_args_list}
+        assert published["pypowerwall/test-gw/grid_energy_imported"] == "0"
+
+
+class TestExtractEnergy:
+    def test_normal_value(self):
+        agg = {"site": {"energy_imported": 4902666.25}}
+        assert _extract_energy(agg, "site", "energy_imported") == pytest.approx(4902666.25)
+
+    def test_zero_is_valid(self):
+        agg = {"site": {"energy_imported": 0}}
+        assert _extract_energy(agg, "site", "energy_imported") == 0.0
+
+    def test_missing_section(self):
+        assert _extract_energy({}, "site", "energy_imported") is None
+
+    def test_missing_field(self):
+        assert _extract_energy({"site": {}}, "site", "energy_imported") is None
+
+    def test_non_numeric_value(self):
+        agg = {"solar": {"energy_exported": "bad"}}
+        assert _extract_energy(agg, "solar", "energy_exported") is None
+
+    def test_none_aggregates(self):
+        assert _extract_energy(None, "site", "energy_imported") is None  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Follow-up to jasonacox/pypowerwall#372 (lifetime energy accumulators merged into `/api/meters/aggregates` on PW3/TEDAPI, shipped in pypowerwall 0.16.5): this pulls the new library version into the server and exposes the lifetime energy counters as first-class MQTT topics + Home Assistant sensors — the change discussed with @cavedon in that thread ("Will these metrics be automatically pushed via MQTT?").

**Changed:**
- **`pypowerwall` dependency `0.16.2` → `0.16.5`** (requirements.txt pin + pyproject floor). This is what populates the lifetime `energy_imported` / `energy_exported` fields on PW3 — the library overlays them from the gateway's native local API. PW2/local mode has always carried them. (The full aggregates JSON topic already reflects this automatically; this PR adds the curated part.)

**Added:**
- **Six lifetime energy MQTT topics (Wh)**, following the existing scalar topic convention (aggregates `site` → `grid`, `load` → `home`):

  | Topic | Meaning |
  |---|---|
  | `{prefix}/{gw}/grid_energy_imported` | lifetime grid import |
  | `{prefix}/{gw}/grid_energy_exported` | lifetime grid export |
  | `{prefix}/{gw}/home_energy_imported` | lifetime home consumption |
  | `{prefix}/{gw}/solar_energy_exported` | lifetime solar production |
  | `{prefix}/{gw}/battery_energy_imported` | lifetime battery charged |
  | `{prefix}/{gw}/battery_energy_exported` | lifetime battery discharged |

- **Six HA auto-discovery sensors** for those topics — `device_class: energy`, `state_class: total_increasing`, unit Wh — so they chart directly in the HA Energy dashboard (daily stats derived by delta, same semantics as PW2's lifetime counters).

**Semantics / edge cases:**
- Lifetime totals in Wh, monotonically increasing — same as PW2's counters. Daily-energy consumers delta them (HA does this automatically with `total_increasing`).
- Gateways whose firmware lacks the native endpoint report `0` — the topics mirror exactly what `/api/meters/aggregates` reports over HTTP, no invention.
- Missing fields (older payloads) simply publish no energy topic.
- Version bumped to `0.4.3` with RELEASE.md entry in prep for merge.

**Tests:** full suite green — 243 passed (was 236). New: publisher energy-topic tests (publish, absent-when-missing, zero-mirroring, `_extract_energy` unit tests) and HA discovery tests (all six sensors present with energy/total_increasing/Wh/state-topic checks; entity-count assertions updated 11 → 17).

Fixes the MQTT/HA half of the request from jasonacox/pypowerwall#372 (comment thread); no separate ticket needed.

— Sam ⚡
