### PR TITLE
feat(timeseries): TimeSeriesStore — persistent daily energy stats (SQLite, UI panel, API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,7 @@ tedapi_rsa_private.pem
 
 # Local gateway config (may contain credentials)
 gateways.yaml
+
+# Time-series runtime artifacts (local runs from source)
+tmp/
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,13 @@ RUN apt-get update && \
 # Copy application
 COPY app/ ./app/
 
+# Persistent data mount point for the time-series SQLite store
+# (PW_TIMESERIES_PATH defaults to /data/timeseries.db). Mount a volume
+# here to keep daily energy history across container rebuilds:
+#   docker run ... -v pws-data:/data ...
+RUN mkdir -p /data
+VOLUME /data
+
 # Expose port
 EXPOSE 8675
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,13 @@ integration: solar, home consumption, battery charge/discharge, grid
 import/export — each tracked directionally (never netted). Totals reset at
 local midnight using each gateway's configured timezone, survive restarts,
 and show in the web console's **Daily Energy** panel plus the
-`/api/timeseries/*` endpoints. Raw samples are pruned to the retention
+`/api/timeseries/*` endpoints. Raw samples also capture battery level
+(state of charge) per poll — kept for the raw retention window only, never
+downsampled into daily aggregates. Clicking the console's **Energy Summary**
+panel toggles it into an **Energy Trend** view: the last 24 hours of raw
+data charted as Solar/Home/Battery/Grid kW (shared left axis) plus Battery
+Level % (dashed, right axis), using the standard color coding. Raw samples
+are pruned to the retention
 window (keeping the last hour for troubleshooting); daily aggregates are one
 tiny row per gateway per day (~100 B/day) so unlimited retention is the
 sensible default. Intervals longer than 1 hour (outage/gap) are never
@@ -465,7 +471,8 @@ All existing proxy endpoints work unchanged:
 **Time-Series Endpoints (Daily Energy):**
 - `GET /api/timeseries/today` - Today's running kWh totals per gateway
 - `GET /api/timeseries/daily?days=7` - Daily kWh totals (per gateway/category)
-- `GET /api/timeseries/samples` - Raw samples (troubleshooting; filters: `gateway`, `start`, `end`, `limit`)
+- `GET /api/timeseries/trend?hours=24` - Bucketed kW + battery level for charting (per-gateway mean, summed across gateways)
+- `GET /api/timeseries/samples` - Raw samples (troubleshooting; filters: `gateway`, `start`, `end`, `limit`) — includes battery level (`soe`)
 - `GET /api/timeseries/status` - Subsystem status, retention settings, DB size
 
 All report `{"enabled": false, ...}` when disabled (`PW_TIMESERIES_RETENTION=-1`).

--- a/README.md
+++ b/README.md
@@ -193,6 +193,27 @@ exponential backoff (60s → 300s max). Fallback state is exposed in `/health`
 and `/stats`. `POST /health/reset` clears fallback state (requires
 `PW_CONTROL_SECRET`). Only active in TEDAPI mode — no overhead for Cloud/FleetAPI.
 
+**Time-Series Storage (Daily Energy Stats):**
+```bash
+PW_TIMESERIES_RETENTION=24h            # Raw 5s sample retention (default: 24h)
+PW_TIMESERIES_DAILY_RETENTION=0        # Daily kWh aggregate retention (default: 0 = unlimited)
+PW_TIMESERIES_PATH=/data/timeseries.db  # SQLite path (default: /data/timeseries.db if /data exists)
+```
+The server records every poll cycle's power readings to a local SQLite
+store (WAL mode) and derives daily energy totals per gateway via trapezoidal
+integration: solar, home consumption, battery charge/discharge, grid
+import/export — each tracked directionally (never netted). Totals reset at
+local midnight using each gateway's configured timezone, survive restarts,
+and show in the web console's **Daily Energy** panel plus the
+`/api/timeseries/*` endpoints. Raw samples are pruned to the retention
+window (keeping the last hour for troubleshooting); daily aggregates are one
+tiny row per gateway per day (~100 B/day) so unlimited retention is the
+sensible default. Intervals longer than 1 hour (outage/gap) are never
+integrated — no fabricated energy. Set `PW_TIMESERIES_RETENTION=-1` to
+disable the subsystem entirely for headless proxy deployments (no SQLite
+file, no writes, UI panel hidden). Retention accepts `90s`, `48h`, `7d`,
+`30d`, `365d` style values; `0` = unlimited.
+
 ### Configuration File (gateways.yaml)
 
 Pass a YAML (or JSON) config file with `--config gateways.yaml` or
@@ -440,6 +461,14 @@ All existing proxy endpoints work unchanged:
 - `GET /api/aggregate/power` - Combined power across all gateways
 - `GET /api/aggregate/soe` - Total battery capacity and charge
 - `GET /api/aggregate/status` - Health status of all gateways
+
+**Time-Series Endpoints (Daily Energy):**
+- `GET /api/timeseries/today` - Today's running kWh totals per gateway
+- `GET /api/timeseries/daily?days=7` - Daily kWh totals (per gateway/category)
+- `GET /api/timeseries/samples` - Raw samples (troubleshooting; filters: `gateway`, `start`, `end`, `limit`)
+- `GET /api/timeseries/status` - Subsystem status, retention settings, DB size
+
+All report `{"enabled": false, ...}` when disabled (`PW_TIMESERIES_RETENTION=-1`).
 
 **WebSocket Endpoints:**
 - `WS /ws/gateway/{id}` - Real-time data stream for specific gateway

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,23 @@
 
 ## Version History
 
+### [0.5.0] - 2026-08-23
+
+**Added:**
+- **Persistent time-series energy stats (TimeSeriesStore)** — new SQLite-backed store that records raw power samples (solar, home, battery, grid, battery charge level) every poll cycle, and downsamples them into persistent daily energy totals (kWh imported/exported/charged/discharged) per gateway. Data survives restarts — daily totals resume from persisted values and keep accruing with no reset or double counting. Storage is bounded: raw samples are kept for a configurable retention window (battery charge level is raw-only, never downsampled), daily aggregates are kept indefinitely.
+- **Daily Energy panel** — new dashboard panel showing today's Solar, Home, Battery Charged/Discharged, and Grid Import/Export totals, using the standard Energy Summary color palette (solar yellow, home blue, battery green, grid gray) via the same CSS variables.
+- **Energy Summary ↔ Energy Trend flip panel** — click the Energy Summary card to flip it in place into an Energy Trend panel (same footprint, no layout shift — panels below never move). The trend chart plots the last 24 hours of raw data with Solar/Home/Battery/Grid kW on the shared left axis (translucent fill to zero) and Battery Level % as a dashed line on the right axis, in standard colors. Time scale options: 30m · 1hr · 3hr · 6hr · 12hr · 24hr (rolling), full local day 0:00–23:59 (default), Day, and "Fit" (all retained data). Click again ("click for summary") to flip back.
+- **Time-series API endpoints:**
+  - `GET /api/timeseries/samples` — raw sample rows (includes `soe` battery level)
+  - `GET /api/timeseries/daily` — persisted daily energy totals
+  - `GET /api/timeseries/trend` — chart-ready bucket aggregation for the trend panel (~360 points regardless of span; supports `hours`, `start`/`end`, `fit`, per-gateway sums for multi-gateway fleets)
+  - `GET /api/timeseries/status` — store health: row counts, retention, `write_failures` counter, DB filename (full path masked)
+
+**Fixed:**
+- **Timezone-correct daily buckets** — daily rows are keyed by local day, so evening local-day samples west of UTC are no longer split into the wrong day row.
+- **Poll-loop resilience** — sample writes run in a dedicated worker thread with a 5s `asyncio.wait_for` guard, so a hung SQLite write (e.g. full disk on an SBC) can never stall gateway polling. Write failures log a rate-limited warning (once per 5 min) and increment the visible `write_failures` counter.
+- **Clean shutdown** — executor shutdown uses `cancel_futures=True` so queued writes can't reopen the DB after close; a clean SIGTERM checkpoints the WAL.
+
 ### [0.4.3] - 2026-08-16
 
 **Added:**

--- a/app/api/timeseries.py
+++ b/app/api/timeseries.py
@@ -17,9 +17,12 @@ Query Parameters:
              gateway (str, optional) — restrict to a single gateway ID
     today:   none — returns every configured gateway's running totals
     trend:   hours (int, default 24, max 168) — window length; gateway
-             (str, optional) restricts to one gateway. Returns ~360
-             bucket-averaged points: solar/home/battery/grid kW plus mean
-             battery level (%) per bucket.
+             (str, optional) restricts to one gateway. start (unix ts,
+             optional) overrides hours with an explicit window start;
+             end (unix ts, optional) explicit window end (default now);
+             fit (bool, optional, default false) uses all retained raw
+             data. Returns ~360 bucket-averaged points: solar/home/
+             battery/grid kW plus mean battery level (%) per bucket.
     samples: gateway (str, optional), start (unix ts), end (unix ts),
              limit (int, default 500, max 10000)
 
@@ -87,6 +90,9 @@ async def get_today():
 async def get_trend(
     hours: int = Query(default=24, ge=1, le=168),
     gateway: Optional[str] = Query(default=None),
+    start: Optional[float] = Query(default=None),
+    end: Optional[float] = Query(default=None),
+    fit: bool = Query(default=False),
 ):
     """Bucketed time series of power (kW) and battery level (%) for charts.
 
@@ -96,7 +102,9 @@ async def get_trend(
     is mean state of charge per bucket (raw-sample only, never persisted
     into daily aggregates).
     """
-    return await get_timeseries_store().get_trend(hours=hours, gateway=gateway)
+    return await get_timeseries_store().get_trend(
+        hours=hours, gateway=gateway, start=start, end=end, fit=fit
+    )
 
 
 @router.get("/samples")

--- a/app/api/timeseries.py
+++ b/app/api/timeseries.py
@@ -8,6 +8,7 @@ All routes are prefixed with /api/timeseries (configured in main.py).
 Routes:
     - GET /api/timeseries/daily   -> Daily kWh totals per gateway/category
     - GET /api/timeseries/today   -> Today's running totals for all gateways
+    - GET /api/timeseries/trend   -> Bucketed kW + battery level (charting)
     - GET /api/timeseries/samples -> Raw samples (troubleshooting)
     - GET /api/timeseries/status  -> Subsystem status and DB sizing
 
@@ -15,6 +16,10 @@ Query Parameters:
     daily:   days (int, default 7)  — number of days back from today
              gateway (str, optional) — restrict to a single gateway ID
     today:   none — returns every configured gateway's running totals
+    trend:   hours (int, default 24, max 168) — window length; gateway
+             (str, optional) restricts to one gateway. Returns ~360
+             bucket-averaged points: solar/home/battery/grid kW plus mean
+             battery level (%) per bucket.
     samples: gateway (str, optional), start (unix ts), end (unix ts),
              limit (int, default 500, max 10000)
 
@@ -28,6 +33,7 @@ Design Notes:
     - Endpoints return immediately; missing data yields empty lists, not
       errors, matching the degraded-gracefully style of the other APIs.
 """
+
 import time
 from typing import Optional
 
@@ -75,6 +81,22 @@ async def get_today():
         "gateways": out,
         "server_time": time.time(),
     }
+
+
+@router.get("/trend")
+async def get_trend(
+    hours: int = Query(default=24, ge=1, le=168),
+    gateway: Optional[str] = Query(default=None),
+):
+    """Bucketed time series of power (kW) and battery level (%) for charts.
+
+    Averages raw samples into ~4-minute buckets over the requested window
+    so a 24h view is ~360 points rather than ~17k rows. Battery kW is
+    positive = discharging, grid kW positive = importing; ``battery_level``
+    is mean state of charge per bucket (raw-sample only, never persisted
+    into daily aggregates).
+    """
+    return await get_timeseries_store().get_trend(hours=hours, gateway=gateway)
 
 
 @router.get("/samples")

--- a/app/api/timeseries.py
+++ b/app/api/timeseries.py
@@ -1,0 +1,96 @@
+"""
+Time-Series API Endpoints
+
+REST API for daily energy statistics and raw sample access backed by the
+TimeSeriesStore (SQLite, see app/core/timeseries.py).
+All routes are prefixed with /api/timeseries (configured in main.py).
+
+Routes:
+    - GET /api/timeseries/daily   -> Daily kWh totals per gateway/category
+    - GET /api/timeseries/today   -> Today's running totals for all gateways
+    - GET /api/timeseries/samples -> Raw samples (troubleshooting)
+    - GET /api/timeseries/status  -> Subsystem status and DB sizing
+
+Query Parameters:
+    daily:   days (int, default 7)  — number of days back from today
+             gateway (str, optional) — restrict to a single gateway ID
+    today:   none — returns every configured gateway's running totals
+    samples: gateway (str, optional), start (unix ts), end (unix ts),
+             limit (int, default 500, max 10000)
+
+All endpoints respond with {"enabled": false, ...} when the subsystem is
+disabled (PW_TIMESERIES_RETENTION=-1) so clients can hide the UI panel
+instead of erroring.
+
+Design Notes:
+    - All reads go through the store's single worker thread — they never
+      block or contend with the poll loop's writes (WAL mode).
+    - Endpoints return immediately; missing data yields empty lists, not
+      errors, matching the degraded-gracefully style of the other APIs.
+"""
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Query
+
+from app.core.gateway_manager import gateway_manager
+from app.core.timeseries import get_timeseries_store
+
+router = APIRouter()
+
+
+@router.get("/daily")
+async def get_daily_energy(
+    days: int = Query(default=7, ge=1, le=366),
+    gateway: Optional[str] = Query(default=None),
+):
+    """Daily energy totals (kWh) per gateway, most recent day first.
+
+    Each day entry contains one row per gateway that reported samples that
+    day, with directional kWh categories (solar, home, battery charge/
+    discharge, grid import/export).
+    """
+    return await get_timeseries_store().get_daily_energy(days=days, gateway=gateway)
+
+
+@router.get("/today")
+async def get_today():
+    """Today's running kWh totals for every configured gateway.
+
+    Uses each gateway's own timezone to determine 'today'. Gateways without
+    samples yet are omitted. Handy for the UI panel and quick checks:
+
+        {"enabled": true, "gateways": {"gw1": {...kWh...}}}
+    """
+    store = get_timeseries_store()
+    if not store.enabled:
+        return {"enabled": False, "gateways": {}}
+    out = {}
+    for gateway_id, gateway in gateway_manager.gateways.items():
+        row = await store.get_today(gateway_id, timezone=gateway.timezone)
+        if row is not None:
+            out[gateway_id] = row
+    return {
+        "enabled": True,
+        "gateways": out,
+        "server_time": time.time(),
+    }
+
+
+@router.get("/samples")
+async def get_samples(
+    gateway: Optional[str] = Query(default=None),
+    start: Optional[float] = Query(default=None),
+    end: Optional[float] = Query(default=None),
+    limit: int = Query(default=500, ge=1, le=10000),
+):
+    """Raw power samples, ascending by time (troubleshooting)."""
+    return await get_timeseries_store().get_samples(
+        gateway=gateway, start=start, end=end, limit=limit
+    )
+
+
+@router.get("/status")
+async def get_status():
+    """Time-series subsystem status: retention settings, DB size, row counts."""
+    return await get_timeseries_store().status()

--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,7 @@ Configuration Methods:
             "timezone": "America/Denver"
           }
         ]'
-    
+
     2. Single Gateway Configuration (legacy compatibility):
         export PW_HOST=192.168.91.1
         export PW_GW_PWD=gateway_wifi_password
@@ -38,19 +38,19 @@ Environment Variables (Proxy Compatible):
         PW_EMAIL             - Tesla account email for cloud mode (default: none)
         PW_TIMEZONE          - Local timezone (default: "America/Los_Angeles")
         PW_AUTH_PATH         - Path to auth token files (default: none)
-    
+
     Server Settings:
         PW_BIND_ADDRESS      - Server bind address (default: "0.0.0.0")
         PW_PORT              - Server port (default: 8675)
         PW_DEBUG             - Enable debug logging "yes"/"no" (default: "no")
         PW_HTTPS             - Enable HTTPS mode (default: "no")
-    
+
     Performance Settings:
         PW_CACHE_EXPIRE      - Polling frequency in seconds (default: 5)
         PW_BROWSER_CACHE     - Browser cache time in seconds (default: 0)
         PW_TIMEOUT           - Pypowerwall timeout in seconds (default: 10)
         PW_POOL_MAXSIZE      - Connection pool size (default: 15)
-    
+
     Network Robustness:
         PW_SUPPRESS_NETWORK_ERRORS  - Suppress error logs (default: "no")
         PW_NETWORK_ERROR_RATE_LIMIT - Errors per minute limit (default: 5)
@@ -60,17 +60,18 @@ Environment Variables (Proxy Compatible):
         PW_CACHE_TTL                - Max cached data age in seconds (default: 30)
         PW_TEDAPI_RECOVERY          - Auto-recover TEDAPI SolarOnly fallback (default: "yes")
         PW_TEDAPI_PROBE_INTERVAL    - Seconds between TEDAPI health probes (default: 30)
-    
+
     UI and Advanced:
         PW_STYLE             - UI style: clear/black/white/grafana/grafana-dark (default: "clear")
         PW_AUTH_MODE         - Auth mode: cookie/token (default: "cookie")
-        PW_CACHE_FILE        - Cache file path (default: auto - uses PW_AUTH_PATH/.powerwall or /tmp/.powerwall)\n        PW_SITEID            - Tesla site ID for multi-site accounts (default: none)
+        PW_CACHE_FILE        - Cache file path (default: auto - uses PW_AUTH_PATH/.powerwall or /tmp/.powerwall)
+        PW_SITEID            - Tesla site ID for multi-site accounts (default: none)
         PW_CONTROL_SECRET    - Enable control commands (default: none/disabled)
         PW_NEG_SOLAR         - Allow negative solar values "yes"/"no" (default: "no")
         PW_RSA_KEY_PATH      - Path to RSA-4096 private key PEM for TEDAPI v1r LAN access (default: none)
         PW_WIFI_HOST         - WiFi host IP for TEDAPI v1r WiFi fallback (default: none)
         PROXY_BASE_URL       - Base URL for reverse proxy (default: "/")
-    
+
     Time-Series Storage (Daily Energy Stats):
         PW_TIMESERIES_RETENTION       - Raw 5s sample retention, e.g. "24h" (default), "7d",
                                         "30d", "365d"; "0" = unlimited, "-1" = disable
@@ -89,13 +90,13 @@ Connection Modes:
         • Configuration: PW_HOST + PW_GW_PWD  (password-based)
         •            OR: PW_HOST + PW_GW_PWD + PW_RSA_KEY_PATH  (RSA key + v1r mode)
         • Example: 192.168.91.1 with gateway password (optionally with RSA PEM key for v1r mode)
-    
+
     Cloud Mode:
         • Remote access from anywhere
         • Requires Tesla account authentication
         • Configuration: PW_EMAIL + PW_AUTH_PATH
         • Setup: Run `python3 -m pypowerwall setup` first
-    
+
     FleetAPI Mode:
         • Official Tesla API
         • Requires app registration with Tesla
@@ -106,7 +107,7 @@ Gateway Configuration Priority:
     1. PW_GATEWAYS JSON (highest priority)
        - Supports multiple gateways with independent settings
        - Each gateway can have different connection modes
-       
+
     2. Legacy environment variables (fallback)
        - Single gateway using PW_HOST, PW_GW_PWD, etc.
        - Automatically creates "default" gateway
@@ -119,12 +120,12 @@ Examples:
     PW_GW_PWD=MyGatewayPassword
     PW_CACHE_EXPIRE=10
     PW_DEBUG=yes
-    
+
     # Single gateway (Cloud mode)
     PW_EMAIL=user@example.com
     PW_AUTH_PATH=/home/user/.pypowerwall
     PW_CACHE_EXPIRE=30
-    
+
     # Multiple gateways (mixed modes)
     PW_GATEWAYS='[
       {"id": "home", "host": "192.168.91.1", "gw_pwd": "pass1"},
@@ -139,12 +140,12 @@ Architecture:
         • Type validation and conversion
         • Default values for all settings
         • Computed properties (e.g., control_enabled)
-    
+
     GatewayConfig Class:
         • Defines single gateway configuration
         • Supports TEDAPI, Cloud, and FleetAPI modes
         • Used in both PW_GATEWAYS and legacy modes
-    
+
     Initialization Flow:
         1. Settings() loads all environment variables
         2. _initialize_gateways() called automatically
@@ -156,27 +157,28 @@ Adding New Settings:
 
     1. Add field to Settings class with Field() and alias:
         new_setting: int = Field(default=42, alias="PW_NEW_SETTING")
-    
+
     2. Document in this module docstring
-    
+
     3. Use in code via settings.new_setting
-    
+
     4. Update README with new variable
 
 Accessing Configuration:
 
     from app.config import settings
-    
+
     # Access settings
     port = settings.server_port
     gateways = settings.gateways
     debug_enabled = settings.debug
-    
+
     # Check features
     if settings.control_enabled:
         # Control commands available
         pass
 """
+
 import json
 import logging
 import os
@@ -207,14 +209,18 @@ class GatewayConfig(BaseModel):
     id: str
     name: Optional[str] = None  # Defaults to id when omitted
     host: Optional[str] = None
-    port: Optional[int] = Field(default=None, ge=1, le=65535)  # Non-standard HTTPS port (e.g. 8443 via travel router)
+    port: Optional[int] = Field(
+        default=None, ge=1, le=65535
+    )  # Non-standard HTTPS port (e.g. 8443 via travel router)
     gw_pwd: Optional[str] = None  # Gateway Wi-Fi password for TEDAPI mode
-    rsa_key_path: Optional[str] = None  # Path to RSA-4096 private key PEM for v1r LAN TEDAPI access
+    rsa_key_path: Optional[str] = (
+        None  # Path to RSA-4096 private key PEM for v1r LAN TEDAPI access
+    )
     wifi_host: Optional[str] = None  # WiFi host IP for TEDAPI v1r WiFi fallback
     email: Optional[str] = None
-    authpath: Optional[
-        str
-    ] = None  # Path to .pypowerwall.auth and .pypowerwall.site files
+    authpath: Optional[str] = (
+        None  # Path to .pypowerwall.auth and .pypowerwall.site files
+    )
     timezone: str = "America/Los_Angeles"
     cloud_mode: bool = False
     fleetapi: bool = False
@@ -469,8 +475,7 @@ class Settings(BaseSettings):
                 gateways_data = json.loads(gateways_json)
             except Exception as e:
                 logger.error(
-                    f"PW_GATEWAYS is not valid JSON ({e}) - "
-                    "no gateways configured"
+                    f"PW_GATEWAYS is not valid JSON ({e}) - " "no gateways configured"
                 )
                 return
             if not isinstance(gateways_data, list):

--- a/app/config.py
+++ b/app/config.py
@@ -64,13 +64,22 @@ Environment Variables (Proxy Compatible):
     UI and Advanced:
         PW_STYLE             - UI style: clear/black/white/grafana/grafana-dark (default: "clear")
         PW_AUTH_MODE         - Auth mode: cookie/token (default: "cookie")
-        PW_CACHE_FILE        - Cache file path (default: auto - uses PW_AUTH_PATH/.powerwall or /tmp/.powerwall)
-        PW_SITEID            - Tesla site ID for multi-site accounts (default: none)
+        PW_CACHE_FILE        - Cache file path (default: auto - uses PW_AUTH_PATH/.powerwall or /tmp/.powerwall)\n        PW_SITEID            - Tesla site ID for multi-site accounts (default: none)
         PW_CONTROL_SECRET    - Enable control commands (default: none/disabled)
         PW_NEG_SOLAR         - Allow negative solar values "yes"/"no" (default: "no")
         PW_RSA_KEY_PATH      - Path to RSA-4096 private key PEM for TEDAPI v1r LAN access (default: none)
         PW_WIFI_HOST         - WiFi host IP for TEDAPI v1r WiFi fallback (default: none)
         PROXY_BASE_URL       - Base URL for reverse proxy (default: "/")
+    
+    Time-Series Storage (Daily Energy Stats):
+        PW_TIMESERIES_RETENTION       - Raw 5s sample retention, e.g. "24h" (default), "7d",
+                                        "30d", "365d"; "0" = unlimited, "-1" = disable
+                                        the subsystem entirely (headless proxy, no SQLite,
+                                        no daily stats UI/API)
+        PW_TIMESERIES_DAILY_RETENTION - Daily kWh aggregate retention (default: "0" =
+                                        unlimited; one tiny row per gateway per day)
+        PW_TIMESERIES_PATH            - SQLite database path (default: /data/timeseries.db
+                                        when /data exists, else data/timeseries.db)
 
 Connection Modes:
 
@@ -291,6 +300,17 @@ class Settings(BaseSettings):
     # CORS configuration
     cors_origins: List[str] = Field(default=["*"], alias="CORS_ORIGINS")
 
+    # Time-series storage (TimeSeriesStore — daily energy stats, see app/core/timeseries.py)
+    timeseries_retention: str = Field(
+        default="24h", alias="PW_TIMESERIES_RETENTION"
+    )  # Raw sample retention; "-1" disables the subsystem, "0" = unlimited
+    timeseries_daily_retention: str = Field(
+        default="0", alias="PW_TIMESERIES_DAILY_RETENTION"
+    )  # Daily aggregate retention; "0" = unlimited (default)
+    timeseries_path: Optional[str] = Field(
+        default=None, alias="PW_TIMESERIES_PATH"
+    )  # SQLite file path; resolved in __init__ (/data aware)
+
     # MQTT settings
     # Set MQTT_HOST to enable MQTT publishing. All other MQTT_ variables are optional.
     mqtt_host: Optional[str] = Field(default=None, alias="MQTT_HOST")
@@ -334,6 +354,15 @@ class Settings(BaseSettings):
             else:
                 # Fall back to /tmp if no auth path
                 self.cache_file = "/tmp/.powerwall"
+        # Set default time-series database path: prefer a /data volume mount
+        # (the Docker image creates /data) so daily energy history survives
+        # container restarts; otherwise keep it local to the working dir.
+        if self.timeseries_path is None:
+            self.timeseries_path = (
+                "/data/timeseries.db"
+                if os.path.isdir("/data")
+                else "data/timeseries.db"
+            )
         self._initialize_gateways()
 
     def _load_config_file(self) -> bool:

--- a/app/config.py
+++ b/app/config.py
@@ -189,7 +189,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.4.3"
+SERVER_VERSION = "0.5.0"
 
 
 class GatewayConfig(BaseModel):

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -1139,7 +1139,9 @@ class GatewayManager:
         Runs after the cache update on every successful poll cycle. Storage
         failures are logged and swallowed — statistics must never break
         polling. Samples are awaited (not fire-and-forget) so each gateway's
-        samples stay strictly ordered for trapezoidal integration.
+        samples stay strictly ordered for trapezoidal integration, but capped
+        by a timeout so a hung SQLite write (disk full, dying flash) can
+        never stall the poll loop.
         """
         try:
             aggregates = data.aggregates or {}
@@ -1154,15 +1156,23 @@ class GatewayManager:
                 ts = datetime.now().timestamp()
             from app.core.timeseries import get_timeseries_store
 
-            await get_timeseries_store().record_sample(
-                gateway_id=gateway_id,
-                ts=ts,
-                solar_w=solar,
-                home_w=load,
-                battery_w=battery,
-                site_w=site,
-                soe=data.soe,
-                timezone=gateway.timezone,
+            await asyncio.wait_for(
+                get_timeseries_store().record_sample(
+                    gateway_id=gateway_id,
+                    ts=ts,
+                    solar_w=solar,
+                    home_w=load,
+                    battery_w=battery,
+                    site_w=site,
+                    soe=data.soe,
+                    timezone=gateway.timezone,
+                ),
+                timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Time-series sample write timed out for %s — polling continues",
+                gateway_id,
             )
         except Exception as e:
             logger.debug(f"Time-series sample recording failed for {gateway_id}: {e}")

--- a/app/core/gateway_manager.py
+++ b/app/core/gateway_manager.py
@@ -435,6 +435,12 @@ class GatewayManager:
                 f"Gateway manager ready - {len(self.gateways)} gateway(s) will connect on first poll"
             )
 
+        # Start the time-series store's background maintenance loop (no-op
+        # when PW_TIMESERIES_RETENTION=-1).
+        from app.core.timeseries import get_timeseries_store
+
+        await get_timeseries_store().start()
+
     async def _init_cloud_control(self, hybrid_configs: List[GatewayConfig]):
         """Create the hybrid cloud-control connection in the background."""
         from app.config import settings
@@ -533,6 +539,12 @@ class GatewayManager:
         self._poll_tasks.clear()
         self._probe_tasks.clear()
         self._mqtt_tasks.clear()
+
+        # Stop the time-series store (maintenance task + SQLite close).
+        from app.core.timeseries import get_timeseries_store, reset_timeseries_store
+
+        await get_timeseries_store().stop()
+        reset_timeseries_store()
 
         # Shutdown thread pool executor
         if self._executor:
@@ -1066,6 +1078,10 @@ class GatewayManager:
                 gateway=gateway, data=data, online=True, last_updated=data.timestamp
             )
 
+            # Persist the sample for daily energy statistics (never raises;
+            # no-op when the store is disabled).
+            await self._record_timeseries_sample(gateway_id, gateway, data)
+
             # Publish to MQTT after the cache is updated (never raises here).
             self._schedule_mqtt_publish(gateway_id)
 
@@ -1114,6 +1130,42 @@ class GatewayManager:
 
             # Publish the offline status to MQTT so HA reflects gateway going offline.
             self._schedule_mqtt_publish(gateway_id)
+
+    async def _record_timeseries_sample(
+        self, gateway_id: str, gateway, data: PowerwallData
+    ) -> None:
+        """Feed one poll result into the TimeSeriesStore.
+
+        Runs after the cache update on every successful poll cycle. Storage
+        failures are logged and swallowed — statistics must never break
+        polling. Samples are awaited (not fire-and-forget) so each gateway's
+        samples stay strictly ordered for trapezoidal integration.
+        """
+        try:
+            aggregates = data.aggregates or {}
+            solar = (aggregates.get("solar") or {}).get("instant_power")
+            load = (aggregates.get("load") or {}).get("instant_power")
+            battery = (aggregates.get("battery") or {}).get("instant_power")
+            site = (aggregates.get("site") or {}).get("instant_power")
+            if None in (solar, load, battery, site):
+                return  # Partial aggregates — skip rather than store zeros
+            ts = data.timestamp
+            if ts is None or ts < 1e9:  # Bogus/missing clock — use server time
+                ts = datetime.now().timestamp()
+            from app.core.timeseries import get_timeseries_store
+
+            await get_timeseries_store().record_sample(
+                gateway_id=gateway_id,
+                ts=ts,
+                solar_w=solar,
+                home_w=load,
+                battery_w=battery,
+                site_w=site,
+                soe=data.soe,
+                timezone=gateway.timezone,
+            )
+        except Exception as e:
+            logger.debug(f"Time-series sample recording failed for {gateway_id}: {e}")
 
     def _schedule_mqtt_publish(self, gateway_id: str) -> None:
         """Schedule an MQTT publish of the current cached status for a gateway.

--- a/app/core/timeseries.py
+++ b/app/core/timeseries.py
@@ -604,9 +604,14 @@ class TimeSeriesStore:
             return self._get_day_row(gateway_id, today, conn)
 
     async def get_trend(
-        self, hours: int = 24, gateway: Optional[str] = None
+        self,
+        hours: int = 24,
+        gateway: Optional[str] = None,
+        start: Optional[float] = None,
+        end: Optional[float] = None,
+        fit: bool = False,
     ) -> Dict[str, Any]:
-        """Bucketed time series for charting (last ``hours`` of raw data).
+        """Bucketed time series for charting.
 
         Raw 5s samples are averaged into ~240-second buckets (per gateway,
         then summed across gateways) so a 24-hour window returns ~360 points
@@ -617,23 +622,40 @@ class TimeSeriesStore:
         samples — it is never downsampled into daily aggregates.
 
         Args:
-            hours:   Window length (1-168).
+            hours:   Window length (1-168) when no explicit ``start``.
             gateway: Restrict to one gateway ID (None = all, summed).
+            start:   Explicit window start (epoch seconds). Overrides
+                     ``hours``.
+            end:     Explicit window end (epoch seconds); default now.
+            fit:     Use all retained raw data (earliest sample -> now).
         """
         if not self.enabled:
             return {"enabled": False, "points": [], "count": 0}
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(
-            self._ensure_executor(), partial(self._get_trend_sync, hours, gateway)
+            self._ensure_executor(),
+            partial(self._get_trend_sync, hours, gateway, start, end, fit),
         )
 
-    def _get_trend_sync(self, hours: int, gateway: Optional[str]) -> Dict[str, Any]:
+    def _get_trend_sync(
+        self,
+        hours: int,
+        gateway: Optional[str],
+        start: Optional[float] = None,
+        end: Optional[float] = None,
+        fit: bool = False,
+    ) -> Dict[str, Any]:
         hours = max(1, min(int(hours), 168))
         now = time.time()
-        span = hours * 3600.0
+        if start is None:
+            span = hours * 3600.0
+            start = now - span
+        end = end or (now + 300.0)  # +300s tolerance for clock skew
+        # No clamp to now: raw samples may sit slightly in the future
+        # (clock skew / rounding) and excluding them drops live buckets.
+        span = max(60.0, end - start)
         # Target ~360 buckets, rounded to a whole minute, never below 60s.
         bucket = max(60.0, round(span / 360.0 / 60.0) * 60.0)
-        start = now - span
         with self._lock:
             try:
                 conn = self._ensure_conn()
@@ -645,7 +667,15 @@ class TimeSeriesStore:
                     "count": 0,
                     "bucket_seconds": bucket,
                     "hours": hours,
+                    "start": start,
+                    "end": end,
                 }
+            if fit:
+                row = conn.execute("SELECT MIN(ts) AS m FROM samples").fetchone()
+                if row is not None and row["m"] is not None and row["m"] < start:
+                    start = float(row["m"])
+            span = max(60.0, end - start)
+            bucket = max(60.0, round(span / 360.0 / 60.0) * 60.0)
             # Inner query: mean per (bucket, gateway) so multi-gateway setups
             # sum instead of average; outer query collapses to fleet totals
             # (mean SoE). Single-gateway deployments get plain bucket means.
@@ -662,13 +692,20 @@ class TimeSeriesStore:
                 "AVG(home_w) AS home_avg, "
                 "AVG(battery_discharge_w - battery_charge_w) AS batt_avg, "
                 "AVG(grid_import_w - grid_export_w) AS grid_avg, "
-                "AVG(soe) AS soe_avg FROM samples WHERE ts>=? "
+                "AVG(soe) AS soe_avg FROM samples WHERE ts>=? AND ts<=? "
                 + gw_filter
                 + "GROUP BY bstart, gateway_id) "
                 "GROUP BY bstart ORDER BY bstart"
             )
             rows = conn.execute(
-                sql, (bucket, bucket, start, *((gateway,) if gateway else ()))
+                sql,
+                (
+                    bucket,
+                    bucket,
+                    start,
+                    end,
+                    *((gateway,) if gateway else ()),
+                ),
             ).fetchall()
             points = [
                 {
@@ -685,6 +722,8 @@ class TimeSeriesStore:
                 "enabled": True,
                 "hours": hours,
                 "bucket_seconds": bucket,
+                "start": start,
+                "end": end,
                 "points": points,
                 "count": len(points),
                 "last_updated": now,

--- a/app/core/timeseries.py
+++ b/app/core/timeseries.py
@@ -603,6 +603,93 @@ class TimeSeriesStore:
                 return None
             return self._get_day_row(gateway_id, today, conn)
 
+    async def get_trend(
+        self, hours: int = 24, gateway: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Bucketed time series for charting (last ``hours`` of raw data).
+
+        Raw 5s samples are averaged into ~240-second buckets (per gateway,
+        then summed across gateways) so a 24-hour window returns ~360 points
+        instead of ~17k rows. Power columns keep the PowerwallData sign
+        convention (battery positive = discharging, grid positive =
+        importing) and are returned in kW; ``battery_level`` is the mean
+        state of energy (%) in each bucket. Battery level lives only in raw
+        samples — it is never downsampled into daily aggregates.
+
+        Args:
+            hours:   Window length (1-168).
+            gateway: Restrict to one gateway ID (None = all, summed).
+        """
+        if not self.enabled:
+            return {"enabled": False, "points": [], "count": 0}
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._ensure_executor(), partial(self._get_trend_sync, hours, gateway)
+        )
+
+    def _get_trend_sync(self, hours: int, gateway: Optional[str]) -> Dict[str, Any]:
+        hours = max(1, min(int(hours), 168))
+        now = time.time()
+        span = hours * 3600.0
+        # Target ~360 buckets, rounded to a whole minute, never below 60s.
+        bucket = max(60.0, round(span / 360.0 / 60.0) * 60.0)
+        start = now - span
+        with self._lock:
+            try:
+                conn = self._ensure_conn()
+            except sqlite3.Error as e:
+                logger.debug("TimeSeriesStore query failed: %s", e)
+                return {
+                    "enabled": True,
+                    "points": [],
+                    "count": 0,
+                    "bucket_seconds": bucket,
+                    "hours": hours,
+                }
+            # Inner query: mean per (bucket, gateway) so multi-gateway setups
+            # sum instead of average; outer query collapses to fleet totals
+            # (mean SoE). Single-gateway deployments get plain bucket means.
+            gw_filter = "AND gateway_id=? " if gateway else ""
+            sql = (
+                "SELECT bstart, "
+                "SUM(solar_avg)/1000.0 AS solar_kw, "
+                "SUM(home_avg)/1000.0 AS home_kw, "
+                "SUM(batt_avg)/1000.0 AS battery_kw, "
+                "SUM(grid_avg)/1000.0 AS grid_kw, "
+                "AVG(soe_avg) AS battery_level "
+                "FROM (SELECT (CAST(ts/? AS INTEGER))*? AS bstart, "
+                "gateway_id, AVG(solar_w) AS solar_avg, "
+                "AVG(home_w) AS home_avg, "
+                "AVG(battery_discharge_w - battery_charge_w) AS batt_avg, "
+                "AVG(grid_import_w - grid_export_w) AS grid_avg, "
+                "AVG(soe) AS soe_avg FROM samples WHERE ts>=? "
+                + gw_filter
+                + "GROUP BY bstart, gateway_id) "
+                "GROUP BY bstart ORDER BY bstart"
+            )
+            rows = conn.execute(
+                sql, (bucket, bucket, start, *((gateway,) if gateway else ()))
+            ).fetchall()
+            points = [
+                {
+                    "ts": row["bstart"],
+                    "solar_kw": row["solar_kw"],
+                    "home_kw": row["home_kw"],
+                    "battery_kw": row["battery_kw"],
+                    "grid_kw": row["grid_kw"],
+                    "battery_level": row["battery_level"],
+                }
+                for row in rows
+            ]
+            return {
+                "enabled": True,
+                "hours": hours,
+                "bucket_seconds": bucket,
+                "points": points,
+                "count": len(points),
+                "last_updated": now,
+            }
+
     async def get_samples(
         self,
         gateway: Optional[str] = None,

--- a/app/core/timeseries.py
+++ b/app/core/timeseries.py
@@ -54,6 +54,7 @@ Environment Variables:
                                   otherwise "data/timeseries.db" relative to
                                   the working directory).
 """
+
 import asyncio
 import logging
 import os
@@ -242,15 +243,12 @@ class TimeSeriesStore:
             directory = os.path.dirname(self._db_path)
             if directory:
                 os.makedirs(directory, exist_ok=True)
-            conn = sqlite3.connect(
-                self._db_path, check_same_thread=False, timeout=10.0
-            )
+            conn = sqlite3.connect(self._db_path, check_same_thread=False, timeout=10.0)
             conn.row_factory = sqlite3.Row
             conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("PRAGMA synchronous=NORMAL")
             conn.execute("PRAGMA busy_timeout=5000")
-            conn.executescript(
-                """
+            conn.executescript("""
                 CREATE TABLE IF NOT EXISTS samples (
                     gateway_id TEXT NOT NULL,
                     ts REAL NOT NULL,
@@ -287,8 +285,7 @@ class TimeSeriesStore:
                     grid_import_w REAL NOT NULL DEFAULT 0,
                     grid_export_w REAL NOT NULL DEFAULT 0
                 );
-                """
-            )
+                """)
             conn.commit()
             self._conn = conn
             logger.debug("TimeSeriesStore opened %s (WAL mode)", self._db_path)
@@ -366,9 +363,7 @@ class TimeSeriesStore:
                 # as raw rows but never move integration state backwards.
                 daily_deltas: Dict[str, Dict[str, float]] = {}
                 if state is not None and ts > state["ts"]:
-                    daily_deltas = self._integrate_interval(
-                        state, ts, values, timezone
-                    )
+                    daily_deltas = self._integrate_interval(state, ts, values, timezone)
 
                 conn.execute(
                     "INSERT OR REPLACE INTO samples "
@@ -475,7 +470,9 @@ class TimeSeriesStore:
 
     @staticmethod
     def _integrate_interval(
-        state: Dict[str, Any], ts: float, values: Dict[str, float],
+        state: Dict[str, Any],
+        ts: float,
+        values: Dict[str, float],
         timezone: Optional[str],
     ) -> Dict[str, Dict[str, float]]:
         """Trapezoidal integration of one interval, split at local midnights.
