### PR TITLE
feat(ui): trend legend toggle + hover tooltip

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -286,6 +286,9 @@
             margin-bottom: 8px;
         }
         .energy-trend-legend .key {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
             cursor: pointer;
             user-select: none;
             transition: opacity 0.15s ease;
@@ -318,10 +321,6 @@
             border-radius: 50%;
             margin-right: 6px;
             vertical-align: middle;
-        }
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
         }
         .energy-trend-legend .swatch {
             display: inline-block;
@@ -1949,6 +1948,9 @@
                 // trend overlay. The grid stays in flow, so the card keeps
                 // its exact height and the panels below never move.
                 card.classList.toggle('trend-mode', energyTrendActive);
+                // No native tooltip in trend mode — it would cover the
+                // chart's hover tooltip. Restore it on the summary side.
+                card.title = energyTrendActive ? '' : 'Click to toggle Energy Trend';
                 document.getElementById('energy-card-title-text').textContent =
                     energyTrendActive ? 'Energy Trend' : 'Energy Summary';
                 document.getElementById('energy-mode-hint').textContent =

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -292,6 +292,17 @@
             cursor: pointer;
             user-select: none;
             transition: opacity 0.15s ease;
+            /* button reset — keys are <button> for keyboard access, styled as plain text */
+            border: 0;
+            background: none;
+            padding: 0;
+            font: inherit;
+            color: inherit;
+        }
+        .energy-trend-legend .key:focus-visible {
+            outline: 1px solid #58a6ff;
+            outline-offset: 2px;
+            border-radius: 3px;
         }
         .energy-trend-legend .key.off {
             opacity: 0.35;
@@ -1254,11 +1265,11 @@
                         <button data-range="fit">Fit</button>
                     </div>
                     <div class="energy-trend-legend">
-                        <span class="key" data-series="solar_kw"><span class="swatch" style="background: var(--solar-color)"></span>Solar kW</span>
-                        <span class="key" data-series="home_kw"><span class="swatch" style="background: var(--home-color)"></span>Home kW</span>
-                        <span class="key" data-series="battery_kw"><span class="swatch" style="background: var(--battery-color)"></span>Battery kW</span>
-                        <span class="key" data-series="grid_kw"><span class="swatch" style="background: var(--grid-color)"></span>Grid kW</span>
-                        <span class="key" data-series="battery_level"><span class="swatch dashed"></span>Battery Level % <span style="color: var(--text-muted)">(right axis)</span></span>
+                        <button type="button" class="key" data-series="solar_kw"><span class="swatch" style="background: var(--solar-color)"></span>Solar kW</button>
+                        <button type="button" class="key" data-series="home_kw"><span class="swatch" style="background: var(--home-color)"></span>Home kW</button>
+                        <button type="button" class="key" data-series="battery_kw"><span class="swatch" style="background: var(--battery-color)"></span>Battery kW</button>
+                        <button type="button" class="key" data-series="grid_kw"><span class="swatch" style="background: var(--grid-color)"></span>Grid kW</button>
+                        <button type="button" class="key" data-series="battery_level"><span class="swatch dashed"></span>Battery Level % <span style="color: var(--text-muted)">(right axis)</span></button>
                     </div>
                     <canvas id="energy-trend-chart"></canvas>
                     <div id="energy-trend-tooltip"></div>
@@ -2079,7 +2090,13 @@
             const W = canvas.width, H = canvas.height;
             ctx.clearRect(0, 0, W, H);
             const points = energyTrendPoints;
-            if (!points || points.length < 2 || W < 100) return;
+            if (!points || points.length < 2 || W < 100) {
+                // No drawable data — clear hover state so no stale tooltip lingers
+                energyTrendHoverPoint = null;
+                const staleTip = document.getElementById('energy-trend-tooltip');
+                if (staleTip) staleTip.style.display = 'none';
+                return;
+            }
 
             const padL = 48, padR = 44, padT = 12, padB = 24;
             const plotW = W - padL - padR, plotH = H - padT - padB;

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -286,6 +286,39 @@
             margin-bottom: 8px;
         }
         .energy-trend-legend .key {
+            cursor: pointer;
+            user-select: none;
+            transition: opacity 0.15s ease;
+        }
+        .energy-trend-legend .key.off {
+            opacity: 0.35;
+        }
+        #energy-trend-tooltip {
+            position: absolute;
+            display: none;
+            background: rgba(13, 17, 23, 0.95);
+            border: 1px solid rgba(139, 148, 158, 0.4);
+            border-radius: 6px;
+            padding: 6px 9px;
+            font-size: 11px;
+            line-height: 1.6;
+            color: var(--text-color, #c9d1d9);
+            pointer-events: none;
+            z-index: 5;
+            white-space: nowrap;
+        }
+        #energy-trend-tooltip .tt-time {
+            font-weight: 600;
+            margin-bottom: 2px;
+        }
+        #energy-trend-tooltip .tt-dot {
+            display: inline-block;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            margin-right: 6px;
+            vertical-align: middle;
+        }
             display: inline-flex;
             align-items: center;
             gap: 6px;
