### PR TITLE
v0.6.1: pypowerwall 0.17.1 bump + suppress uvicorn access logs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,15 @@
 
 ## Version History
 
-### [0.6.0] - Upcoming
+### [0.6.1] - 2026-09-01
+
+**Changed:**
+- **Bumped pypowerwall dependency to 0.17.1** — picks up the cloud `set_operation()` fixes validated on PW3 hardware during hybrid-mode testing (#79, #85). Docker images now ship pypowerwall 0.17.1.
+
+**Fixed:**
+- **Uvicorn HTTP access logs are no longer emitted when debug mode is disabled** — the server previously logged every request line (`INFO: 192.168.1.3 - "GET /soe HTTP/1.1" 200 OK`) even without `PW_DEBUG`, because `uvicorn.run()` applies its default logging config and resets logger levels set at import time. Access logs are now disabled at the source via `access_log=settings.debug`. (#86)
+
+### [0.6.0] - 2026-08-30
 
 **Added:**
 - **Powerwall 3 Basic LAN support (`PW_HOST` + `PW_PASSWORD`)** — you can now connect a PW3 gateway using only its local address and Basic password (the one printed on the gateway QR card / in the Tesla app), with no Tesla cloud credentials and no `PW_EMAIL`/`PW_TOKEN`. Uses the gateway's local TEDAPI via the pypowerwall library's Basic auth mode; poll-only (no cloud control), consistent with local v1r connections. Connection mode is reported in the Console gateway card.

--- a/app/config.py
+++ b/app/config.py
@@ -199,7 +199,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.6.0"
+SERVER_VERSION = "0.6.1"
 
 
 class GatewayConfig(BaseModel):

--- a/app/main.py
+++ b/app/main.py
@@ -922,8 +922,9 @@ For more information, visit: https://github.com/jasonacox/pypowerwall-server
             reload=args.reload,
             # Suppress HTTP access logs ("GET /soe 200 OK") unless debug is
             # enabled. uvicorn.run() applies its default logging config which
-            # resets logger levels set at import time, so access_log=False is
-            # the reliable switch here (see discussion #86).
+            # resets logger levels set at import time, so passing
+            # access_log=settings.debug (False unless debug) is the reliable
+            # switch here (see discussion #86).
             access_log=settings.debug,
         )
     except KeyboardInterrupt:

--- a/app/main.py
+++ b/app/main.py
@@ -110,6 +110,9 @@ class _SuppressWebSocketConnectionMessages(logging.Filter):
 #   uvicorn.access: "GET /api/..." request lines
 #   uvicorn.error filter: "connection open", "connection closed", WebSocket [accepted]
 if not settings.debug:
+    # Note: uvicorn.run() below re-applies its default logging config, which
+    # resets these levels — access logs are suppressed via access_log=False
+    # there. This block still covers the uvicorn.error websocket noise filter.
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("uvicorn.error").addFilter(_SuppressWebSocketConnectionMessages())
 logger = logging.getLogger(__name__)
@@ -917,6 +920,11 @@ For more information, visit: https://github.com/jasonacox/pypowerwall-server
             host=settings.server_host,
             port=settings.server_port,
             reload=args.reload,
+            # Suppress HTTP access logs ("GET /soe 200 OK") unless debug is
+            # enabled. uvicorn.run() applies its default logging config which
+            # resets logger levels set at import time, so access_log=False is
+            # the reliable switch here (see discussion #86).
+            access_log=settings.debug,
         )
     except KeyboardInterrupt:
         print("\nShutting down...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.6.0"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.6.1"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [
@@ -30,7 +30,7 @@ dependencies = [
     "uvicorn[standard]>=0.29.0",
     "pydantic>=2.11.0",
     "pydantic-settings>=2.9.0",
-    "pypowerwall>=0.17.0",
+    "pypowerwall>=0.17.1",
     "websockets>=13.1",
     "psutil>=6.1.0",
     "beautifulsoup4>=4.12.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.12
 uvicorn[standard]==0.29.0
 pydantic==2.11.3
 pydantic-settings==2.9.1
-pypowerwall==0.17.0
+pypowerwall==0.17.1
 websockets==13.1
 psutil==6.1.1
 beautifulsoup4==4.12.3


### PR DESCRIPTION
Per the v0.6.1 kickoff in discussions #79 and #86:

## Changes
- **Bump pypowerwall dependency to 0.17.1** (`requirements.txt` pin, `pyproject.toml` floor) — picks up the cloud `set_operation()` fixes validated on PW3 hardware during #79/#85 testing; Docker images will now ship 0.17.1.
- **Suppress uvicorn access logs unless debug** — pass `access_log=settings.debug` to `uvicorn.run()`. `uvicorn.run()` applies its default logging config at startup, which resets the `uvicorn.access` logger level set at import time, so access lines were emitted at INFO even without `PW_DEBUG` (#86). Left the `uvicorn.error` websocket-noise filter in place with an explanatory comment.
- **Version bump to 0.6.1** (`pyproject.toml`, `app/config.py`) and **RELEASE.md** — dated the 0.6.0 entry (2026-08-30) and added the 0.6.1 section.

## Testing
- Full suite: **311 passed** with `pypowerwall==0.17.1` installed.

— Sam 🔌