@@ -505,9 +502,7 @@ class TimeSeriesStore:
                 v1 = values[category]
                 watts0 = v0 + (v1 - v0) * f0
                 watts1 = v0 + (v1 - v0) * f1
-                day_deltas[category] += (
-                    (watts0 + watts1) / 2.0 * (b - a) / 3_600_000.0
-                )
+                day_deltas[category] += (watts0 + watts1) / 2.0 * (b - a) / 3_600_000.0
         return result
 
     def _get_day_row(
@@ -549,9 +544,13 @@ class TimeSeriesStore:
             except sqlite3.Error as e:
                 logger.debug("TimeSeriesStore query failed: %s", e)
                 return {"enabled": True, "days": [], "last_updated": None}
-            cutoff = (
-                datetime.now(_UTC) - timedelta(days=max(days - 1, 0))
-            ).strftime("%Y-%m-%d")
+            # Days are stored as gateway-local dates, which can trail or lead
+            # the UTC date around midnight. Widen the SQL cutoff by one day so
+            # late-local-day rows are never dropped, then trim to `days` after
+            # grouping (ISO day strings sort correctly across gateways).
+            cutoff = (datetime.now(_UTC) - timedelta(days=max(days, 1))).strftime(
+                "%Y-%m-%d"
+            )
             if gateway:
                 rows = conn.execute(
                     "SELECT * FROM daily_energy WHERE day>=? AND gateway_id=? "
@@ -576,7 +575,7 @@ class TimeSeriesStore:
                     {"day": day, "gateways": gateways}
                     for day, gateways in sorted(
                         by_day.items(), key=lambda item: item[0], reverse=True
-                    )
+                    )[:days]
                 ],
                 "last_updated": last_updated,
             }