@@ -1222,13 +1255,14 @@
                         <button data-range="fit">Fit</button>
                     </div>
                     <div class="energy-trend-legend">
-                        <span class="key"><span class="swatch" style="background: var(--solar-color)"></span>Solar kW</span>
-                        <span class="key"><span class="swatch" style="background: var(--home-color)"></span>Home kW</span>
-                        <span class="key"><span class="swatch" style="background: var(--battery-color)"></span>Battery kW</span>
-                        <span class="key"><span class="swatch" style="background: var(--grid-color)"></span>Grid kW</span>
-                        <span class="key"><span class="swatch dashed"></span>Battery Level % <span style="color: var(--text-muted)">(right axis)</span></span>
+                        <span class="key" data-series="solar_kw"><span class="swatch" style="background: var(--solar-color)"></span>Solar kW</span>
+                        <span class="key" data-series="home_kw"><span class="swatch" style="background: var(--home-color)"></span>Home kW</span>
+                        <span class="key" data-series="battery_kw"><span class="swatch" style="background: var(--battery-color)"></span>Battery kW</span>
+                        <span class="key" data-series="grid_kw"><span class="swatch" style="background: var(--grid-color)"></span>Grid kW</span>
+                        <span class="key" data-series="battery_level"><span class="swatch dashed"></span>Battery Level % <span style="color: var(--text-muted)">(right axis)</span></span>
                     </div>
                     <canvas id="energy-trend-chart"></canvas>
+                    <div id="energy-trend-tooltip"></div>
                     <div class="energy-trend-note" id="energy-trend-note"></div>
                 </div>
                 </div>
@@ -2020,6 +2054,19 @@
             grid: '#8b949e'
         };
 
+        // Click a legend key to show/hide that series
+        const energyTrendHidden = new Set();
+        const TREND_SERIES = [
+            { key: 'solar_kw',    label: 'Solar',         color: TREND_COLORS.solar,   axis: 'kw' },
+            { key: 'home_kw',     label: 'Home',          color: TREND_COLORS.home,    axis: 'kw' },
+            { key: 'battery_kw',  label: 'Battery',       color: TREND_COLORS.battery, axis: 'kw' },
+            { key: 'grid_kw',     label: 'Grid',          color: TREND_COLORS.grid,    axis: 'kw' },
+            { key: 'battery_level', label: 'Battery Level', color: TREND_COLORS.battery, axis: 'pct' }
+        ];
+
+        // Nearest data point to the cursor (null when not hovering)
+        let energyTrendHoverPoint = null;
+
         function drawEnergyTrendChart() {
             const canvas = document.getElementById('energy-trend-chart');
             if (!canvas) return;
@@ -2039,11 +2086,14 @@
             const xSpan = (x1 - x0) || 1;
             const X = ts => padL + ((ts - x0) / xSpan) * plotW;
 
-            // kW scale (left axis) across solar/home/battery/grid, zero included
+            // kW scale (left axis) across visible series only, zero included
             let minKw = 0, maxKw = 0;
             for (const p of points) {
-                minKw = Math.min(minKw, p.solar_kw, p.home_kw, p.battery_kw, p.grid_kw);
-                maxKw = Math.max(maxKw, p.solar_kw, p.home_kw, p.battery_kw, p.grid_kw);
+                for (const s of TREND_SERIES) {
+                    if (s.axis !== 'kw' || energyTrendHidden.has(s.key)) continue;
+                    minKw = Math.min(minKw, p[s.key]);
+                    maxKw = Math.max(maxKw, p[s.key]);
+                }
             }
             if (maxKw === minKw) maxKw = minKw + 1;
             const Y = kw => padT + (1 - (kw - minKw) / (maxKw - minKw)) * plotH;
@@ -2132,16 +2182,125 @@
                 }
             };
 
