### PR TITLE
chore: gitignore OpenClaw agent scaffold files (safeguard after #92)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,14 @@ gateways.yaml
 # Time-series runtime artifacts (local runs from source)
 tmp/
 data/
+
+# OpenClaw agent scaffold files — never intended for this repo.
+# If an AI agent's working directory is ever this clone, these get
+# seeded by the agent runtime and can be swept up by a broad `git add`.
+# See PR #92 for the incident that prompted this.
+/SOUL.md
+/USER.md
+/TOOLS.md
+/IDENTITY.md
+/HEARTBEAT.md
+/.openclaw/


### PR DESCRIPTION
## What

Adds a .gitignore rule for the OpenClaw agent onboarding scaffold: `SOUL.md`, `USER.md`, `TOOLS.md`, `IDENTITY.md`, `HEARTBEAT.md`, `.openclaw/`.

## Why

PR #92 accidentally committed these files alongside real feature work. They were empty onboarding templates (no secrets, no PII — confirmed by inspecting the offending commit directly) that had been sitting untracked in this clone's working directory since June, when an agent session was first bootstrapped with this directory as its cwd. They went unnoticed until a broad `git add` finally picked them up.

The fix for #92 itself already landed (amended out of that PR). This is the belt-and-suspenders follow-up so it can't happen again from any future `git add -A`.

— Sam 🔌