@@ -687,9 +686,7 @@ class TimeSeriesStore:
                     db_size += wal.stat().st_size
                 try:
                     conn = self._ensure_conn()
-                    samples = conn.execute(
-                        "SELECT COUNT(*) FROM samples"
-                    ).fetchone()[0]
+                    samples = conn.execute("SELECT COUNT(*) FROM samples").fetchone()[0]
                     daily_rows = conn.execute(
                         "SELECT COUNT(*) FROM daily_energy"
                     ).fetchone()[0]
@@ -747,9 +744,7 @@ class TimeSeriesStore:
         if not self.enabled:
             return
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            self._ensure_executor(), self._maintenance_sync
-        )
+        await loop.run_in_executor(self._ensure_executor(), self._maintenance_sync)
 
     def _maintenance_sync(self) -> None:
         with self._lock:
@@ -787,7 +782,7 @@ class TimeSeriesStore:
             except asyncio.CancelledError:
                 pass
             self._maintenance_task = None
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         if loop.is_running():
             await loop.run_in_executor(None, self._close_sync)
         else:  # pragma: no cover - defensive

--- a/app/core/timeseries.py
+++ b/app/core/timeseries.py
@@ -93,6 +93,9 @@ RAW_KEEP_FLOOR = 3600.0
 # Maintenance (pruning) cadence in seconds.
 MAINTENANCE_INTERVAL = 60.0
 
+# Minimum seconds between repeated write-failure warnings.
+_FAILURE_WARN_INTERVAL = 300.0
+
 # UTC fallback zoneinfo object for gateways with unresolvable timezones.
 _UTC = ZoneInfo("UTC")
 
@@ -201,6 +204,10 @@ class TimeSeriesStore:
         self._conn: Optional[sqlite3.Connection] = None
         self._executor: Optional[ThreadPoolExecutor] = None
         self._maintenance_task: Optional[asyncio.Task] = None
+        # Write-failure tracking: surfaced in status(), warned at most once
+        # per _FAILURE_WARN_INTERVAL so a full disk is visible without spam.
+        self._write_failures = 0
+        self._last_failure_warn = 0.0
         # In-memory cache of the last integrated sample per gateway:
         # {gateway_id: {"ts": float, "values": {category: watts}}}
         self._state: Dict[str, Dict[str, Any]] = {}
@@ -440,8 +447,20 @@ class TimeSeriesStore:
                         return self._get_day_row(gateway_id, today, conn)
                 return None
             except Exception as e:  # storage must never break polling
-                logger.debug("TimeSeriesStore sample write failed: %s", e)
+                self._note_write_failure(e)
                 return None
+
+    def _note_write_failure(self, exc: Exception) -> None:
+        """Count a failed write; warn at most once per interval."""
+        self._write_failures += 1
+        now = time.time()
+        if now - self._last_failure_warn >= _FAILURE_WARN_INTERVAL:
+            self._last_failure_warn = now
+            logger.warning(
+                "TimeSeriesStore sample write failed (%d total): %s",
+                self._write_failures,
+                exc,
+            )
 
     def _load_state(
         self, gateway_id: str, conn: sqlite3.Connection
@@ -791,10 +810,11 @@ class TimeSeriesStore:
                 "enabled": False,
                 "retention_seconds": -1,
                 "daily_retention_seconds": self._daily_retention,
-                "db_path": None,
+                "db_file": None,
                 "db_size_bytes": 0,
                 "samples": 0,
                 "daily_rows": 0,
+                "write_failures": 0,
                 "gateways": [],
             }
         loop = asyncio.get_running_loop()
@@ -828,10 +848,13 @@ class TimeSeriesStore:
             "enabled": True,
             "retention_seconds": self._retention,
             "daily_retention_seconds": self._daily_retention,
-            "db_path": self._db_path,
+            # Filename only — the unauthenticated status endpoint must not
+            # disclose filesystem layout (matches the /stats masking policy).
+            "db_file": os.path.basename(self._db_path),
             "db_size_bytes": db_size,
             "samples": samples,
             "daily_rows": daily_rows,
+            "write_failures": self._write_failures,
             "gateways": gateways,
         }
 
@@ -925,7 +948,8 @@ class TimeSeriesStore:
                 self._conn = None
             self._state.clear()
         if self._executor is not None:
-            self._executor.shutdown(wait=False)
+            # cancel_futures: queued writes must not reopen the closed DB
+            self._executor.shutdown(wait=False, cancel_futures=True)
             self._executor = None
 
 

--- a/app/core/timeseries.py
+++ b/app/core/timeseries.py
@@ -646,7 +646,8 @@ class TimeSeriesStore:
             start:   Explicit window start (epoch seconds). Overrides
                      ``hours``.
             end:     Explicit window end (epoch seconds); default now.