-            drawSeries('solar_kw', TREND_COLORS.solar, false, Y, true);
-            drawSeries('home_kw', TREND_COLORS.home, false, Y, true);
-            drawSeries('battery_kw', TREND_COLORS.battery, false, Y, true);
-            drawSeries('grid_kw', TREND_COLORS.grid, false, Y, true);
-            drawSeries('battery_level', TREND_COLORS.battery, true, Ypct, false);
+            for (const s of TREND_SERIES) {
+                if (energyTrendHidden.has(s.key)) continue;
+                drawSeries(s.key, s.color, s.key === 'battery_level', s.axis === 'pct' ? Ypct : Y, s.axis === 'kw');
+            }
+
+            // Hover crosshair + value dots
+            if (energyTrendHoverPoint) {
+                const hx = X(energyTrendHoverPoint.ts);
+                ctx.strokeStyle = 'rgba(139, 148, 158, 0.5)';
+                ctx.lineWidth = 1;
+                ctx.setLineDash([3, 3]);
+                ctx.beginPath(); ctx.moveTo(hx, padT); ctx.lineTo(hx, H - padB); ctx.stroke();
+                ctx.setLineDash([]);
+                for (const s of TREND_SERIES) {
+                    if (energyTrendHidden.has(s.key)) continue;
+                    const v = energyTrendHoverPoint[s.key];
+                    if (v == null) continue;
+                    const hy = s.axis === 'pct' ? Ypct(v) : Y(v);
+                    ctx.fillStyle = s.color;
+                    ctx.beginPath(); ctx.arc(hx, hy, 3.5, 0, Math.PI * 2); ctx.fill();
+                    ctx.strokeStyle = 'rgba(13, 17, 23, 0.9)';
+                    ctx.lineWidth = 1.5; ctx.stroke();
+                }
+            }
         }
 
         document.getElementById('energy-card').addEventListener('click', toggleEnergyTrend);
         window.addEventListener('resize', () => {
             if (energyTrendActive) drawEnergyTrendChart();
+        });
+
+        // Legend toggle: click a key to show/hide that series
+        document.querySelectorAll('.energy-trend-legend .key[data-series]').forEach(keyEl => {
+            keyEl.addEventListener('click', e => {
+                e.stopPropagation();  // don't flip the card back to summary mode
+                const k = keyEl.dataset.series;
+                if (energyTrendHidden.has(k)) {
+                    energyTrendHidden.delete(k);
+                    keyEl.classList.remove('off');
+                } else {
+                    energyTrendHidden.add(k);
+                    keyEl.classList.add('off');
+                }
+                drawEnergyTrendChart();
+                updateEnergyTrendTooltip();
+            });
+        });
+
+        // Hover: crosshair + tooltip with time and each series' value
+        const trendCanvas = document.getElementById('energy-trend-chart');
+        const trendTooltip = document.getElementById('energy-trend-tooltip');
+
+        function fmtHoverTime(ts) {
+            const d = new Date(ts * 1000);
+            const h = d.getHours() % 12 || 12;
+            const m = String(d.getMinutes()).padStart(2, '0');
+            const ap = d.getHours() >= 12 ? 'pm' : 'am';
+            return `${d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} ${h}:${m}${ap}`;
+        }
+
+        function updateEnergyTrendTooltip() {
+            if (!energyTrendHoverPoint) {
+                trendTooltip.style.display = 'none';
+                return;
+            }
+            const p = energyTrendHoverPoint;
+            let html = `<div class="tt-time">${fmtHoverTime(p.ts)}</div>`;
+            for (const s of TREND_SERIES) {
+                if (energyTrendHidden.has(s.key)) continue;
+                const v = p[s.key];
+                if (v == null) continue;
+                html += `<div><span class="tt-dot" style="background:${s.color}"></span>${s.label}: <b>${v.toFixed(s.axis === 'pct' ? 0 : 2)} ${s.axis === 'pct' ? '%' : 'kW'}</b></div>`;
+            }
+            trendTooltip.innerHTML = html;
+            trendTooltip.style.display = 'block';
+        }
+
+        trendCanvas.addEventListener('mousemove', e => {
+            const points = energyTrendPoints;
+            if (!points || points.length < 2) return;
+            const rect = trendCanvas.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const W = rect.width, H = rect.height;
+            const padL = 48, padR = 44, padT = 12, padB = 24;
+            const plotW = W - padL - padR;
+            if (plotW <= 0 || x < padL || x > W - padR) {
+                energyTrendHoverPoint = null;
+                trendTooltip.style.display = 'none';
+                drawEnergyTrendChart();
+                return;
+            }
+            const dom = energyTrendDomain || { t0: points[0].ts, t1: points[points.length - 1].ts };
+            const xSpan = (dom.t1 - dom.t0) || 1;
+            const ts = dom.t0 + ((x - padL) / plotW) * xSpan;
+            // nearest data point by timestamp
+            let best = null, bestD = Infinity;
+            for (const p of points) {
+                const d = Math.abs(p.ts - ts);
+                if (d < bestD) { bestD = d; best = p; }
+            }
+            if (best === energyTrendHoverPoint) return;
+            energyTrendHoverPoint = best;
+            drawEnergyTrendChart();
+            updateEnergyTrendTooltip();
+            // position tooltip near the cursor, clamped inside the panel
+            const panel = document.getElementById('energy-trend').getBoundingClientRect();
+            const tipW = trendTooltip.offsetWidth, tipH = trendTooltip.offsetHeight;
+            let left = e.clientX - panel.left + 14;
+            if (left + tipW > panel.width - 4) left = e.clientX - panel.left - tipW - 14;
+            let top = e.clientY - panel.top - tipH - 10;
+            if (top < 2) top = e.clientY - panel.top + 14;
+            trendTooltip.style.left = `${left}px`;
+            trendTooltip.style.top = `${top}px`;
+        });
+
+        trendCanvas.addEventListener('mouseleave', () => {
+            energyTrendHoverPoint = null;
+            trendTooltip.style.display = 'none';
+            drawEnergyTrendChart();
         });
 
         async function loadStats() {


### PR DESCRIPTION
Implements the two enhancements from Discussion #78 on the Energy Trend panel:

**1. Click-to-toggle series** — clicking a legend key (Solar kW, Home kW, Battery kW, Grid kW, Battery Level %) shows/hides that line on the graph, Grafana-style. Hidden keys dim in the legend, and the kW axis rescales to the remaining visible series.

**2. Hover tooltip** — hovering the chart shows a crosshair with a dot on each visible series, plus a tooltip with the timestamp and each series' value at that point (kW, and Battery Level in %).

Notes:
- Legend clicks use `stopPropagation` so they don't accidentally flip the card back to the summary view.
- Tooltip is clamped inside the panel and follows the cursor.
- Verified with a headless harness: base draw, series hiding/rescale, tooltip contents with hidden/visible series.

@jasonacox — this is the PR you asked for in #78. Screenshots on request.