-            fit:     Use all retained raw data (earliest sample -> now).
+            fit:     Fit the window to the full range of retained raw data
+                     (earliest → latest sample, per gateway when filtered).
         """
         if not self.enabled:
             return {"enabled": False, "points": [], "count": 0}
@@ -690,9 +691,16 @@ class TimeSeriesStore:
                     "end": end,
                 }
             if fit:
-                row = conn.execute("SELECT MIN(ts) AS m FROM samples").fetchone()
-                if row is not None and row["m"] is not None and row["m"] < start:
-                    start = float(row["m"])
+                # Fit spans the full range of retained raw data (per gateway
+                # when filtered); span floor below handles the 1-sample case.
+                row = conn.execute(
+                    "SELECT MIN(ts) AS lo, MAX(ts) AS hi FROM samples"
+                    + (" WHERE gateway_id=?" if gateway else ""),
+                    ((gateway,) if gateway else ()),
+                ).fetchone()
+                if row is not None and row["lo"] is not None:
+                    start = float(row["lo"])
+                    end = float(row["hi"])
             span = max(60.0, end - start)
             bucket = max(60.0, round(span / 360.0 / 60.0) * 60.0)
             # Inner query: mean per (bucket, gateway) so multi-gateway setups

--- a/app/core/timeseries.py
+++ b/app/core/timeseries.py
@@ -1,0 +1,841 @@
+"""
+TimeSeriesStore - Lightweight SQLite-backed time-series storage.
+
+Persists raw 5-second power samples from the existing poll loop and derives
+daily energy totals (kWh) per gateway via trapezoidal integration. Survives
+restarts, adds no network calls, and can be disabled entirely for headless
+proxy deployments (PW_TIMESERIES_RETENTION=-1).
+
+Architecture:
+    Two-layer storage keeps the on-disk footprint tiny by default:
+
+    1. Raw samples (table ``samples``) - one row per gateway per poll cycle
+       (~17k rows/day at the default 5s interval). Power readings are split
+       into directional components at record time (battery charge/discharge,
+       grid import/export) so no information is netted away. Pruned to the
+       PW_TIMESERIES_RETENTION window by a background maintenance task.
+
+    2. Daily aggregates (table ``daily_energy``) - one row per gateway per
+       local day holding cumulative kWh per category. This is the layer that
+       outlives raw-sample pruning: a full year of daily totals is ~1 KB per
+       gateway. Retention governed by PW_TIMESERIES_DAILY_RETENTION.
+
+    A third table (``integration_state``) stores the last integrated sample
+    per gateway so energy accumulation resumes exactly where it left off
+    after a restart, without double counting.
+
+Energy integration:
+    Trapezoidal integration between consecutive samples:
+        kWh = (P0 + P1) / 2 * dt / 3_600_000   (P in watts, dt in seconds)
+
+    - Intervals longer than the 1-hour gap threshold are NOT integrated
+      (stale/outage data must not fabricate energy).
+    - Intervals crossing local midnight (in the gateway's configured
+      timezone) are split at the boundary so each day accrues only its own
+      energy. DST transitions are handled naturally because integration is
+      performed on real elapsed time; only day attribution uses local dates.
+
+Thread safety:
+    All SQLite access is serialized through a single worker thread
+    (dedicated ThreadPoolExecutor(max_workers=1)) plus an RLock, mirroring
+    the StatsTracker pattern. WAL mode allows the API readers to query
+    without blocking the writer.
+
+Environment Variables:
+    PW_TIMESERIES_RETENTION       Raw sample retention (default "24h").
+                                  Duration suffixes: s/m/h/d/w.
+                                  "0" = unlimited, "-1" = disable subsystem
+                                  entirely (no SQLite file, no UI panel).
+    PW_TIMESERIES_DAILY_RETENTION Daily aggregate retention (default "0" =
+                                  unlimited). One row/day/gateway is tiny,
+                                  so unlimited is a sensible default.
+    PW_TIMESERIES_PATH            SQLite file path (default "/data/timeseries.db"
+                                  when /data exists — e.g. the Docker image —
+                                  otherwise "data/timeseries.db" relative to
+                                  the working directory).
+"""
+import asyncio
+import logging
+import os
+import sqlite3
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
+from functools import partial
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger = logging.getLogger(__name__)
+
+# Categories tracked per sample. Sign conventions match PowerwallData:
+# battery positive = discharging, site positive = importing.
+CATEGORIES = (
+    "solar",
+    "home",
+    "battery_charge",
+    "battery_discharge",
+    "grid_import",
+    "grid_export",
+)
+
+# Do not integrate across gaps longer than this (seconds). A gateway that
+# was unreachable for an hour must not come back and fabricate the energy
+# it presumably did (or did not) move while gone.
+GAP_THRESHOLD = 3600.0
+
+# Raw samples are always kept for at least this long even when retention is
+# configured shorter, preserving a troubleshooting window (seconds).
+RAW_KEEP_FLOOR = 3600.0
+
+# Maintenance (pruning) cadence in seconds.
+MAINTENANCE_INTERVAL = 60.0
+
+# UTC fallback zoneinfo object for gateways with unresolvable timezones.
+_UTC = ZoneInfo("UTC")
+
+# zoneinfo cache: timezone name -> ZoneInfo (or None when unresolvable)
+_zone_cache: Dict[str, Optional[ZoneInfo]] = {}
+
+
+def parse_duration(value: str) -> int:
+    """Parse a retention setting into seconds.
+
+    Accepted forms:
+        "-1"          -> -1  (disabled)
+        "0"           -> 0   (unlimited)
+        "24h", "7d"   -> suffixed durations (s, m, h, d, w)
+        "3600"        -> bare number treated as seconds
+
+    Raises:
+        ValueError: on unparseable input.
+    """
+    text = str(value).strip().lower()
+    if not text:
+        raise ValueError(f"invalid duration: {value!r}")
+    if text == "-1":
+        return -1
+    multipliers = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
+    negative = text.startswith("-")
+    if negative:
+        text = text[1:]
+    if text and (text[-1] in multipliers or text.isdigit()):
+        if text[-1] in multipliers:
+            number = text[:-1]
+            suffix = text[-1]
+        else:
+            number = text
+            suffix = "s"
+        try:
+            parsed = int(number)
+        except ValueError:
+            raise ValueError(f"invalid duration: {value!r}") from None
+        if parsed < 0 or negative:
+            return -1
+        return parsed * multipliers[suffix]
+    raise ValueError(f"invalid duration: {value!r}")
+
+
+def _get_zone(name: Optional[str]) -> ZoneInfo:
+    """Resolve a timezone name to ZoneInfo, cached, falling back to UTC."""
+    if not name:
+        return _UTC
+    if name not in _zone_cache:
+        try:
+            _zone_cache[name] = ZoneInfo(name)
+        except (ZoneInfoNotFoundError, ValueError, OSError):
+            logger.warning(
+                "Unknown timezone %r for time-series aggregation - using UTC", name
+            )
+            _zone_cache[name] = None
+    return _zone_cache[name] or _UTC
+
+
+def _local_date(ts: float, zone: ZoneInfo):
+    """Local calendar date for a unix timestamp."""
+    return datetime.fromtimestamp(ts, zone).date()
+
+
+def _midnights_between(t0: float, t1: float, zone: ZoneInfo) -> List[float]:
+    """Timestamps of local midnights strictly inside the interval (t0, t1)."""
+    out: List[float] = []
+    cursor = datetime.fromtimestamp(t0, zone).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    ) + timedelta(days=1)
+    while True:
+        midnight = cursor.timestamp()
+        if midnight >= t1:
+            break
+        if midnight > t0:
+            out.append(midnight)
+        cursor += timedelta(days=1)
+    return out
+
+
+class TimeSeriesStore:
+    """Thread-safe SQLite time-series store for daily energy statistics."""
+
+    def __init__(
+        self,
+        db_path: str,
+        retention: Any = "24h",
+        daily_retention: Any = "0",
+    ):
+        """Create the store.
+
+        Args:
+            db_path:         SQLite database file path.
+            retention:       Raw sample retention (duration string or seconds).
+                             -1 disables the store, 0 means unlimited.
+            daily_retention: Daily aggregate retention (duration string or
+                             seconds). 0 means unlimited.
+        """
+        self._db_path = str(db_path)
+        self._retention = self._coerce(retention, "24h", "PW_TIMESERIES_RETENTION")
+        self._daily_retention = self._coerce(
+            daily_retention, "0", "PW_TIMESERIES_DAILY_RETENTION"
+        )
+        self._lock = threading.RLock()
+        self._conn: Optional[sqlite3.Connection] = None
+        self._executor: Optional[ThreadPoolExecutor] = None
+        self._maintenance_task: Optional[asyncio.Task] = None
+        # In-memory cache of the last integrated sample per gateway:
+        # {gateway_id: {"ts": float, "values": {category: watts}}}
+        self._state: Dict[str, Dict[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _coerce(value: Any, default: str, setting: str) -> int:
+        """Parse a retention value with a safe default on bad input."""
+        if isinstance(value, bool):
+            return parse_duration(default)
+        if isinstance(value, (int, float)):
+            result = int(value)
+            return -1 if result < 0 else result
+        try:
+            return parse_duration(str(value))
+        except ValueError:
+            logger.warning(
+                "Invalid %s value %r - using default %r", setting, value, default
+            )
+            return parse_duration(default)
+
+    @property
+    def enabled(self) -> bool:
+        """True when the subsystem is active (retention != -1)."""
+        return self._retention != -1
+
+    def _ensure_executor(self) -> ThreadPoolExecutor:
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="timeseries"
+            )
+        return self._executor
+
+    def _ensure_conn(self) -> sqlite3.Connection:
+        """Open (lazily) and return the SQLite connection. Caller holds the lock."""
+        if self._conn is None:
+            directory = os.path.dirname(self._db_path)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            conn = sqlite3.connect(
+                self._db_path, check_same_thread=False, timeout=10.0
+            )
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS samples (
+                    gateway_id TEXT NOT NULL,
+                    ts REAL NOT NULL,
+                    solar_w REAL NOT NULL DEFAULT 0,
+                    home_w REAL NOT NULL DEFAULT 0,
+                    battery_charge_w REAL NOT NULL DEFAULT 0,
+                    battery_discharge_w REAL NOT NULL DEFAULT 0,
+                    grid_import_w REAL NOT NULL DEFAULT 0,
+                    grid_export_w REAL NOT NULL DEFAULT 0,
+                    soe REAL,
+                    PRIMARY KEY (gateway_id, ts)
+                );
+                CREATE INDEX IF NOT EXISTS idx_samples_ts ON samples(ts);
+                CREATE TABLE IF NOT EXISTS daily_energy (
+                    gateway_id TEXT NOT NULL,
+                    day TEXT NOT NULL,
+                    solar_kwh REAL NOT NULL DEFAULT 0,
+                    home_kwh REAL NOT NULL DEFAULT 0,
+                    battery_charge_kwh REAL NOT NULL DEFAULT 0,
+                    battery_discharge_kwh REAL NOT NULL DEFAULT 0,
+                    grid_import_kwh REAL NOT NULL DEFAULT 0,
+                    grid_export_kwh REAL NOT NULL DEFAULT 0,
+                    last_sample_ts REAL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (gateway_id, day)
+                );
+                CREATE TABLE IF NOT EXISTS integration_state (
+                    gateway_id TEXT PRIMARY KEY,
+                    ts REAL NOT NULL,
+                    solar_w REAL NOT NULL DEFAULT 0,
+                    home_w REAL NOT NULL DEFAULT 0,
+                    battery_charge_w REAL NOT NULL DEFAULT 0,
+                    battery_discharge_w REAL NOT NULL DEFAULT 0,
+                    grid_import_w REAL NOT NULL DEFAULT 0,
+                    grid_export_w REAL NOT NULL DEFAULT 0
+                );
+                """
+            )
+            conn.commit()
+            self._conn = conn
+            logger.debug("TimeSeriesStore opened %s (WAL mode)", self._db_path)
+        return self._conn
+
+    # ------------------------------------------------------------------
+    # Sample recording + integration
+    # ------------------------------------------------------------------
+
+    async def record_sample(
+        self,
+        gateway_id: str,
+        ts: float,
+        solar_w: float,
+        home_w: float,
+        battery_w: float,
+        site_w: float,
+        soe: Optional[float] = None,
+        timezone: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Record one power sample and integrate it into daily totals.
+
+        Battery and grid power are split into directional components using
+        the PowerwallData sign conventions (battery positive = discharging,
+        site positive = importing) so charge/discharge and import/export are
+        never netted together.
+
+        Args:
+            gateway_id: Gateway identifier.
+            ts:         Unix timestamp of the sample.
+            solar_w:    Solar production (W).
+            home_w:     Home/load consumption (W).
+            battery_w:  Battery power (W, positive = discharging).
+            site_w:     Grid power (W, positive = importing).
+            soe:        Battery state of energy (%) if known.
+            timezone:   Gateway timezone name for local-midnight aggregation.
+
+        Returns:
+            The updated daily-energy row for the gateway's current local day
+            (or None when the store is disabled / sample skipped).
+        """
+        if not self.enabled:
+            return None
+        values = {
+            "solar": max(0.0, float(solar_w or 0.0)),
+            "home": max(0.0, float(home_w or 0.0)),
+            "battery_charge": max(0.0, -float(battery_w or 0.0)),
+            "battery_discharge": max(0.0, float(battery_w or 0.0)),
+            "grid_import": max(0.0, float(site_w or 0.0)),
+            "grid_export": max(0.0, -float(site_w or 0.0)),
+        }
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._ensure_executor(),
+            partial(
+                self._record_sample_sync, gateway_id, float(ts), values, soe, timezone
+            ),
+        )
+
+    def _record_sample_sync(
+        self,
+        gateway_id: str,
+        ts: float,
+        values: Dict[str, float],
+        soe: Optional[float],
+        timezone: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            try:
+                conn = self._ensure_conn()
+                state = self._load_state(gateway_id, conn)
+
+                # Integrate against the previous sample unless this one is
+                # out-of-order/duplicate (dt <= 0) — those still get stored
+                # as raw rows but never move integration state backwards.
+                daily_deltas: Dict[str, Dict[str, float]] = {}
+                if state is not None and ts > state["ts"]:
+                    daily_deltas = self._integrate_interval(
+                        state, ts, values, timezone
+                    )
+
+                conn.execute(
+                    "INSERT OR REPLACE INTO samples "
+                    "(gateway_id, ts, solar_w, home_w, battery_charge_w, "
+                    "battery_discharge_w, grid_import_w, grid_export_w, soe) "
+                    "VALUES (?,?,?,?,?,?,?,?,?)",
+                    (
+                        gateway_id,
+                        ts,
+                        values["solar"],
+                        values["home"],
+                        values["battery_charge"],
+                        values["battery_discharge"],
+                        values["grid_import"],
+                        values["grid_export"],
+                        soe,
+                    ),
+                )
+                for day, deltas in daily_deltas.items():
+                    conn.execute(
+                        "INSERT INTO daily_energy "
+                        "(gateway_id, day, solar_kwh, home_kwh, battery_charge_kwh, "
+                        "battery_discharge_kwh, grid_import_kwh, grid_export_kwh, "
+                        "last_sample_ts, updated_at) "
+                        "VALUES (?,?,?,?,?,?,?,?,?,?) "
+                        "ON CONFLICT(gateway_id, day) DO UPDATE SET "
+                        "solar_kwh=solar_kwh+excluded.solar_kwh, "
+                        "home_kwh=home_kwh+excluded.home_kwh, "
+                        "battery_charge_kwh=battery_charge_kwh"
+                        "+excluded.battery_charge_kwh, "
+                        "battery_discharge_kwh=battery_discharge_kwh"
+                        "+excluded.battery_discharge_kwh, "
+                        "grid_import_kwh=grid_import_kwh+excluded.grid_import_kwh, "
+                        "grid_export_kwh=grid_export_kwh+excluded.grid_export_kwh, "
+                        "last_sample_ts=excluded.last_sample_ts, "
+                        "updated_at=excluded.updated_at",
+                        (
+                            gateway_id,
+                            day,
+                            deltas["solar"],
+                            deltas["home"],
+                            deltas["battery_charge"],
+                            deltas["battery_discharge"],
+                            deltas["grid_import"],
+                            deltas["grid_export"],
+                            ts,
+                            time.time(),
+                        ),
+                    )
+                if state is None or ts > state["ts"]:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO integration_state "
+                        "(gateway_id, ts, solar_w, home_w, battery_charge_w, "
+                        "battery_discharge_w, grid_import_w, grid_export_w) "
+                        "VALUES (?,?,?,?,?,?,?,?)",
+                        (
+                            gateway_id,
+                            ts,
+                            values["solar"],
+                            values["home"],
+                            values["battery_charge"],
+                            values["battery_discharge"],
+                            values["grid_import"],
+                            values["grid_export"],
+                        ),
+                    )
+                    self._state[gateway_id] = {"ts": ts, "values": dict(values)}
+                conn.commit()
+
+                if daily_deltas:
+                    zone = _get_zone(timezone)
+                    today = _local_date(ts, zone).isoformat()
+                    if today in daily_deltas:
+                        return self._get_day_row(gateway_id, today, conn)
+                return None
+            except Exception as e:  # storage must never break polling
+                logger.debug("TimeSeriesStore sample write failed: %s", e)
+                return None
+
+    def _load_state(
+        self, gateway_id: str, conn: sqlite3.Connection
+    ) -> Optional[Dict[str, Any]]:
+        """Last integrated sample for a gateway (memory cache -> DB)."""
+        if gateway_id in self._state:
+            return self._state[gateway_id]
+        row = conn.execute(
+            "SELECT * FROM integration_state WHERE gateway_id=?", (gateway_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        state = {
+            "ts": row["ts"],
+            "values": {
+                "solar": row["solar_w"],
+                "home": row["home_w"],
+                "battery_charge": row["battery_charge_w"],
+                "battery_discharge": row["battery_discharge_w"],
+                "grid_import": row["grid_import_w"],
+                "grid_export": row["grid_export_w"],
+            },
+        }
+        self._state[gateway_id] = state
+        return state
+
+    @staticmethod
+    def _integrate_interval(
+        state: Dict[str, Any], ts: float, values: Dict[str, float],
+        timezone: Optional[str],
+    ) -> Dict[str, Dict[str, float]]:
+        """Trapezoidal integration of one interval, split at local midnights.
+
+        Returns {day: {category: kWh accrued on that local day}}.
+        Skips integration entirely across gaps longer than GAP_THRESHOLD.
+        """
+        t0 = state["ts"]
+        dt = ts - t0
+        if dt <= 0 or dt > GAP_THRESHOLD:
+            return {}
+
+        zone = _get_zone(timezone)
+        segments = [t0] + _midnights_between(t0, ts, zone) + [ts]
+        result: Dict[str, Dict[str, float]] = {}
+        for a, b in zip(segments, segments[1:]):
+            # Segment [a, b] accrues to the local date of its start; a
+            # segment ending exactly at midnight belongs to the day before.
+            day = _local_date(a, zone).isoformat()
+            f0 = (a - t0) / dt
+            f1 = (b - t0) / dt
+            day_deltas = result.setdefault(
+                day, {category: 0.0 for category in CATEGORIES}
+            )
+            for category in CATEGORIES:
+                v0 = state["values"][category]
+                v1 = values[category]
+                watts0 = v0 + (v1 - v0) * f0
+                watts1 = v0 + (v1 - v0) * f1
+                day_deltas[category] += (
+                    (watts0 + watts1) / 2.0 * (b - a) / 3_600_000.0
+                )
+        return result
+
+    def _get_day_row(
+        self, gateway_id: str, day: str, conn: sqlite3.Connection
+    ) -> Optional[Dict[str, Any]]:
+        row = conn.execute(
+            "SELECT * FROM daily_energy WHERE gateway_id=? AND day=?",
+            (gateway_id, day),
+        ).fetchone()
+        return dict(row) if row else None
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    async def get_daily_energy(
+        self, days: int = 7, gateway: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Daily energy totals, most recent day first.
+
+        Args:
+            days:    Number of days to include (counting back from today).
+            gateway: Restrict to one gateway ID (None = all gateways).
+        """
+        if not self.enabled:
+            return {"enabled": False, "days": [], "last_updated": None}
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._ensure_executor(),
+            partial(self._get_daily_energy_sync, days, gateway),
+        )
+
+    def _get_daily_energy_sync(
+        self, days: int, gateway: Optional[str]
+    ) -> Dict[str, Any]:
+        with self._lock:
+            try:
+                conn = self._ensure_conn()
+            except sqlite3.Error as e:
+                logger.debug("TimeSeriesStore query failed: %s", e)
+                return {"enabled": True, "days": [], "last_updated": None}
+            cutoff = (
+                datetime.now(_UTC) - timedelta(days=max(days - 1, 0))
+            ).strftime("%Y-%m-%d")
+            if gateway:
+                rows = conn.execute(
+                    "SELECT * FROM daily_energy WHERE day>=? AND gateway_id=? "
+                    "ORDER BY day DESC",
+                    (cutoff, gateway),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM daily_energy WHERE day>=? ORDER BY day DESC",
+                    (cutoff,),
+                ).fetchall()
+            by_day: Dict[str, Dict[str, Dict[str, Any]]] = {}
+            last_updated: Optional[float] = None
+            for row in rows:
+                entry = dict(row)
+                by_day.setdefault(row["day"], {})[row["gateway_id"]] = entry
+                if row["last_sample_ts"]:
+                    last_updated = max(last_updated or 0.0, row["last_sample_ts"])
+            return {
+                "enabled": True,
+                "days": [
+                    {"day": day, "gateways": gateways}
+                    for day, gateways in sorted(
+                        by_day.items(), key=lambda item: item[0], reverse=True
+                    )
+                ],
+                "last_updated": last_updated,
+            }
+
+    async def get_today(
+        self, gateway_id: str, timezone: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Today's running totals for one gateway (gateway-local day)."""
+        if not self.enabled:
+            return None
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._ensure_executor(), partial(self._get_today_sync, gateway_id, timezone)
+        )
+
+    def _get_today_sync(
+        self, gateway_id: str, timezone: Optional[str]
+    ) -> Optional[Dict[str, Any]]:
+        zone = _get_zone(timezone)
+        today = _local_date(time.time(), zone).isoformat()
+        with self._lock:
+            try:
+                conn = self._ensure_conn()
+            except Exception:
+                return None
+            return self._get_day_row(gateway_id, today, conn)
+
+    async def get_samples(
+        self,
+        gateway: Optional[str] = None,
+        start: Optional[float] = None,
+        end: Optional[float] = None,
+        limit: int = 500,
+    ) -> Dict[str, Any]:
+        """Raw samples, ascending by time (for troubleshooting).
+
+        Args:
+            gateway: Restrict to one gateway ID (None = all).
+            start:   Inclusive start timestamp (unix).
+            end:     Inclusive end timestamp (unix).
+            limit:   Maximum rows to return (capped at 10,000).
+        """
+        if not self.enabled:
+            return {"enabled": False, "samples": [], "count": 0}
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._ensure_executor(),
+            partial(self._get_samples_sync, gateway, start, end, limit),
+        )
+
+    def _get_samples_sync(
+        self,
+        gateway: Optional[str],
+        start: Optional[float],
+        end: Optional[float],
+        limit: int,
+    ) -> Dict[str, Any]:
+        limit = max(1, min(int(limit), 10_000))
+        with self._lock:
+            try:
+                conn = self._ensure_conn()
+            except sqlite3.Error as e:
+                logger.debug("TimeSeriesStore query failed: %s", e)
+                return {"enabled": True, "samples": [], "count": 0}
+            clauses, params = [], []
+            if gateway:
+                clauses.append("gateway_id=?")
+                params.append(gateway)
+            if start is not None:
+                clauses.append("ts>=?")
+                params.append(float(start))
+            if end is not None:
+                clauses.append("ts<=?")
+                params.append(float(end))
+            where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+            rows = conn.execute(
+                f"SELECT * FROM samples{where} ORDER BY ts DESC LIMIT ?",
+                (*params, limit),
+            ).fetchall()
+            samples = [dict(row) for row in reversed(rows)]
+            return {"enabled": True, "samples": samples, "count": len(samples)}
+
+    async def status(self) -> Dict[str, Any]:
+        """Subsystem status for /api/timeseries/status and the UI."""
+        if not self.enabled:
+            return {
+                "enabled": False,
+                "retention_seconds": -1,
+                "daily_retention_seconds": self._daily_retention,
+                "db_path": None,
+                "db_size_bytes": 0,
+                "samples": 0,
+                "daily_rows": 0,
+                "gateways": [],
+            }
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._ensure_executor(), self._status_sync)
+
+    def _status_sync(self) -> Dict[str, Any]:
+        db_size = 0
+        samples = daily_rows = 0
+        gateways: List[str] = []
+        with self._lock:
+            if Path(self._db_path).exists():
+                db_size = os.path.getsize(self._db_path)
+                wal = Path(self._db_path + "-wal")
+                if wal.exists():
+                    db_size += wal.stat().st_size
+                try:
+                    conn = self._ensure_conn()
+                    samples = conn.execute(
+                        "SELECT COUNT(*) FROM samples"
+                    ).fetchone()[0]
+                    daily_rows = conn.execute(
+                        "SELECT COUNT(*) FROM daily_energy"
+                    ).fetchone()[0]
+                    gateways = [
+                        row[0]
+                        for row in conn.execute(
+                            "SELECT DISTINCT gateway_id FROM integration_state"
+                        ).fetchall()
+                    ]
+                except sqlite3.Error as e:
+                    logger.debug("TimeSeriesStore status query failed: %s", e)
+        return {
+            "enabled": True,
+            "retention_seconds": self._retention,
+            "daily_retention_seconds": self._daily_retention,
+            "db_path": self._db_path,
+            "db_size_bytes": db_size,
+            "samples": samples,
+            "daily_rows": daily_rows,
+            "gateways": gateways,
+        }
+
+    # ------------------------------------------------------------------
+    # Maintenance (pruning)
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the background maintenance loop (no-op when disabled)."""
+        if not self.enabled:
+            return
+        if self._maintenance_task is None or self._maintenance_task.done():
+            self._maintenance_task = asyncio.create_task(
+                self._maintenance_loop(), name="timeseries-maintenance"
+            )
+            logger.info(
+                "TimeSeriesStore enabled — raw retention %ss, daily retention %ss, "
+                "db: %s",
+                self._retention,
+                self._daily_retention,
+                self._db_path,
+            )
+
+    async def _maintenance_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(MAINTENANCE_INTERVAL)
+                await self.maintenance()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug("TimeSeriesStore maintenance error: %s", e)
+
+    async def maintenance(self) -> None:
+        """Prune raw samples and stale daily aggregates, checkpoint WAL."""
+        if not self.enabled:
+            return
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            self._ensure_executor(), self._maintenance_sync
+        )
+
+    def _maintenance_sync(self) -> None:
+        with self._lock:
+            try:
+                conn = self._ensure_conn()
+                now = time.time()
+                if self._retention > 0:
+                    # Raw samples older than the retention window go away,
+                    # but the last RAW_KEEP_FLOOR of data always stays.
+                    cutoff = now - max(self._retention, RAW_KEEP_FLOOR)
+                    conn.execute("DELETE FROM samples WHERE ts < ?", (cutoff,))
+                if self._daily_retention > 0:
+                    cutoff_day = (
+                        datetime.fromtimestamp(now, _UTC)
+                        - timedelta(seconds=self._daily_retention)
+                    ).strftime("%Y-%m-%d")
+                    conn.execute(
+                        "DELETE FROM daily_energy WHERE day < ?", (cutoff_day,)
+                    )
+                conn.commit()
+                conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            except sqlite3.Error as e:
+                logger.debug("TimeSeriesStore maintenance failed: %s", e)
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    async def stop(self) -> None:
+        """Stop maintenance and close the database. Safe to call repeatedly."""
+        if self._maintenance_task and not self._maintenance_task.done():
+            self._maintenance_task.cancel()
+            try:
+                await self._maintenance_task
+            except asyncio.CancelledError:
+                pass
+            self._maintenance_task = None
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            await loop.run_in_executor(None, self._close_sync)
+        else:  # pragma: no cover - defensive
+            self._close_sync()
+
+    def _close_sync(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                try:
+                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                    self._conn.close()
+                except sqlite3.Error as e:
+                    logger.debug("TimeSeriesStore close failed: %s", e)
+                self._conn = None
+            self._state.clear()
+        if self._executor is not None:
+            self._executor.shutdown(wait=False)
+            self._executor = None
+
+
+# module-level singleton, built lazily from settings (never at import time,
+# so disabled deployments and tests never touch the filesystem)
+_store: Optional[TimeSeriesStore] = None
+
+
+def get_timeseries_store() -> TimeSeriesStore:
+    """Return the process-wide TimeSeriesStore built from settings."""
+    global _store
+    if _store is None:
+        from app.config import settings  # late import — avoids import cycle
+
+        _store = TimeSeriesStore(
+            db_path=settings.timeseries_path,
+            retention=settings.timeseries_retention,
+            daily_retention=settings.timeseries_daily_retention,
+        )
+    return _store
+
+
+def reset_timeseries_store() -> None:
+    """Close and drop the singleton (used by tests and config reloads).
+
+    Cancels the maintenance task without awaiting (callers are typically
+    synchronous teardown paths), then closes SQLite synchronously.
+    """
+    global _store
+    if _store is not None:
+        if _store._maintenance_task and not _store._maintenance_task.done():
+            _store._maintenance_task.cancel()
+        _store._close_sync()  # pylint: disable=protected-access
+        _store = None

--- a/app/main.py
+++ b/app/main.py
@@ -67,7 +67,7 @@ from typing import Optional
 from app.api.auth import verify_control_token
 
 from app.config import settings, SERVER_VERSION
-from app.api import legacy, gateways, aggregates, websockets
+from app.api import legacy, gateways, aggregates, websockets, timeseries
 from app.core.gateway_manager import gateway_manager
 from app.utils.transform import get_static
 from app.utils.stats_tracker import stats_tracker
@@ -322,6 +322,7 @@ static_path = Path(__file__).parent / "static"
 # routes are not shadowed by legacy endpoints that share the /api/* path prefix.
 app.include_router(gateways.router, prefix="/api/gateways", tags=["Gateways"])
 app.include_router(aggregates.router, prefix="/api/aggregate", tags=["Aggregates"])
+app.include_router(timeseries.router, prefix="/api/timeseries", tags=["TimeSeries"])
 app.include_router(websockets.router, prefix="/ws", tags=["WebSockets"])
 
 app.include_router(legacy.router, tags=["Legacy Proxy Compatibility"])

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -235,6 +235,47 @@
         /* Energy Summary Card */
         .energy-card {
             grid-column: span 6;
+            cursor: pointer;
+        }
+        .energy-card.trend-mode {
+            grid-column: span 12;
+        }
+        .energy-mode-hint {
+            font-size: 0.8em;
+            color: var(--text-secondary);
+        }
+        .energy-trend-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px 16px;
+            font-size: 0.8em;
+            color: var(--text-secondary);
+            margin-bottom: 8px;
+        }
+        .energy-trend-legend .key {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .energy-trend-legend .swatch {
+            display: inline-block;
+            width: 16px;
+            height: 3px;
+            border-radius: 2px;
+        }
+        .energy-trend-legend .swatch.dashed {
+            background: repeating-linear-gradient(90deg, var(--battery-color) 0 5px, transparent 5px 9px);
+        }
+        #energy-trend-chart {
+            width: 100%;
+            height: 260px;
+            display: block;
+        }
+        .energy-trend-note {
+            font-size: 0.8em;
+            color: var(--text-muted);
+            margin-top: 6px;
+            min-height: 1em;
         }
         
         .energy-grid {
@@ -690,12 +731,12 @@
             padding: 8px 12px;
             border-left: 3px solid var(--text-muted);
         }
-        .daily-grid .health-item.pos {
-            border-left-color: var(--accent-green);
-        }
-        .daily-grid .health-item.neg {
-            border-left-color: var(--accent-yellow, #d29922);
-        }
+        /* Category borders match the Energy Summary panel's standard colors:
+           solar = yellow, home = blue, battery = green, grid = gray. */
+        .daily-grid .health-item.cat-solar { border-left-color: var(--solar-color); }
+        .daily-grid .health-item.cat-home { border-left-color: var(--home-color); }
+        .daily-grid .health-item.cat-battery { border-left-color: var(--battery-color); }
+        .daily-grid .health-item.cat-grid { border-left-color: var(--grid-color); }
         .daily-grid .health-value {
             font-size: 0.95em;
         }
@@ -1052,8 +1093,8 @@
                 </div>
             </div>
             
-            <!-- Energy Summary -->
-            <div class="card energy-card">
+            <!-- Energy Summary (click to toggle Energy Trend) -->
+            <div class="card energy-card" id="energy-card" title="Click to toggle Energy Trend">
                 <div class="card-header">
                     <div class="card-title">
                         <span class="icon">
@@ -1062,10 +1103,11 @@
                                 <path d="M18 17 L13 9 L9 13 L3 7" fill="none"/>
                             </svg>
                         </span>
-                        Energy Summary
+                        <span id="energy-card-title-text">Energy Summary</span>
                     </div>
+                    <div class="energy-mode-hint" id="energy-mode-hint">click for 24h trend</div>
                 </div>
-                <div class="energy-grid">
+                <div class="energy-grid" id="energy-grid">
                     <div class="energy-item solar">
                         <canvas id="solar-trend" class="trend-chart"></canvas>
                         <div class="energy-label">
@@ -1105,6 +1147,18 @@
                         <div class="energy-value" id="grid-power">-- kW</div>
                         <div class="energy-detail" id="grid-status">--</div>
                     </div>
+                </div>
+                <!-- Energy Trend (shown while the card is toggled) -->
+                <div id="energy-trend" style="display:none">
+                    <div class="energy-trend-legend">
+                        <span class="key"><span class="swatch" style="background: var(--solar-color)"></span>Solar kW</span>
+                        <span class="key"><span class="swatch" style="background: var(--home-color)"></span>Home kW</span>
+                        <span class="key"><span class="swatch" style="background: var(--battery-color)"></span>Battery kW</span>
+                        <span class="key"><span class="swatch" style="background: var(--grid-color)"></span>Grid kW</span>
+                        <span class="key"><span class="swatch dashed"></span>Battery Level % <span style="color: var(--text-muted)">(right axis)</span></span>
+                    </div>
+                    <canvas id="energy-trend-chart"></canvas>
+                    <div class="energy-trend-note" id="energy-trend-note"></div>
                 </div>
             </div>
             
@@ -1725,12 +1779,12 @@
                     if (isMulti) html += `<div class="gateway-section-header">${gatewayMeta[gwId]?.name || gwId}</div>`;
                     const t = today.gateways[gwId] || {};
                     html += `<div class="daily-grid">
-                        <div class="health-item pos"><div class="health-label">Solar Today</div><div class="health-value">${fmt(t.solar_kwh, 2)} kWh</div></div>
-                        <div class="health-item"><div class="health-label">Home Today</div><div class="health-value">${fmt(t.home_kwh, 2)} kWh</div></div>
-                        <div class="health-item pos"><div class="health-label">Batt Charged</div><div class="health-value">${fmt(t.battery_charge_kwh, 2)} kWh</div></div>
-                        <div class="health-item neg"><div class="health-label">Batt Discharged</div><div class="health-value">${fmt(t.battery_discharge_kwh, 2)} kWh</div></div>
-                        <div class="health-item"><div class="health-label">Grid Import</div><div class="health-value">${fmt(t.grid_import_kwh, 2)} kWh</div></div>
-                        <div class="health-item pos"><div class="health-label">Grid Export</div><div class="health-value">${fmt(t.grid_export_kwh, 2)} kWh</div></div>
+                        <div class="health-item cat-solar"><div class="health-label">Solar Today</div><div class="health-value">${fmt(t.solar_kwh, 2)} kWh</div></div>
+                        <div class="health-item cat-home"><div class="health-label">Home Today</div><div class="health-value">${fmt(t.home_kwh, 2)} kWh</div></div>
+                        <div class="health-item cat-battery"><div class="health-label">Batt Charged</div><div class="health-value">${fmt(t.battery_charge_kwh, 2)} kWh</div></div>
+                        <div class="health-item cat-battery"><div class="health-label">Batt Discharged</div><div class="health-value">${fmt(t.battery_discharge_kwh, 2)} kWh</div></div>
+                        <div class="health-item cat-grid"><div class="health-label">Grid Import</div><div class="health-value">${fmt(t.grid_import_kwh, 2)} kWh</div></div>
+                        <div class="health-item cat-grid"><div class="health-label">Grid Export</div><div class="health-value">${fmt(t.grid_export_kwh, 2)} kWh</div></div>
                     </div>`;
 
                     // History table for this gateway (most recent first)
@@ -1760,6 +1814,174 @@
                 console.log('Daily energy not available:', e.message);
             }
         }
+
+        // ---------------------------------------------------------------
+        // Energy Summary <-> Energy Trend toggle
+        // Clicking the card swaps the live 2x2 tiles for a 24-hour chart
+        // of raw time-series data (kW series + battery level on 2nd axis).
+        // ---------------------------------------------------------------
+        let energyTrendActive = false;
+        let energyTrendTimer = null;
+        let energyTrendPoints = null;
+
+        function toggleEnergyTrend() {
+            energyTrendActive = !energyTrendActive;
+            const card = document.getElementById('energy-card');
+            card.classList.toggle('trend-mode', energyTrendActive);
+            document.getElementById('energy-grid').style.display = energyTrendActive ? 'none' : '';
+            document.getElementById('energy-trend').style.display = energyTrendActive ? '' : 'none';
+            document.getElementById('energy-card-title-text').textContent =
+                energyTrendActive ? 'Energy Trend' : 'Energy Summary';
+            document.getElementById('energy-mode-hint').textContent =
+                energyTrendActive ? 'last 24 hours — click to return' : 'click for 24h trend';
+            if (energyTrendTimer) { clearInterval(energyTrendTimer); energyTrendTimer = null; }
+            if (energyTrendActive) {
+                loadEnergyTrend();
+                energyTrendTimer = setInterval(loadEnergyTrend, 60000);
+            } else {
+                energyTrendPoints = null;
+            }
+        }
+
+        async function loadEnergyTrend() {
+            const note = document.getElementById('energy-trend-note');
+            try {
+                const resp = await fetch('/api/timeseries/trend?hours=24');
+                if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+                const data = await resp.json();
+                if (!data.enabled) {
+                    energyTrendPoints = null;
+                    drawEnergyTrendChart();
+                    note.textContent = 'Energy Trend needs local time-series storage (PW_TIMESERIES_RETENTION not -1).';
+                    return;
+                }
+                const points = data.points || [];
+                if (points.length < 2) {
+                    energyTrendPoints = null;
+                    drawEnergyTrendChart();
+                    note.textContent = 'Not enough raw samples yet — the trend appears as data accumulates (24h retained).';
+                    return;
+                }
+                energyTrendPoints = points;
+                const span = points[points.length - 1].ts - points[0].ts;
+                const bucketMin = Math.round((data.bucket_seconds || 240) / 60);
+                note.textContent = `Last 24h of raw samples · ${bucketMin} min resolution · ${Math.round(span / 3600)}h of data`;
+                drawEnergyTrendChart();
+            } catch (e) {
+                energyTrendPoints = null;
+                drawEnergyTrendChart();
+                note.textContent = `Trend data unavailable: ${e.message}`;
+            }
+        }
+
+        // Standard colors: solar yellow, home blue, battery green, grid gray
+        const TREND_COLORS = {
+            solar: '#f0c000',
+            home: '#58a6ff',
+            battery: '#3fb950',
+            grid: '#8b949e'
+        };
+
+        function drawEnergyTrendChart() {
+            const canvas = document.getElementById('energy-trend-chart');
+            if (!canvas) return;
+            const rect = canvas.getBoundingClientRect();
+            canvas.width = rect.width;
+            canvas.height = rect.height;
+            const ctx = canvas.getContext('2d');
+            const W = canvas.width, H = canvas.height;
+            ctx.clearRect(0, 0, W, H);
+            const points = energyTrendPoints;
+            if (!points || points.length < 2 || W < 100) return;
+
+            const padL = 48, padR = 44, padT = 12, padB = 24;
+            const plotW = W - padL - padR, plotH = H - padT - padB;
+            const x0 = points[0].ts, x1 = points[points.length - 1].ts;
+            const xSpan = (x1 - x0) || 1;
+            const X = ts => padL + ((ts - x0) / xSpan) * plotW;
+
+            // kW scale (left axis) across solar/home/battery/grid, zero included
+            let minKw = 0, maxKw = 0;
+            for (const p of points) {
+                minKw = Math.min(minKw, p.solar_kw, p.home_kw, p.battery_kw, p.grid_kw);
+                maxKw = Math.max(maxKw, p.solar_kw, p.home_kw, p.battery_kw, p.grid_kw);
+            }
+            if (maxKw === minKw) maxKw = minKw + 1;
+            const Y = kw => padT + (1 - (kw - minKw) / (maxKw - minKw)) * plotH;
+            // Battery level scale (right axis, fixed 0-100%)
+            const Ypct = pct => padT + (1 - Math.max(0, Math.min(100, pct)) / 100) * plotH;
+
+            // Horizontal gridlines + left kW labels / right % labels
+            ctx.font = '11px system-ui, sans-serif';
+            ctx.textAlign = 'right';
+            ctx.textBaseline = 'middle';
+            for (let i = 0; i <= 4; i++) {
+                const kw = minKw + ((maxKw - minKw) * i) / 4;
+                const y = Y(kw);
+                ctx.strokeStyle = 'rgba(139, 148, 158, 0.15)';
+                ctx.lineWidth = 1;
+                ctx.beginPath(); ctx.moveTo(padL, y); ctx.lineTo(W - padR, y); ctx.stroke();
+                ctx.fillStyle = 'rgba(139, 148, 158, 0.8)';
+                ctx.fillText(kw.toFixed(1), padL - 6, y);
+                ctx.textAlign = 'left';
+                ctx.fillText(`${Math.round(i * 25)}%`, W - padR + 6, y);
+                ctx.textAlign = 'right';
+            }
+
+            // Zero line (battery/grid swing negative)
+            if (minKw < 0) {
+                const zy = Y(0);
+                ctx.strokeStyle = 'rgba(139, 148, 158, 0.4)';
+                ctx.setLineDash([4, 4]);
+                ctx.beginPath(); ctx.moveTo(padL, zy); ctx.lineTo(W - padR, zy); ctx.stroke();
+                ctx.setLineDash([]);
+                ctx.fillStyle = 'rgba(139, 148, 158, 0.9)';
+                ctx.textAlign = 'right';
+                ctx.textBaseline = 'middle';
+                ctx.fillText('0', padL - 6, zy);
+            }
+
+            // Time axis labels (~6 ticks), e.g. "4p"
+            ctx.fillStyle = 'rgba(139, 148, 158, 0.8)';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'top';
+            const ticks = Math.min(6, points.length - 1);
+            for (let i = 0; i <= ticks; i++) {
+                const ts = x0 + (xSpan * i) / ticks;
+                const d = new Date(ts * 1000);
+                const h = d.getHours();
+                const label = `${h % 12 || 12}${h >= 12 ? 'p' : 'a'}`;
+                ctx.fillText(label, X(ts), H - padB + 6);
+            }
+
+            const drawSeries = (key, color, dashed, yScale) => {
+                ctx.strokeStyle = color;
+                ctx.lineWidth = 1.8;
+                if (dashed) ctx.setLineDash([5, 4]);
+                ctx.beginPath();
+                let started = false;
+                for (const p of points) {
+                    const v = p[key];
+                    if (v == null) { started = false; continue; }
+                    const x = X(p.ts), y = yScale(v);
+                    if (!started) { ctx.moveTo(x, y); started = true; }
+                    else ctx.lineTo(x, y);
+                }
+                ctx.stroke();
+                ctx.setLineDash([]);
+            };
+
+            drawSeries('solar_kw', TREND_COLORS.solar, false, Y);
+            drawSeries('home_kw', TREND_COLORS.home, false, Y);
+            drawSeries('battery_kw', TREND_COLORS.battery, false, Y);
+            drawSeries('grid_kw', TREND_COLORS.grid, false, Y);
+            drawSeries('battery_level', TREND_COLORS.battery, true, Ypct);
+        }
+
+        document.getElementById('energy-card').addEventListener('click', toggleEnergyTrend);
+        window.addEventListener('resize', () => {
+            if (energyTrendActive) drawEnergyTrendChart();
+        });
 
         async function loadStats() {
             try {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -237,6 +237,28 @@
             grid-column: span 6;
             cursor: pointer;
         }
+        /* The summary grid always stays in flow and defines the card height;
+           the trend panel overlays it at the same footprint so flipping
+           between the two never shifts the panels below. */
+        .energy-body {
+            position: relative;
+        }
+        #energy-trend {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            display: none;
+            flex-direction: column;
+            overflow: hidden;
+        }
+        .energy-card.trend-mode .energy-grid {
+            visibility: hidden;
+        }
+        .energy-card.trend-mode #energy-trend {
+            display: flex;
+        }
         .energy-mode-hint {
             font-size: 0.8em;
             color: var(--text-secondary);
@@ -244,6 +266,7 @@
         .energy-trend-legend {
             display: flex;
             flex-wrap: wrap;
+            flex-shrink: 0;
             gap: 6px 16px;
             font-size: 0.8em;
             color: var(--text-secondary);
@@ -265,12 +288,15 @@
         }
         #energy-trend-chart {
             width: 100%;
-            height: 240px;
+            flex: 1 1 auto;
+            min-height: 140px;
+            height: auto;
             display: block;
         }
         .energy-trend-ranges {
             display: flex;
             flex-wrap: wrap;
+            flex-shrink: 0;
             gap: 4px;
             margin-bottom: 8px;
         }
@@ -292,6 +318,7 @@
             background: rgba(139, 148, 158, 0.2);
         }
         .energy-trend-note {
+            flex-shrink: 0;
             font-size: 0.8em;
             color: var(--text-muted);
             margin-top: 6px;
@@ -1127,6 +1154,7 @@
                     </div>
                     <div class="energy-mode-hint" id="energy-mode-hint">click for 24h trend</div>
                 </div>
+                <div class="energy-body">
                 <div class="energy-grid" id="energy-grid">
                     <div class="energy-item solar">
                         <canvas id="solar-trend" class="trend-chart"></canvas>
@@ -1168,8 +1196,8 @@
                         <div class="energy-detail" id="grid-status">--</div>
                     </div>
                 </div>
-                <!-- Energy Trend (shown while the card is toggled) -->
-                <div id="energy-trend" style="display:none">
+                <!-- Energy Trend (overlays the summary grid at the same footprint) -->
+                <div id="energy-trend">
                     <div class="energy-trend-ranges" id="energy-trend-ranges">
                         <button data-range="30m">30m</button>
                         <button data-range="1h">1hr</button>
@@ -1188,6 +1216,7 @@
                     </div>
                     <canvas id="energy-trend-chart"></canvas>
                     <div class="energy-trend-note" id="energy-trend-note"></div>
+                </div>
                 </div>
             </div>
             
@@ -1860,15 +1889,17 @@
         function toggleEnergyTrend() {
             energyTrendActive = !energyTrendActive;
             const card = document.getElementById('energy-card');
+            // .trend-mode hides the summary tiles (visibility only) and shows
+            // the trend panel as an overlay. The grid stays in flow, so the
+            // card keeps its exact height and the panels below never move.
             card.classList.toggle('trend-mode', energyTrendActive);
-            document.getElementById('energy-grid').style.display = energyTrendActive ? 'none' : '';
-            document.getElementById('energy-trend').style.display = energyTrendActive ? '' : 'none';
             document.getElementById('energy-card-title-text').textContent =
                 energyTrendActive ? 'Energy Trend' : 'Energy Summary';
             document.getElementById('energy-mode-hint').textContent =
-                energyTrendActive ? 'click to return' : 'click for 24h trend';
+                energyTrendActive ? 'click for summary' : 'click for 24h trend';
             if (energyTrendTimer) { clearInterval(energyTrendTimer); energyTrendTimer = null; }
             if (energyTrendActive) {
+                drawEnergyTrendChart();  // size the canvas bitmap to the new box
                 loadEnergyTrend();
                 energyTrendTimer = setInterval(loadEnergyTrend, 60000);
             } else {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -249,6 +249,13 @@
         .energy-body.swapping {
             opacity: 0;
         }
+        /* .energy-item has transition:all, which animates the inherited
+           visibility change — tiles would linger 200ms into the fade-in.
+           Suppress child transitions while swapping so the switch is
+           instant while the body is transparent. */
+        .energy-body.swapping * {
+            transition: none !important;
+        }
         #energy-trend {
             position: absolute;
             top: 0;
@@ -1920,10 +1927,13 @@
                     energyTrendPoints = null;
                     energyTrendDomain = null;
                 }
-                // Phase 3: fade the new panel in.
+                // Phase 3: let the swapped panel commit for one frame
+                // (child transitions still suppressed), then fade in.
                 requestAnimationFrame(() => {
-                    body.classList.remove('swapping');
-                    energyTrendSwapping = false;
+                    requestAnimationFrame(() => {
+                        body.classList.remove('swapping');
+                        energyTrendSwapping = false;
+                    });
                 });
             }, 160);
         }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1217,7 +1217,8 @@
                         <button data-range="3h">3hr</button>
                         <button data-range="6h">6hr</button>
                         <button data-range="12h">12hr</button>
-                        <button data-range="day" class="active">24hr</button>
+                        <button data-range="24h" class="active">24hr</button>
+                        <button data-range="day">Day</button>
                         <button data-range="fit">Fit</button>
                     </div>
                     <div class="energy-trend-legend">
@@ -1895,10 +1896,10 @@
         let energyTrendSwapping = false;
         let energyTrendTimer = null;
         let energyTrendPoints = null;
-        let energyTrendRange = 'day';   // '30m','1h','3h','6h','12h','day','fit'
+        let energyTrendRange = '24h';   // '30m','1h','3h','6h','12h','24h','day','fit'
         let energyTrendDomain = null;   // {t0, t1} epoch seconds for x-axis
 
-        const TREND_RANGE_MINUTES = { '30m': 30, '1h': 60, '3h': 180, '6h': 360, '12h': 720 };
+        const TREND_RANGE_MINUTES = { '30m': 30, '1h': 60, '3h': 180, '6h': 360, '12h': 720, '24h': 1440 };
 
         function toggleEnergyTrend() {
             if (energyTrendSwapping) return;  // ignore clicks mid-swap
@@ -1986,8 +1987,9 @@
                     t0 = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime() / 1000;
                     t1 = t0 + 86399;
                 } else if (energyTrendRange === 'fit') {
+                    // Fitted window from the API (earliest -> latest sample)
                     t0 = data.start || (points.length ? points[0].ts : now - 86400);
-                    t1 = now;
+                    t1 = data.end || now;
                 } else {
                     t0 = now - (TREND_RANGE_MINUTES[energyTrendRange] || 60) * 60;
                     t1 = now;

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -237,9 +237,6 @@
             grid-column: span 6;
             cursor: pointer;
         }
-        .energy-card.trend-mode {
-            grid-column: span 12;
-        }
         .energy-mode-hint {
             font-size: 0.8em;
             color: var(--text-secondary);
@@ -268,8 +265,31 @@
         }
         #energy-trend-chart {
             width: 100%;
-            height: 260px;
+            height: 240px;
             display: block;
+        }
+        .energy-trend-ranges {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            margin-bottom: 8px;
+        }
+        .energy-trend-ranges button {
+            background: transparent;
+            color: var(--text-secondary);
+            border: 1px solid rgba(139, 148, 158, 0.4);
+            border-radius: 4px;
+            font-size: 0.75em;
+            padding: 2px 8px;
+            cursor: pointer;
+        }
+        .energy-trend-ranges button:hover {
+            border-color: var(--text-secondary);
+        }
+        .energy-trend-ranges button.active {
+            color: var(--text-primary, #e6edf3);
+            border-color: var(--text-secondary);
+            background: rgba(139, 148, 158, 0.2);
         }
         .energy-trend-note {
             font-size: 0.8em;
@@ -1150,6 +1170,15 @@
                 </div>
                 <!-- Energy Trend (shown while the card is toggled) -->
                 <div id="energy-trend" style="display:none">
+                    <div class="energy-trend-ranges" id="energy-trend-ranges">
+                        <button data-range="30m">30m</button>
+                        <button data-range="1h">1hr</button>
+                        <button data-range="3h">3hr</button>
+                        <button data-range="6h">6hr</button>
+                        <button data-range="12h">12hr</button>
+                        <button data-range="day" class="active">24hr</button>
+                        <button data-range="fit">Fit</button>
+                    </div>
                     <div class="energy-trend-legend">
                         <span class="key"><span class="swatch" style="background: var(--solar-color)"></span>Solar kW</span>
                         <span class="key"><span class="swatch" style="background: var(--home-color)"></span>Home kW</span>
@@ -1823,6 +1852,10 @@
         let energyTrendActive = false;
         let energyTrendTimer = null;
         let energyTrendPoints = null;
+        let energyTrendRange = 'day';   // '30m','1h','3h','6h','12h','day','fit'
+        let energyTrendDomain = null;   // {t0, t1} epoch seconds for x-axis
+
+        const TREND_RANGE_MINUTES = { '30m': 30, '1h': 60, '3h': 180, '6h': 360, '12h': 720 };
 
         function toggleEnergyTrend() {
             energyTrendActive = !energyTrendActive;
@@ -1833,20 +1866,48 @@
             document.getElementById('energy-card-title-text').textContent =
                 energyTrendActive ? 'Energy Trend' : 'Energy Summary';
             document.getElementById('energy-mode-hint').textContent =
-                energyTrendActive ? 'last 24 hours — click to return' : 'click for 24h trend';
+                energyTrendActive ? 'click to return' : 'click for 24h trend';
             if (energyTrendTimer) { clearInterval(energyTrendTimer); energyTrendTimer = null; }
             if (energyTrendActive) {
                 loadEnergyTrend();
                 energyTrendTimer = setInterval(loadEnergyTrend, 60000);
             } else {
                 energyTrendPoints = null;
+                energyTrendDomain = null;
             }
         }
 
+        document.querySelectorAll('#energy-trend-ranges button').forEach(btn => {
+            btn.addEventListener('click', ev => {
+                ev.stopPropagation();  // don't toggle the card off
+                energyTrendRange = btn.dataset.range;
+                document.querySelectorAll('#energy-trend-ranges button').forEach(b =>
+                    b.classList.toggle('active', b === btn));
+                loadEnergyTrend();
+            });
+        });
+
         async function loadEnergyTrend() {
             const note = document.getElementById('energy-trend-note');
+            const params = new URLSearchParams();
+            const now = Date.now() / 1000;
+            let label;
+            if (energyTrendRange === 'fit') {
+                params.set('fit', 'true');
+                label = 'all retained data';
+            } else if (energyTrendRange === 'day') {
+                // Full local day 0:00 to 23:59
+                const d = new Date();
+                const midnight = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime() / 1000;
+                params.set('start', midnight);
+                label = 'today 0:00\u201323:59';
+            } else {
+                const mins = TREND_RANGE_MINUTES[energyTrendRange] || 60;
+                params.set('start', Math.round(now - mins * 60));
+                label = `last ${mins >= 60 ? (mins / 60) + 'h' : mins + 'm'}`;
+            }
             try {
-                const resp = await fetch('/api/timeseries/trend?hours=24');
+                const resp = await fetch('/api/timeseries/trend?' + params.toString());
                 if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
                 const data = await resp.json();
                 if (!data.enabled) {
@@ -1856,16 +1917,30 @@
                     return;
                 }
                 const points = data.points || [];
+                // x-axis domain: requested window (day view spans to end of
+                // day even before data exists up to it)
+                let t0, t1;
+                if (energyTrendRange === 'day') {
+                    const d = new Date();
+                    t0 = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime() / 1000;
+                    t1 = t0 + 86399;
+                } else if (energyTrendRange === 'fit') {
+                    t0 = data.start || (points.length ? points[0].ts : now - 86400);
+                    t1 = now;
+                } else {
+                    t0 = now - (TREND_RANGE_MINUTES[energyTrendRange] || 60) * 60;
+                    t1 = now;
+                }
+                energyTrendDomain = { t0, t1 };
                 if (points.length < 2) {
                     energyTrendPoints = null;
                     drawEnergyTrendChart();
-                    note.textContent = 'Not enough raw samples yet — the trend appears as data accumulates (24h retained).';
+                    note.textContent = 'Not enough raw samples in this window yet \u2014 the trend appears as data accumulates.';
                     return;
                 }
                 energyTrendPoints = points;
-                const span = points[points.length - 1].ts - points[0].ts;
                 const bucketMin = Math.round((data.bucket_seconds || 240) / 60);
-                note.textContent = `Last 24h of raw samples · ${bucketMin} min resolution · ${Math.round(span / 3600)}h of data`;
+                note.textContent = `${label} \u00b7 ${bucketMin >= 60 ? (bucketMin / 60) + 'h' : bucketMin + ' min'} resolution \u00b7 ${points.length} points`;
                 drawEnergyTrendChart();
             } catch (e) {
                 energyTrendPoints = null;
@@ -1896,7 +1971,8 @@
 
             const padL = 48, padR = 44, padT = 12, padB = 24;
             const plotW = W - padL - padR, plotH = H - padT - padB;
-            const x0 = points[0].ts, x1 = points[points.length - 1].ts;
+            const dom = energyTrendDomain || { t0: points[0].ts, t1: points[points.length - 1].ts };
+            const x0 = dom.t0, x1 = dom.t1;
             const xSpan = (x1 - x0) || 1;
             const X = ts => padL + ((ts - x0) / xSpan) * plotW;
 
@@ -1954,28 +2030,50 @@
                 ctx.fillText(label, X(ts), H - padB + 6);
             }
 
-            const drawSeries = (key, color, dashed, yScale) => {
-                ctx.strokeStyle = color;
-                ctx.lineWidth = 1.8;
-                if (dashed) ctx.setLineDash([5, 4]);
-                ctx.beginPath();
-                let started = false;
+            const drawSeries = (key, color, dashed, yScale, fill) => {
+                // Collect contiguous segments (gaps where v == null)
+                const segments = [];
+                let seg = [];
                 for (const p of points) {
                     const v = p[key];
-                    if (v == null) { started = false; continue; }
-                    const x = X(p.ts), y = yScale(v);
-                    if (!started) { ctx.moveTo(x, y); started = true; }
-                    else ctx.lineTo(x, y);
+                    if (v == null) {
+                        if (seg.length > 1) segments.push(seg);
+                        seg = [];
+                    } else {
+                        seg.push([X(p.ts), yScale(v)]);
+                    }
                 }
-                ctx.stroke();
-                ctx.setLineDash([]);
+                if (seg.length > 1) segments.push(seg);
+                for (const s of segments) {
+                    if (fill) {
+                        // Translucent fill between line and zero axis
+                        const zy = Y(0);
+                        ctx.fillStyle = color;
+                        ctx.globalAlpha = 0.12;
+                        ctx.beginPath();
+                        ctx.moveTo(s[0][0], zy);
+                        for (const [sx, sy] of s) ctx.lineTo(sx, sy);
+                        ctx.lineTo(s[s.length - 1][0], zy);
+                        ctx.closePath();
+                        ctx.fill();
+                        ctx.globalAlpha = 1;
+                    }
+                    ctx.strokeStyle = color;
+                    ctx.lineWidth = 1.8;
+                    if (dashed) ctx.setLineDash([5, 4]);
+                    ctx.beginPath();
+                    ctx.moveTo(s[0][0], s[0][1]);
+                    for (let i = 1; i < s.length; i++) ctx.lineTo(s[i][0], s[i][1]);
+                    ctx.stroke();
+                    ctx.setLineDash([]);
+                }
             };
 
-            drawSeries('solar_kw', TREND_COLORS.solar, false, Y);
-            drawSeries('home_kw', TREND_COLORS.home, false, Y);
-            drawSeries('battery_kw', TREND_COLORS.battery, false, Y);
-            drawSeries('grid_kw', TREND_COLORS.grid, false, Y);
-            drawSeries('battery_level', TREND_COLORS.battery, true, Ypct);
+            drawSeries('solar_kw', TREND_COLORS.solar, false, Y, true);
+            drawSeries('home_kw', TREND_COLORS.home, false, Y, true);
+            drawSeries('battery_kw', TREND_COLORS.battery, false, Y, true);
+            drawSeries('grid_kw', TREND_COLORS.grid, false, Y, true);
+            drawSeries('battery_level', TREND_COLORS.battery, true, Ypct, false);
         }
 
         document.getElementById('energy-card').addEventListener('click', toggleEnergyTrend);

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -239,9 +239,15 @@
         }
         /* The summary grid always stays in flow and defines the card height;
            the trend panel overlays it at the same footprint so flipping
-           between the two never shifts the panels below. */
+           between the two never shifts the panels below. The swap is
+           two-phase: fade out, switch panels while fully transparent, fade
+           back in — the two panels never show at the same time. */
         .energy-body {
             position: relative;
+            transition: opacity 150ms ease;
+        }
+        .energy-body.swapping {
+            opacity: 0;
         }
         #energy-trend {
             position: absolute;
@@ -1879,6 +1885,7 @@
         // of raw time-series data (kW series + battery level on 2nd axis).
         // ---------------------------------------------------------------
         let energyTrendActive = false;
+        let energyTrendSwapping = false;
         let energyTrendTimer = null;
         let energyTrendPoints = null;
         let energyTrendRange = 'day';   // '30m','1h','3h','6h','12h','day','fit'
@@ -1887,25 +1894,38 @@
         const TREND_RANGE_MINUTES = { '30m': 30, '1h': 60, '3h': 180, '6h': 360, '12h': 720 };
 
         function toggleEnergyTrend() {
+            if (energyTrendSwapping) return;  // ignore clicks mid-swap
+            energyTrendSwapping = true;
             energyTrendActive = !energyTrendActive;
             const card = document.getElementById('energy-card');
-            // .trend-mode hides the summary tiles (visibility only) and shows
-            // the trend panel as an overlay. The grid stays in flow, so the
-            // card keeps its exact height and the panels below never move.
-            card.classList.toggle('trend-mode', energyTrendActive);
-            document.getElementById('energy-card-title-text').textContent =
-                energyTrendActive ? 'Energy Trend' : 'Energy Summary';
-            document.getElementById('energy-mode-hint').textContent =
-                energyTrendActive ? 'click for summary' : 'click for 24h trend';
-            if (energyTrendTimer) { clearInterval(energyTrendTimer); energyTrendTimer = null; }
-            if (energyTrendActive) {
-                drawEnergyTrendChart();  // size the canvas bitmap to the new box
-                loadEnergyTrend();
-                energyTrendTimer = setInterval(loadEnergyTrend, 60000);
-            } else {
-                energyTrendPoints = null;
-                energyTrendDomain = null;
-            }
+            const body = card.querySelector('.energy-body');
+            // Phase 1: fade the current panel out completely.
+            body.classList.add('swapping');
+            setTimeout(() => {
+                // Phase 2: swap panels while fully transparent. .trend-mode
+                // hides the summary tiles (visibility only) and shows the
+                // trend overlay. The grid stays in flow, so the card keeps
+                // its exact height and the panels below never move.
+                card.classList.toggle('trend-mode', energyTrendActive);
+                document.getElementById('energy-card-title-text').textContent =
+                    energyTrendActive ? 'Energy Trend' : 'Energy Summary';
+                document.getElementById('energy-mode-hint').textContent =
+                    energyTrendActive ? 'click for summary' : 'click for 24h trend';
+                if (energyTrendTimer) { clearInterval(energyTrendTimer); energyTrendTimer = null; }
+                if (energyTrendActive) {
+                    drawEnergyTrendChart();  // size the canvas bitmap to the new box
+                    loadEnergyTrend();
+                    energyTrendTimer = setInterval(loadEnergyTrend, 60000);
+                } else {
+                    energyTrendPoints = null;
+                    energyTrendDomain = null;
+                }
+                // Phase 3: fade the new panel in.
+                requestAnimationFrame(() => {
+                    body.classList.remove('swapping');
+                    energyTrendSwapping = false;
+                });
+            }, 160);
         }
 
         document.querySelectorAll('#energy-trend-ranges button').forEach(btn => {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -671,6 +671,54 @@
         .mqtt-card {
             grid-column: span 12;
         }
+
+        /* Daily Energy Card */
+        .daily-energy-card {
+            grid-column: span 12;
+        }
+        .daily-energy-hint {
+            font-size: 0.8em;
+            color: var(--text-secondary);
+        }
+        .daily-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+        .daily-grid .health-item {
+            padding: 8px 12px;
+            border-left: 3px solid var(--text-muted);
+        }
+        .daily-grid .health-item.pos {
+            border-left-color: var(--accent-green);
+        }
+        .daily-grid .health-item.neg {
+            border-left-color: var(--accent-yellow, #d29922);
+        }
+        .daily-grid .health-value {
+            font-size: 0.95em;
+        }
+        .daily-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.85em;
+        }
+        .daily-table th, .daily-table td {
+            text-align: right;
+            padding: 4px 8px;
+            border-bottom: 1px solid rgba(255,255,255,0.06);
+        }
+        .daily-table th:first-child, .daily-table td:first-child {
+            text-align: left;
+        }
+        .daily-table th {
+            color: var(--text-secondary);
+            font-weight: 500;
+        }
+        .daily-table tr.today td {
+            color: var(--accent-green);
+        }
         .mqtt-status-badge {
             font-size: 0.8em;
             font-weight: 600;
@@ -1251,6 +1299,25 @@
                     </div>
                 </div>
             </div>
+
+            <!-- Daily Energy (hidden until time-series storage is enabled) -->
+            <div class="card daily-energy-card" id="daily-energy-card" style="display:none">
+                <div class="card-header">
+                    <div class="card-title">
+                        <span class="icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M12 2v7" fill="none"/>
+                                <path d="M9 9h6l-3 5h3l-6 8 2-6H8z" fill="none"/>
+                            </svg>
+                        </span>
+                        Daily Energy
+                    </div>
+                    <div class="daily-energy-hint">kWh per day — local time-series storage</div>
+                </div>
+                <div id="daily-energy-content" class="daily-energy-content">
+                    <div class="no-strings">Loading daily energy...</div>
+                </div>
+            </div>
         </div>
     </div>
     
@@ -1620,6 +1687,77 @@
                 document.getElementById('mqtt-tls').textContent = mqtt.tls ? 'Enabled' : 'Disabled';
             } catch (e) {
                 // MQTT endpoint unavailable — silently skip
+            }
+        }
+
+        // Fetch daily energy totals from the time-series store
+        async function loadDailyEnergy() {
+            const card = document.getElementById('daily-energy-card');
+            const container = document.getElementById('daily-energy-content');
+            try {
+                const todayResp = await fetch('/api/timeseries/today');
+                if (!todayResp.ok) return;
+                const today = await todayResp.json();
+                if (!today.enabled) { card.style.display = 'none'; return; }
+
+                const gwIds = Object.keys(today.gateways || {});
+                if (!gwIds.length) {
+                    card.style.display = '';
+                    container.innerHTML = '<div class="no-strings">No energy samples recorded yet — totals appear after the first polls.</div>';
+                    return;
+                }
+
+                // Recent history (includes today)
+                let days = {};
+                try {
+                    const histResp = await fetch('/api/timeseries/daily?days=8');
+                    if (histResp.ok) {
+                        const hist = await histResp.json();
+                        for (const d of (hist.days || [])) days[d.day] = d.gateways;
+                    }
+                } catch (e) { /* history optional */ }
+
+                const fmt = (v, dp=1) => (v == null ? '--' : v.toFixed(dp));
+                let html = '';
+                const isMulti = Object.keys(gatewayMeta).length > 1;
+
+                for (const gwId of gwIds) {
+                    if (isMulti) html += `<div class="gateway-section-header">${gatewayMeta[gwId]?.name || gwId}</div>`;
+                    const t = today.gateways[gwId] || {};
+                    html += `<div class="daily-grid">
+                        <div class="health-item pos"><div class="health-label">Solar Today</div><div class="health-value">${fmt(t.solar_kwh, 2)} kWh</div></div>
+                        <div class="health-item"><div class="health-label">Home Today</div><div class="health-value">${fmt(t.home_kwh, 2)} kWh</div></div>
+                        <div class="health-item pos"><div class="health-label">Batt Charged</div><div class="health-value">${fmt(t.battery_charge_kwh, 2)} kWh</div></div>
+                        <div class="health-item neg"><div class="health-label">Batt Discharged</div><div class="health-value">${fmt(t.battery_discharge_kwh, 2)} kWh</div></div>
+                        <div class="health-item"><div class="health-label">Grid Import</div><div class="health-value">${fmt(t.grid_import_kwh, 2)} kWh</div></div>
+                        <div class="health-item pos"><div class="health-label">Grid Export</div><div class="health-value">${fmt(t.grid_export_kwh, 2)} kWh</div></div>
+                    </div>`;
+
+                    // History table for this gateway (most recent first)
+                    const rows = Object.entries(days)
+                        .filter(([, gws]) => gws && gws[gwId])
+                        .sort((a, b) => b[0].localeCompare(a[0]))
+                        .slice(0, 7);
+                    if (rows.length) {
+                        const todayKey = t.day;
+                        html += `<table class="daily-table"><thead><tr>
+                            <th>Day</th><th>Solar</th><th>Home</th><th>Batt Chg</th><th>Batt Dchg</th><th>Grid Imp</th><th>Grid Exp</th>
+                        </tr></thead><tbody>`;
+                        for (const [day, gws] of rows) {
+                            const r = gws[gwId];
+                            html += `<tr${day === todayKey ? ' class="today"' : ''}><td>${day}</td>
+                                <td>${fmt(r.solar_kwh)}</td><td>${fmt(r.home_kwh)}</td>
+                                <td>${fmt(r.battery_charge_kwh)}</td><td>${fmt(r.battery_discharge_kwh)}</td>
+                                <td>${fmt(r.grid_import_kwh)}</td><td>${fmt(r.grid_export_kwh)}</td></tr>`;
+                        }
+                        html += '</tbody></table>';
+                    }
+                }
+                card.style.display = '';
+                container.innerHTML = html || '<div class="no-strings">No energy data yet</div>';
+            } catch (e) {
+                // Time-series endpoints unavailable — keep the card hidden
+                console.log('Daily energy not available:', e.message);
             }
         }
 
@@ -2157,6 +2295,7 @@
             loadPowerwalls();
             loadGateways();
             loadMqtt();
+            loadDailyEnergy();
 
             // Refresh secondary data periodically
             setInterval(() => {
@@ -2166,6 +2305,7 @@
                 loadPowerwalls();
                 loadGateways();
                 loadMqtt();
+                loadDailyEnergy();
             }, 30000);
         })();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,13 @@ services:
       
       # Control features (optional) - Uncomment to enable:
       # - PW_CONTROL_SECRET=your-secure-random-token-here
+      
+      # Time-series daily energy stats (optional) - SQLite store lives at
+      # /data/timeseries.db by default; mount the volume to keep history:
+      # - PW_TIMESERIES_RETENTION=24h       # raw sample window; -1 disables
+      # - PW_TIMESERIES_DAILY_RETENTION=0   # daily kWh rows; 0 = unlimited
+    volumes:
+      - pws-data:/data
     # Health check - verifies the server process is running and responding.
     # /health always returns HTTP 200 regardless of gateway connectivity,
     # making it safe for process-level liveness checking. wget is included
@@ -55,3 +62,6 @@ services:
 networks:
   pypowerwall:
     driver: bridge
+
+volumes:
+  pws-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.4.3"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.5.0"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,10 @@ import pytest
 from unittest.mock import Mock
 from fastapi.testclient import TestClient
 from app.main import app
+from app.config import settings
 from app.core.gateway_manager import gateway_manager
 from app.core.scaling import raw_to_tesla_battery_percent
+from app.core.timeseries import reset_timeseries_store
 
 
 def _reset_singleton_state():
@@ -42,6 +44,22 @@ def reset_gateway_manager():
     _reset_singleton_state()
     yield
     _reset_singleton_state()
+
+
+@pytest.fixture(autouse=True)
+def isolate_timeseries_store(tmp_path, monkeypatch):
+    """Redirect the TimeSeriesStore to a per-test temp directory.
+
+    Tests that exercise the poll loop record real samples; without this
+    they would create data/timeseries.db in the repo checkout. Dedicated
+    time-series tests construct TimeSeriesStore directly.
+    """
+    monkeypatch.setattr(
+        settings, "timeseries_path", str(tmp_path / "timeseries.db")
+    )
+    reset_timeseries_store()
+    yield
+    reset_timeseries_store()
 
 
 @pytest.fixture

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,0 +1,434 @@
+"""Tests for the TimeSeriesStore (app/core/timeseries.py).
+
+Covers:
+    - parse_duration retention parsing
+    - Directional sign splitting (battery charge/discharge, grid import/export)
+    - Trapezoidal power->kWh integration accuracy
+    - Local-midnight day splitting (energy accrues to the correct local day)
+    - 1-hour gap threshold (no integration across stale gaps)
+    - Restart persistence (integration state + daily aggregates survive close)
+    - Out-of-order / duplicate sample handling
+    - Raw sample pruning vs. the keep-floor
+    - Disabled subsystem (PW_TIMESERIES_RETENTION=-1)
+    - /api/timeseries/* endpoints (enabled and disabled)
+"""
+import asyncio
+import math
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.core.timeseries import (
+    GAP_THRESHOLD,
+    RAW_KEEP_FLOOR,
+    TimeSeriesStore,
+    parse_duration,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_duration
+# ---------------------------------------------------------------------------
+
+
+class TestParseDuration:
+    def test_suffixed(self):
+        assert parse_duration("24h") == 86400
+        assert parse_duration("7d") == 604800
+        assert parse_duration("30d") == 2592000
+        assert parse_duration("365d") == 31536000
+        assert parse_duration("90s") == 90
+        assert parse_duration("2w") == 1209600
+        assert parse_duration("10m") == 600
+
+    def test_bare_number_is_seconds(self):
+        assert parse_duration("3600") == 3600
+        assert parse_duration("0") == 0
+
+    def test_disabled_and_negative(self):
+        assert parse_duration("-1") == -1
+        assert parse_duration("-24h") == -1
+        assert parse_duration("-5") == -1
+
+    def test_invalid_raises(self):
+        for bad in ("", "abc", "12x", "h", "1.5h"):
+            with pytest.raises(ValueError):
+                parse_duration(bad)
+
+    def test_coerce_in_constructor(self):
+        store = TimeSeriesStore(db_path=":memory:", retention="garbage")
+        # Falls back to default 24h rather than raising
+        assert store._retention == 86400
+        store = TimeSeriesStore(db_path=":memory:", retention=7 * 86400)
+        assert store._retention == 604800
+        store = TimeSeriesStore(db_path=":memory:", retention=-1)
+        assert store.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Core recording + integration
+# ---------------------------------------------------------------------------
+
+
+async def record(store, ts, solar=0.0, home=0.0, battery=0.0, site=0.0,
+                 soe=None, tz="UTC", gw="gw1"):
+    return await store.record_sample(
+        gateway_id=gw, ts=ts, solar_w=solar, home_w=home,
+        battery_w=battery, site_w=site, soe=soe, timezone=tz,
+    )
+
+
+class TestIntegration:
+    @pytest.mark.asyncio
+    async def test_ramp_up_integration(self, tmp_path):
+        """First sample is 0 W, second is 3600 W one hour later.
+        Trapezoid = average power * time = 1800 W * 1 h = 1.8 kWh per
+        category — proving linear interpolation rather than assuming either
+        endpoint's power for the whole interval.
+        """
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        await record(store, 1000.0)
+        row = await record(store, 1000.0 + 3600, solar=3600, home=3600,
+                           battery=-3600, site=3600)
+        assert row["solar_kwh"] == pytest.approx(1.8)
+        assert row["home_kwh"] == pytest.approx(1.8)
+        assert row["battery_charge_kwh"] == pytest.approx(1.8)
+        assert row["grid_import_kwh"] == pytest.approx(1.8)
+        # Discharge/export stayed zero (negative battery = charging)
+        assert row["battery_discharge_kwh"] == pytest.approx(0.0)
+        assert row["grid_export_kwh"] == pytest.approx(0.0)
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_steady_state_accuracy(self, tmp_path):
+        """Both endpoints at the same power: 3600 W * 1 h = 1 kWh exactly."""
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        await record(store, 2000.0, solar=3600, home=2000, battery=-1000, site=-1000)
+        row = await record(store, 2000.0 + 3600, solar=3600, home=2000,
+                           battery=-1000, site=-1000)
+        assert row["solar_kwh"] == pytest.approx(3.6)
+        assert row["home_kwh"] == pytest.approx(2.0)
+        assert row["battery_charge_kwh"] == pytest.approx(1.0)
+        assert row["grid_export_kwh"] == pytest.approx(1.0)
+        assert row["grid_import_kwh"] == pytest.approx(0.0)
+        assert row["battery_discharge_kwh"] == pytest.approx(0.0)
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_directional_split_no_netting(self, tmp_path):
+        """Sign flips fill the correct bucket; buckets never net to zero.
+
+        Note: integration interpolates the directional components (charge
+        and discharge as separate non-negative series), so an interval where
+        power crosses zero accrues to BOTH buckets (triangle halves). At the
+        5s poll interval the crossing window is sub-second, making this
+        negligible in practice while guaranteeing directions never net.
+        """
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        # Hour 1: battery discharging 2000W, grid importing 1000W
+        await record(store, 0.0, battery=2000, site=1000)
+        row = await record(store, 3600.0, battery=2000, site=1000)
+        assert row["battery_discharge_kwh"] == pytest.approx(2.0)
+        assert row["grid_import_kwh"] == pytest.approx(1.0)
+        assert row["battery_charge_kwh"] == pytest.approx(0.0)
+        assert row["grid_export_kwh"] == pytest.approx(0.0)
+        # Hour 2: full sign flip to charging 2000W / exporting 1000W.
+        # Both directions accrue from the component ramps (import 1000->0,
+        # export 0->1000): +0.5 kWh each.
+        row = await record(store, 7200.0, battery=-2000, site=-1000)
+        assert row["battery_charge_kwh"] == pytest.approx(1.0)
+        assert row["grid_export_kwh"] == pytest.approx(0.5)
+        # Import/discharge grew only via their component ramps — never netted
+        assert row["grid_import_kwh"] == pytest.approx(1.5)
+        assert row["battery_discharge_kwh"] == pytest.approx(3.0)
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_gap_threshold_no_integration(self, tmp_path):
+        """A gap longer than 1 hour must not fabricate energy."""
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        await record(store, 0.0, solar=5000)
+        # Jump forward past the gap threshold
+        row = await record(store, GAP_THRESHOLD + 100, solar=5000)
+        assert row is None  # gap -> no integration, no daily row returned
+        daily = await store.get_daily_energy(days=7)
+        totals = [g for d in daily["days"] for g in d["gateways"].values()]
+        assert all(t["solar_kwh"] == 0.0 for t in totals)
+        # The raw sample itself was still stored
+        samples = await store.get_samples()
+        assert samples["count"] == 2
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_midnight_split(self, tmp_path):
+        """Energy on either side of local midnight lands on its own day."""
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        # UTC timezone; midnight falls on integer 86400 boundaries.
+        # Three samples at 23:00, 00:00, 01:00 — each interval is exactly
+        # 3600s (the gap threshold, still integrated) at steady 1200 W.
+        midnight = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ).timestamp()
+        t0 = midnight - 3600
+        tmid = midnight
+        t1 = midnight + 3600
+        day1 = datetime.fromtimestamp(t0, timezone.utc).date().isoformat()
+        day2 = datetime.fromtimestamp(t1, timezone.utc).date().isoformat()
+        assert day1 != day2
+        await record(store, t0, solar=1200)
+        await record(store, tmid, solar=1200)
+        await record(store, t1, solar=1200)
+        daily = await store.get_daily_energy(days=7)
+        by_day = {d["day"]: d["gateways"]["gw1"] for d in daily["days"]}
+        assert by_day[day1]["solar_kwh"] == pytest.approx(1.2)  # 1200W * 1h
+        assert by_day[day2]["solar_kwh"] == pytest.approx(1.2)
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_dst_timezone_supported(self, tmp_path):
+        """A named timezone with DST resolves without error; totals right
+        regardless of which local day they land on."""
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        t0 = time.time() - 3600
+        await record(store, t0, solar=1000, tz="America/Los_Angeles")
+        await record(store, t0 + 3600, solar=1000, tz="America/Los_Angeles")
+        daily = await store.get_daily_energy(days=7)
+        total = sum(
+            g["solar_kwh"] for d in daily["days"] for g in d["gateways"].values()
+        )
+        assert total == pytest.approx(1.0)
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_unknown_timezone_falls_back_to_utc(self, tmp_path):
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        midnight = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ).timestamp()
+        t0 = midnight - 3600
+        await record(store, t0, solar=1200, tz="Not/ARealZone")
+        await record(store, midnight, solar=1200, tz="Not/ARealZone")
+        await record(store, t0 + 2 * 3600, solar=1200, tz="Not/ARealZone")
+        daily = await store.get_daily_energy(days=7)
+        assert len(daily["days"]) >= 1  # no crash; days split at UTC midnight
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_out_of_order_and_duplicate_samples(self, tmp_path):
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        await record(store, 1000.0, solar=1000)
+        # 5s at 1000 W -> 0.0013888 kWh
+        row = await record(store, 1005.0, solar=1000)
+        assert row["solar_kwh"] == pytest.approx(1000 * 5 / 3.6e6)
+        # Duplicate timestamp: stored, no double integration
+        assert await record(store, 1005.0, solar=1000) is None
+        # Out-of-order older sample: stored as raw data, not integrated
+        assert await record(store, 1002.0, solar=999) is None
+        # Next in-order sample integrates only from ts=1005 (state unmoved)
+        row = await record(store, 1010.0, solar=1000)
+        assert row["solar_kwh"] == pytest.approx(2 * 1000 * 5 / 3.6e6)
+        samples = await store.get_samples(limit=10)
+        assert samples["count"] == 4  # raw rows kept even when not integrated
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_multi_gateway_isolation(self, tmp_path):
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        now = time.time()
+        await record(store, now, solar=1000, gw="a")
+        await record(store, now + 3600, solar=1000, gw="a")
+        await record(store, now, solar=2000, gw="b")
+        await record(store, now + 3600, solar=2000, gw="b")
+        daily = await store.get_daily_energy(days=7)
+        day = daily["days"][0]["gateways"]
+        assert day["a"]["solar_kwh"] == pytest.approx(1.0)
+        assert day["b"]["solar_kwh"] == pytest.approx(2.0)
+        await store.stop()
+
+
+# ---------------------------------------------------------------------------
+# Persistence + maintenance
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenceAndMaintenance:
+    @pytest.mark.asyncio
+    async def test_restart_resumes_without_double_counting(self, tmp_path):
+        path = str(tmp_path / "ts.db")
+        store = TimeSeriesStore(db_path=path)
+        await record(store, 0.0, solar=1000)
+        await record(store, 3600.0, solar=1000)
+        await store.stop()
+
+        # "Restart": fresh instance on the same file
+        store2 = TimeSeriesStore(db_path=path)
+        # Same-timestamp duplicate: no new energy
+        row = await record(store2, 3600.0, solar=1000)
+        assert row is None
+        row = await record(store2, 7200.0, solar=1000)
+        assert row["solar_kwh"] == pytest.approx(2.0)  # 1h + 1h
+        await store2.stop()
+
+    @pytest.mark.asyncio
+    async def test_maintenance_prunes_old_samples_keeps_floor(self, tmp_path):
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"), retention=7200)
+        now = time.time()
+        # Samples spanning well beyond the 2h retention
+        for i in range(20):
+            await record(store, now - 86400 + i * 300, solar=1000)
+        for i in range(20):
+            await record(store, now - 3600 + i * 60, solar=1000)
+        await store.maintenance()
+        samples = await store.get_samples(limit=10000)
+        oldest = samples["samples"][0]["ts"]
+        # Everything older than max(2h, 1h floor) is gone...
+        assert oldest >= now - max(7200, RAW_KEEP_FLOOR) - 60
+        # ...and daily aggregates were preserved despite pruning
+        daily = await store.get_daily_energy(days=7)
+        assert sum(
+            g["solar_kwh"] for d in daily["days"] for g in d["gateways"].values()
+        ) > 0
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_status(self, tmp_path):
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        await record(store, time.time(), solar=100)
+        await record(store, time.time() + 5, solar=100)
+        s = await store.status()
+        assert s["enabled"] is True
+        assert s["samples"] == 2
+        assert s["db_size_bytes"] > 0
+        assert "gw1" in s["gateways"]
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_samples_query_filters(self, tmp_path):
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        for i in range(10):
+            await record(store, 1000.0 + i * 10, solar=100, gw="a")
+            await record(store, 1000.0 + i * 10, solar=100, gw="b")
+        out = await store.get_samples(gateway="a", start=1015, end=1040, limit=5)
+        assert out["count"] == 3
+        assert all(s["gateway_id"] == "a" for s in out["samples"])
+        ts_list = [s["ts"] for s in out["samples"]]
+        assert ts_list == sorted(ts_list)
+        await store.stop()
+
+
+# ---------------------------------------------------------------------------
+# Disabled subsystem
+# ---------------------------------------------------------------------------
+
+
+class TestDisabled:
+    @pytest.mark.asyncio
+    async def test_disabled_never_touches_disk(self, tmp_path):
+        db = tmp_path / "ts.db"
+        store = TimeSeriesStore(db_path=str(db), retention="-1")
+        assert store.enabled is False
+        row = await record(store, time.time(), solar=1000)
+        assert row is None
+        await store.start()  # no-op
+        assert (await store.get_daily_energy())["enabled"] is False
+        assert (await store.get_samples())["enabled"] is False
+        s = await store.status()
+        assert s["enabled"] is False and s["db_path"] is None
+        await store.stop()
+        assert not db.exists()  # nothing was ever written
+
+    def test_maintenance_disabled_noop(self, tmp_path):
+        store = TimeSeriesStore(db_path=str(tmp_path / "x.db"), retention="-1")
+        assert asyncio.run(store.maintenance()) is None
+
+
+# ---------------------------------------------------------------------------
+# API endpoints (uses the app TestClient; conftest isolates the DB path)
+# ---------------------------------------------------------------------------
+
+
+class TestAPI:
+    def test_status_endpoint_enabled(self, client):
+        resp = client.get("/api/timeseries/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enabled"] is True
+        assert "retention_seconds" in body
+
+    def test_today_endpoint_shape(self, client):
+        resp = client.get("/api/timeseries/today")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enabled"] is True
+        assert body["gateways"] == {}  # no gateways configured in tests
+        assert "server_time" in body
+
+    def test_daily_endpoint_shape(self, client):
+        resp = client.get("/api/timeseries/daily?days=7")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enabled"] is True
+        assert body["days"] == []
+
+    def test_daily_endpoint_validation(self, client):
+        assert client.get("/api/timeseries/daily?days=0").status_code == 422
+        assert client.get("/api/timeseries/daily?days=999").status_code == 422
+
+    def test_samples_endpoint(self, client):
+        resp = client.get("/api/timeseries/samples")
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 0
+
+    def test_disabled_reports_enabled_false(self, client, monkeypatch):
+        from app.core import timeseries as ts_mod
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "timeseries_retention", "-1")
+        ts_mod.reset_timeseries_store()
+        body = client.get("/api/timeseries/status").json()
+        assert body["enabled"] is False
+        body = client.get("/api/timeseries/today").json()
+        assert body["enabled"] is False
+        body = client.get("/api/timeseries/daily").json()
+        assert body["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Poll-loop wiring (gateway_manager feeds the store)
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoopWiring:
+    @pytest.mark.asyncio
+    async def test_poll_records_sample(self, tmp_path, monkeypatch,
+                                       mock_gateway_manager, mock_pypowerwall):
+        """A successful poll cycle must land in the time-series store."""
+        import app.core.timeseries as ts_mod
+        from app.config import settings
+        from app.models.gateway import Gateway, GatewayStatus
+
+        monkeypatch.setattr(
+            settings, "timeseries_path", str(tmp_path / "wired.db")
+        )
+        ts_mod.reset_timeseries_store()
+
+        gw = Gateway(id="gw1", name="G1", host="1.2.3.4", gw_pwd="x",
+                     timezone="UTC")
+        mock_gateway_manager.gateways["gw1"] = gw
+        mock_gateway_manager.connections["gw1"] = mock_pypowerwall
+        mock_gateway_manager.cache["gw1"] = GatewayStatus(gateway=gw, online=False)
+
+        await mock_gateway_manager._poll_gateway("gw1")
+
+        store = ts_mod.get_timeseries_store()
+        samples = await store.get_samples(gateway="gw1")
+        assert samples["count"] == 1
+        s = samples["samples"][0]
+        assert s["solar_w"] == 5000
+        assert s["home_w"] == 3100
+        assert s["battery_charge_w"] == 2000  # battery -2000 => charging
+        assert s["battery_discharge_w"] == 0
+        assert s["grid_import_w"] == 100
+        assert s["grid_export_w"] == 0
+        ts_mod.reset_timeseries_store()

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -322,6 +322,9 @@ class TestPersistenceAndMaintenance:
         assert s["samples"] == 2
         assert s["db_size_bytes"] > 0
         assert "gw1" in s["gateways"]
+        assert s["write_failures"] == 0
+        # Status must not disclose the filesystem path (only the filename)
+        assert s["db_file"] == "ts.db"
         await store.stop()
 
     @pytest.mark.asyncio
@@ -355,7 +358,7 @@ class TestDisabled:
         assert (await store.get_daily_energy())["enabled"] is False
         assert (await store.get_samples())["enabled"] is False
         s = await store.status()
-        assert s["enabled"] is False and s["db_path"] is None
+        assert s["enabled"] is False and s["db_file"] is None
         await store.stop()
         assert not db.exists()  # nothing was ever written
 

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -434,6 +434,39 @@ class TestTrend:
         trend = await store.get_trend()
         assert trend == {"enabled": False, "points": [], "count": 0}
 
+    @pytest.mark.asyncio
+    async def test_trend_explicit_window_and_fit(self, tmp_path):
+        """start/end define an arbitrary window; fit spans all samples."""
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        now = time.time()
+        # Old sample well outside a 1h window, recent samples inside it
+        await record(store, now - 48 * 3600, solar=9000, gw="a")
+        await record(store, now - 600, solar=1000, gw="a")
+        await record(store, now - 300, solar=2000, gw="a")
+
+        # Explicit window: last 30 minutes only -> 60s buckets, one point
+        # per bucket; the 48h-old sample is excluded
+        trend = await store.get_trend(start=now - 1800, end=now)
+        assert trend["enabled"] is True
+        assert trend["start"] == pytest.approx(now - 1800)
+        assert trend["end"] == pytest.approx(now)
+        assert trend["bucket_seconds"] == 60
+        assert trend["count"] == 2
+        values = sorted(p["solar_kw"] for p in trend["points"])
+        assert values == pytest.approx([1.0, 2.0])
+        assert all(p["solar_kw"] < 9.0 for p in trend["points"])
+
+        # end in the future is honored as-is (bucket sizing follows span)
+        future = await store.get_trend(start=now - 1800, end=now + 3600)
+        assert future["end"] == pytest.approx(now + 3600)
+
+        # Fit: spans back to the 48h-old sample
+        fit = await store.get_trend(fit=True)
+        assert fit["start"] <= now - 48 * 3600
+        assert fit["bucket_seconds"] == 480  # 48h span -> 8min buckets
+        assert fit["count"] >= 2
+        await store.stop()
+
 
 # ---------------------------------------------------------------------------
 # API endpoints (uses the app TestClient; conftest isolates the DB path)

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -248,11 +248,18 @@ class TestIntegration:
     @pytest.mark.asyncio
     async def test_multi_gateway_isolation(self, tmp_path):
         store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
-        now = time.time()
-        await record(store, now, solar=1000, gw="a")
-        await record(store, now + 3600, solar=1000, gw="a")
-        await record(store, now, solar=2000, gw="b")
-        await record(store, now + 3600, solar=2000, gw="b")
+        # Anchor mid-day UTC three days back so the 1-hour interval can
+        # never straddle a UTC midnight (which would split the day row and
+        # make the assertion time-of-day dependent). Stays inside days=7.
+        base = (
+            (datetime.now(timezone.utc) - timedelta(days=3))
+            .replace(hour=12, minute=0, second=0, microsecond=0)
+            .timestamp()
+        )
+        await record(store, base, solar=1000, gw="a")
+        await record(store, base + 3600, solar=1000, gw="a")
+        await record(store, base, solar=2000, gw="b")
+        await record(store, base + 3600, solar=2000, gw="b")
         daily = await store.get_daily_energy(days=7)
         day = daily["days"][0]["gateways"]
         assert day["a"]["solar_kwh"] == pytest.approx(1.0)
@@ -358,6 +365,77 @@ class TestDisabled:
 
 
 # ---------------------------------------------------------------------------
+# Trend query (bucketed kW + battery level for the console chart)
+# ---------------------------------------------------------------------------
+
+
+class TestTrend:
+    @pytest.mark.asyncio
+    async def test_trend_buckets_and_battery_level(self, tmp_path):
+        """24h trend buckets average raw samples, sum across gateways, and
+        carry battery level (%) from raw samples only."""
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
+        # 24h window -> 240s buckets; align to a bucket edge so all three
+        # samples land in one bucket deterministically.
+        base = math.floor(time.time() / 240) * 240
+        for ts, soe in ((base, 50.0), (base + 100, 60.0), (base + 200, 70.0)):
+            await record(
+                store,
+                ts,
+                solar=1000,
+                home=2000,
+                battery=-1000,
+                site=500,
+                soe=soe,
+                gw="a",
+            )
+            await record(
+                store,
+                ts,
+                solar=2000,
+                home=0,
+                battery=0,
+                site=0,
+                soe=soe + 10,
+                gw="b",
+            )
+        trend = await store.get_trend(hours=24)
+        assert trend["enabled"] is True
+        assert trend["hours"] == 24
+        assert trend["bucket_seconds"] == 240
+        assert trend["count"] == 1  # single bucket
+        p = trend["points"][0]
+        assert p["ts"] == base
+        # Fleet totals: gateway a + gateway b
+        assert p["solar_kw"] == pytest.approx(3.0)
+        assert p["home_kw"] == pytest.approx(2.0)
+        assert p["battery_kw"] == pytest.approx(-1.0)  # charging = negative
+        assert p["grid_kw"] == pytest.approx(0.5)  # importing = positive
+        # Mean battery level across samples and gateways: (60 + 70) / 2
+        assert p["battery_level"] == pytest.approx(65.0)
+
+        # Gateway filter returns just that gateway's values
+        solo = await store.get_trend(hours=24, gateway="a")
+        assert solo["points"][0]["solar_kw"] == pytest.approx(1.0)
+        assert solo["points"][0]["battery_level"] == pytest.approx(60.0)
+
+        # Battery level lives in raw samples only — never in daily aggregates
+        samples = await store.get_samples()
+        assert samples["count"] == 6
+        assert all(s["soe"] is not None for s in samples["samples"])
+        daily = await store.get_daily_energy(days=1)
+        row = daily["days"][0]["gateways"]["a"]
+        assert "soe" not in row
+        await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_trend_disabled(self, tmp_path):
+        store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"), retention=-1)
+        trend = await store.get_trend()
+        assert trend == {"enabled": False, "points": [], "count": 0}
+
+
+# ---------------------------------------------------------------------------
 # API endpoints (uses the app TestClient; conftest isolates the DB path)
 # ---------------------------------------------------------------------------
 
@@ -393,6 +471,17 @@ class TestAPI:
         resp = client.get("/api/timeseries/samples")
         assert resp.status_code == 200
         assert resp.json()["count"] == 0
+
+    def test_trend_endpoint(self, client):
+        resp = client.get("/api/timeseries/trend?hours=24")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enabled"] is True
+        assert body["points"] == []
+        assert body["hours"] == 24
+        assert "bucket_seconds" in body
+        assert client.get("/api/timeseries/trend?hours=0").status_code == 422
+        assert client.get("/api/timeseries/trend?hours=999").status_code == 422
 
     def test_disabled_reports_enabled_false(self, client, monkeypatch):
         from app.core import timeseries as ts_mod

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -12,6 +12,7 @@ Covers:
     - Disabled subsystem (PW_TIMESERIES_RETENTION=-1)
     - /api/timeseries/* endpoints (enabled and disabled)
 """
+
 import asyncio
 import math
 import time
@@ -25,7 +26,6 @@ from app.core.timeseries import (
     TimeSeriesStore,
     parse_duration,
 )
-
 
 # ---------------------------------------------------------------------------
 # parse_duration
@@ -71,11 +71,18 @@ class TestParseDuration:
 # ---------------------------------------------------------------------------
 
 
-async def record(store, ts, solar=0.0, home=0.0, battery=0.0, site=0.0,
-                 soe=None, tz="UTC", gw="gw1"):
+async def record(
+    store, ts, solar=0.0, home=0.0, battery=0.0, site=0.0, soe=None, tz="UTC", gw="gw1"
+):
     return await store.record_sample(
-        gateway_id=gw, ts=ts, solar_w=solar, home_w=home,
-        battery_w=battery, site_w=site, soe=soe, timezone=tz,
+        gateway_id=gw,
+        ts=ts,
+        solar_w=solar,
+        home_w=home,
+        battery_w=battery,
+        site_w=site,
+        soe=soe,
+        timezone=tz,
     )
 
 
@@ -89,8 +96,9 @@ class TestIntegration:
         """
         store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
         await record(store, 1000.0)
-        row = await record(store, 1000.0 + 3600, solar=3600, home=3600,
-                           battery=-3600, site=3600)
+        row = await record(
+            store, 1000.0 + 3600, solar=3600, home=3600, battery=-3600, site=3600
+        )
         assert row["solar_kwh"] == pytest.approx(1.8)
         assert row["home_kwh"] == pytest.approx(1.8)
         assert row["battery_charge_kwh"] == pytest.approx(1.8)
@@ -105,8 +113,9 @@ class TestIntegration:
         """Both endpoints at the same power: 3600 W * 1 h = 1 kWh exactly."""
         store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
         await record(store, 2000.0, solar=3600, home=2000, battery=-1000, site=-1000)
-        row = await record(store, 2000.0 + 3600, solar=3600, home=2000,
-                           battery=-1000, site=-1000)
+        row = await record(
+            store, 2000.0 + 3600, solar=3600, home=2000, battery=-1000, site=-1000
+        )
         assert row["solar_kwh"] == pytest.approx(3.6)
         assert row["home_kwh"] == pytest.approx(2.0)
         assert row["battery_charge_kwh"] == pytest.approx(1.0)
@@ -167,9 +176,11 @@ class TestIntegration:
         # UTC timezone; midnight falls on integer 86400 boundaries.
         # Three samples at 23:00, 00:00, 01:00 — each interval is exactly
         # 3600s (the gap threshold, still integrated) at steady 1200 W.
-        midnight = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        ).timestamp()
+        midnight = (
+            datetime.now(timezone.utc)
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+            .timestamp()
+        )
         t0 = midnight - 3600
         tmid = midnight
         t1 = midnight + 3600
@@ -203,9 +214,11 @@ class TestIntegration:
     @pytest.mark.asyncio
     async def test_unknown_timezone_falls_back_to_utc(self, tmp_path):
         store = TimeSeriesStore(db_path=str(tmp_path / "ts.db"))
-        midnight = datetime.now(timezone.utc).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        ).timestamp()
+        midnight = (
+            datetime.now(timezone.utc)
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+            .timestamp()
+        )
         t0 = midnight - 3600
         await record(store, t0, solar=1200, tz="Not/ARealZone")
         await record(store, midnight, solar=1200, tz="Not/ARealZone")
@@ -286,9 +299,10 @@ class TestPersistenceAndMaintenance:
         assert oldest >= now - max(7200, RAW_KEEP_FLOOR) - 60
         # ...and daily aggregates were preserved despite pruning
         daily = await store.get_daily_energy(days=7)
-        assert sum(
-            g["solar_kwh"] for d in daily["days"] for g in d["gateways"].values()
-        ) > 0
+        assert (
+            sum(g["solar_kwh"] for d in daily["days"] for g in d["gateways"].values())
+            > 0
+        )
         await store.stop()
 
     @pytest.mark.asyncio
@@ -401,20 +415,18 @@ class TestAPI:
 
 class TestPollLoopWiring:
     @pytest.mark.asyncio
-    async def test_poll_records_sample(self, tmp_path, monkeypatch,
-                                       mock_gateway_manager, mock_pypowerwall):
+    async def test_poll_records_sample(
+        self, tmp_path, monkeypatch, mock_gateway_manager, mock_pypowerwall
+    ):
         """A successful poll cycle must land in the time-series store."""
         import app.core.timeseries as ts_mod
         from app.config import settings
         from app.models.gateway import Gateway, GatewayStatus
 
-        monkeypatch.setattr(
-            settings, "timeseries_path", str(tmp_path / "wired.db")
-        )
+        monkeypatch.setattr(settings, "timeseries_path", str(tmp_path / "wired.db"))
         ts_mod.reset_timeseries_store()
 
-        gw = Gateway(id="gw1", name="G1", host="1.2.3.4", gw_pwd="x",
-                     timezone="UTC")
+        gw = Gateway(id="gw1", name="G1", host="1.2.3.4", gw_pwd="x", timezone="UTC")
         mock_gateway_manager.gateways["gw1"] = gw
         mock_gateway_manager.connections["gw1"] = mock_pypowerwall
         mock_gateway_manager.cache["gw1"] = GatewayStatus(gateway=gw, online=False)

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -468,6 +468,16 @@ class TestTrend:
         assert fit["start"] <= now - 48 * 3600
         assert fit["bucket_seconds"] == 480  # 48h span -> 8min buckets
         assert fit["count"] >= 2
+
+        # Fit window ends at the newest sample, not "now" — the data fills
+        # the full graph width
+        assert fit["end"] == pytest.approx(now - 300)
+
+        # Gateway-filtered fit spans only that gateway's samples
+        await record(store, now - 60, solar=500, gw="b")
+        fit_b = await store.get_trend(fit=True, gateway="b")
+        assert fit_b["start"] == pytest.approx(now - 60)
+        assert fit_b["end"] == pytest.approx(now - 60)
         await store.stop()
 
 


### PR DESCRIPTION
Implements the TimeSeriesStore subsystem discussed in #71 — persistent daily energy statistics with zero new network calls, built on the two-layer aggregation strategy we converged on in the thread.

Closes #71 (once ready).

## What it does

Every successful poll cycle (5s) records a raw sample per gateway to a local SQLite store (WAL mode). Power is split directionally at record time — battery charge vs discharge, grid import vs export — so nothing is ever netted. Trapezoidal integration converts power to kWh and accrues it into **daily aggregate rows** (one tiny row per gateway per local day, split at each gateway's configured timezone midnight). Daily totals survive restarts; raw samples are pruned to the retention window (the last hour of raw data is always kept for troubleshooting).

Intervals longer than 1 hour (gateway outage, backoff) are never integrated — no fabricated energy across gaps.

## Architecture

```
poll loop (_poll_gateway) ──▶ TimeSeriesStore.record_sample()
                                 │  (awaited in poll order, executor-serialized,
                                 │   failures swallowed — stats never break polling)
                                 ▼
               ┌──────────────────────────────────┐
               │ SQLite (WAL, busy_timeout, RLock │
               │ + single worker thread)          │
               │  samples           raw 5s rows   │── pruned to PW_TIMESERIES_RETENTION
               │  daily_energy      1 row/day/gw  │── kept per PW_TIMESERIES_DAILY_RETENTION
               │  integration_state resume point  │── restart without double counting
               └──────────────────────────────────┘
                     │                                    │
             /api/timeseries/*                     web console "Daily Energy" panel
```

- **Thread safety:** RLock + dedicated `ThreadPoolExecutor(max_workers=1)` (StatsTracker pattern). A background maintenance task prunes/checkpoints every 60s.
- **Disabled mode (`-1`):** no SQLite file is ever created, endpoints report `{"enabled": false}`, UI panel stays hidden.

## Environment settings

| Variable | Default | Meaning |
|---|---|---|
| `PW_TIMESERIES_RETENTION` | `24h` | Raw 5s sample window. Accepts `90s`, `48h`, `7d`, `30d`, `365d`. `0` = unlimited. **`-1` = disable subsystem entirely** (headless proxy — no SQLite writes, no UI panel) |
| `PW_TIMESERIES_DAILY_RETENTION` | `0` | Daily kWh aggregate retention. `0` = unlimited (rows are ~100 B/day/gateway, so unlimited is the sensible default) |
| `PW_TIMESERIES_PATH` | `/data/timeseries.db` if `/data` exists, else `data/timeseries.db` | SQLite file location — volume-mount it in Docker |

The Dockerfile now creates `/data` as a VOLUME mount point, and `docker-compose.yml` ships with a `pws-data:/data` volume.

## Measured storage & performance

Benchmark: 7 days of realistic samples through the real async record path (120,961 records), then queries against the populated DB:

| Metric | Measured |
|---|---|
| Feed throughput | 1,834 records/s (poll loop needs 0.2/s — ~9000× headroom) |
| Raw sample cost | **84 B/sample** → 24h ≈ **1.5 MB**, 7d ≈ **10 MB**, 30d ≈ **44 MB**, 365d raw ≈ **0.5 GB** |
| Daily aggregates | ~100 B/day/gateway → **1 year ≈ 36 KB per gateway** (why unlimited is the default) |
| `GET /api/timeseries/daily` (7d) | 0.3 ms |
| `GET /api/timeseries/samples` (10k rows) | 22 ms |
| Maintenance prune pass | 106 ms (every 60s) |

Smoke-verified end-to-end: fed 2 days of synthetic data, started the real server against the DB, and confirmed energy balance on the API (solar 51.8 kWh = home 15.4 + charge 28.8 − discharge 5.9 + export 16.0 − import 2.5) with correct local-midnight day splits.

## API

- `GET /api/timeseries/today` — running kWh totals per gateway (gateway-local day)
- `GET /api/timeseries/daily?days=7[&gateway=id]` — daily rows, most recent first, with `last_updated`
- `GET /api/timeseries/trend?hours=24[&gateway=id]` — bucketed kW + battery level for charting (server-side ~4-min buckets, ~360 points per 24h; per-gateway means, summed across gateways)
- `GET /api/timeseries/samples?gateway=&start=&end=&limit=` — raw samples for troubleshooting
- `GET /api/timeseries/status` — enabled flag, retention settings, DB size, row counts

All respond `{"enabled": false, ...}` when disabled, so clients degrade gracefully.

## UI

A **Daily Energy** card on the console (styled to match the existing MQTT/health cards, hidden until the store reports enabled):
- Today's kWh per category (solar, home, battery charged/discharged, grid import/export)
- Recent-days table (up to 7) per gateway, multi-gateway section headers like the alerts/strings cards
- Tile border colors match the Energy Summary standard palette: solar = yellow, home = blue, battery = green, grid = gray

The **Energy Summary** card is now clickable — it converts in place into an **Energy Trend** panel (click again to switch back):
- Last 24 hours of raw samples charted on canvas: Solar/Home/Battery/Grid kW share the left axis, battery level % rides a dashed line on the right axis, standard color coding throughout
- Refreshes every 60s while active; goes full-width for legibility; degrades to a hint when the subsystem is disabled or no samples exist yet

Battery level (state of charge) is captured on every raw sample (`soe` column) and kept for the raw retention window only — it is never downsampled into daily aggregates.

## Tests

30 new tests (`tests/test_timeseries.py`): duration parsing, trapezoid math (ramp + steady state), directional no-netting semantics, midnight split, DST/unknown-timezone fallback, gap threshold, duplicate/out-of-order samples, multi-gateway isolation, restart persistence without double counting, pruning + keep-floor, disabled mode (proves no file is created), API shape/validation, and poll-loop wiring through the mocked gateway. Full suite: **273 passed** (243 baseline + 30).

`tests/conftest.py` isolates the store to a per-test tmp dir so no test touches the checkout.

## Notes / follow-ups

- **MQTT publication of daily totals** (HA discovery, `total_increasing`) was floated in the #71 thread — intentionally left for a follow-up PR to keep this one reviewable; the store API is ready for it.
- Integration interpolates directional components, so an interval where power crosses zero accrues a small amount to both buckets; at 5s sampling this is sub-second and negligible, and it guarantees directions never net (documented in the test).

## Credits

The energy accumulation design — trapezoidal integration, 1-hour gap threshold, separate charge/discharge and import/export directions, per-gateway timezone midnight reset — builds directly on the proof-of-concept @KC333555888 posted in #71:

- [pypowerwall-server-daily-energy.zip](https://github.com/user-attachments/files/30525118/pypowerwall-server-daily-energy.zip)
- [PR_DESCRIPTION.md](https://github.com/user-attachments/files/30525099/PR_DESCRIPTION.md)
- [0001 Add daily energy summary tracking (patch)](https://github.com/user-attachments/files/30525098/0001-Add-daily-energy-summary-tracking-resets-at-local-mi.patch)
- [0002 Publish daily energy over MQTT + HA discovery (patch)](https://github.com/user-attachments/files/30525097/0002-Publish-daily-energy-totals-over-MQTT-HA-auto-discov.patch)

— Sam 🔌