### PR TITLE
Add Powerwall Control card

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,17 @@ curl -X POST http://localhost:8675/control/mode \
 > stick). If you need mode + reserve 0, set the mode with the *current* reserve
 > level first, then set the reserve to `0` in a separate call.
 
+**Web Console (`/console`):** when `PW_CONTROL_SECRET` is set, the Console shows
+a *Powerwall Control* card (after System Health) with mode select
+(Self-Consumption/Backup/Time-Based), reserve slider + number (0–100) and a
+token field (`sessionStorage` only, `Authorization: Bearer <token>` per request).
+Availability is checked via unauthenticated `GET /control/status`
+(`{"enabled": bool}`); current values come from `GET /api/operation`. One Save
+button sends a single combined `POST /control/mode {"value": mode, "level":
+reserve}` when both changed (reserve 0 + mode change is auto-split into two
+calls, see note above), otherwise a single `/control/reserve` or `/control/mode`
+call. Controls the default gateway.
+
 ### Data Aggregation Strategy
 Multi-gateway aggregation uses **smart aggregation** that will evolve over time:
 

--- a/README.md
+++ b/README.md
@@ -667,7 +667,9 @@ curl -X POST http://localhost:8675/control/mode \
 **Web Console (`/console`):** when `PW_CONTROL_SECRET` is set, the Console shows
 a *Powerwall Control* card (after System Health) with mode select
 (Self-Consumption/Backup/Time-Based), reserve slider + number (0–100) and a
-token field (`sessionStorage` only, `Authorization: Bearer <token>` per request).
+token field (kept in the tab by default, optional “Remember my token on this
+device” persists it in `localStorage`; sent as `Authorization: Bearer <token>`
+per request).
 Availability is checked via unauthenticated `GET /control/status`
 (`{"enabled": bool}`); current values come from `GET /api/operation`. One Save
 button sends a single combined `POST /control/mode {"value": mode, "level":

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,11 @@
 
 ## Version History
 
+### [0.6.2] - Upcoming
+
+**Added:**
+- **Web Console Powerwall Control card (`PW_CONTROL_SECRET`)** — the Console gains a Powerwall Control card (shown after System Health when a control secret is configured) with mode select (Self-Consumption/Backup/Time-Based), reserve slider + number (0–100), and a token field kept client-side (session-only by default, optional "Remember my token on this device" via `localStorage`). Mode + reserve changes go through the existing `POST /control/*` API with `Authorization: Bearer <token>`; a mode change together with reserve 0 is auto-split into two calls to avoid the Tesla cloud API quirk that can silently drop the mode change. Card availability is exposed by a new unauthenticated `GET /control/status` returning only `{"enabled": bool}`. (#94)
+
 ### [0.6.1] - 2026-09-04
 
 **Added:**

--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -2183,3 +2183,4 @@ async def get_version():
         pass
 
     return {"version": version, "vint": vint}
+

--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -24,7 +24,8 @@ Key Routes (all cache-backed for graceful degradation):
 Auth Routes (powerflow web app compatibility):
     - POST /api/login/Basic -> Fake login; sets long-lived AuthCookie/UserRecord
 
-Control Routes (require authentication):
+Control Routes (require authentication, except status):
+    - GET /control/status -> Control availability (unauthenticated, {"enabled": bool})
     - POST /control/{path} -> Control operations (reserve, mode, etc.)
 
 Design Principles:
@@ -63,6 +64,20 @@ from app.utils.stats_tracker import stats_tracker
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.get("/control/status")
+async def control_status():
+    """Control availability for the Console WebGUI (unauthenticated).
+
+    Returns only ``{"enabled": bool}`` derived from
+    ``settings.control_enabled`` (i.e. ``PW_CONTROL_SECRET`` is set).
+    Deliberately contains no secret and no gateway details because
+    ``/console`` and ``/stats`` are unauthenticated — the browser needs
+    to know *whether* to show the Control card without learning the token.
+    All actual writes stay behind ``verify_control_token``.
+    """
+    return {"enabled": settings.control_enabled}
 
 
 @router.post("/control/{path:path}")
@@ -2168,4 +2183,3 @@ async def get_version():
         pass
 
     return {"version": version, "vint": vint}
-

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -730,7 +730,7 @@
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
             gap: 16px;
-            margin-bottom: 16px;
+            margin-bottom: 0;
         }
         .control-field {
             background: var(--bg-secondary);
@@ -739,6 +739,12 @@
             display: flex;
             flex-direction: column;
             gap: 10px;
+        }
+        .control-save-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-top: 16px;
         }
         .control-label {
             font-size: 0.75em;
@@ -787,6 +793,18 @@
         }
         .control-token-row input {
             flex: 1;
+        }
+        .control-remember {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 0.8em;
+            color: var(--text-secondary);
+            cursor: pointer;
+            user-select: none;
+        }
+        .control-remember input {
+            accent-color: var(--accent-green);
         }
         .control-btn {
             background: transparent;
@@ -842,8 +860,8 @@
         }
         .control-message {
             font-size: 0.85em;
-            min-height: 1.4em;
-            margin-top: 12px;
+            min-height: 1em;
+            margin-top: 8px;
             color: var(--text-secondary);
         }
         .control-message.success { color: var(--accent-green); }
@@ -1542,46 +1560,42 @@
                         </span>
                         Powerwall Control
                     </div>
-                    <div class="control-badge" id="control-badge">Control active</div>
-                </div>
-                <div class="control-hint" style="margin-bottom:12px">
-                    Controls the default gateway · Token from <code>PW_CONTROL_SECRET</code> required
-                    <span id="control-gateway-label"></span>
+                    <div class="control-badge" id="control-badge">Control enabled</div>
                 </div>
                 <div class="control-warning" id="control-stale-warning"></div>
                 <div class="control-warning" id="control-reserve0-warning"></div>
                 <div class="control-grid">
                     <div class="control-field">
-                        <div class="control-label">Operating Mode</div>
+                        <div class="control-label">Mode</div>
                         <select id="control-mode">
                             <option value="self_consumption">Self-Consumption</option>
                             <option value="backup">Backup</option>
                             <option value="autonomous">Time-Based</option>
                         </select>
-                        <div class="control-hint">Current: <span id="control-current-mode">--</span></div>
+                        <div class="control-hint">Now: <span id="control-current-mode">--</span></div>
                     </div>
                     <div class="control-field">
-                        <div class="control-label">Backup Reserve (%)</div>
+                        <div class="control-label">Backup Reserve</div>
                         <div class="control-reserve-row">
-                            <input type="range" id="control-reserve-slider" min="0" max="100" step="1" value="20">
-                            <input type="number" id="control-reserve-number" min="0" max="100" step="1" value="20">
+                            <input type="range" id="control-reserve-slider" min="0" max="100" step="1" value="20" aria-label="Backup reserve percent">
+                            <input type="number" id="control-reserve-number" min="0" max="100" step="1" value="20" aria-label="Backup reserve percent value">
                         </div>
-                        <div class="control-hint">Current: <span id="control-current-reserve" class="control-reserve-value">--</span></div>
+                        <div class="control-hint">Now: <span id="control-current-reserve" class="control-reserve-value">--</span></div>
                     </div>
                     <div class="control-field">
-                        <div class="control-label">Control Token</div>
+                        <div class="control-label">Token</div>
                         <div class="control-token-row">
-                            <input type="password" id="control-token" placeholder="Paste token (PW_CONTROL_SECRET)" autocomplete="off">
+                            <input type="password" id="control-token" placeholder="Paste your control token" autocomplete="off">
                             <button type="button" class="control-btn control-icon-btn" id="control-token-toggle" title="Show token" aria-label="Show token"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
                             <button type="button" class="control-btn control-icon-btn" id="control-token-clear" title="Clear token" aria-label="Clear token">✕</button>
                         </div>
-                        <div class="control-hint">sessionStorage only, cleared when the tab closes. Header: <code>Authorization: Bearer &lt;token&gt;</code></div>
+                        <label class="control-remember"><input type="checkbox" id="control-remember"> Remember my token on this device</label>
                     </div>
                 </div>
-                <div>
+                <div class="control-save-row" id="control-save-row" style="display:none">
                     <button type="button" class="control-btn primary" id="control-save">Save</button>
                 </div>
-                <div class="control-message" id="control-message"></div>
+                <div class="control-message" id="control-message" style="display:none"></div>
             </div>
             
             <!-- Powerwall Status -->
@@ -3050,6 +3064,7 @@
         
         // Powerwall Control (GET /control/status → enabled, writes via POST /control/*)
         const CONTROL_TOKEN_KEY = 'pw_control_token';
+        const CONTROL_REMEMBER_KEY = 'pw_control_remember';
         const CONTROL_EYE_OPEN = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
         const CONTROL_EYE_CLOSED = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>';
         let controlEnabled = false;
@@ -3057,9 +3072,14 @@
         let controlDirty = false;
         let controlSaving = false;
 
+        function isRememberToken() {
+            return document.getElementById('control-remember')?.checked === true;
+        }
+
         function getControlToken() {
             try {
-                return sessionStorage.getItem(CONTROL_TOKEN_KEY) || '';
+                return localStorage.getItem(CONTROL_TOKEN_KEY)
+                    || sessionStorage.getItem(CONTROL_TOKEN_KEY) || '';
             } catch (e) {
                 return document.getElementById('control-token')?.value || '';
             }
@@ -3067,9 +3087,23 @@
 
         function setControlToken(value) {
             try {
-                if (value) sessionStorage.setItem(CONTROL_TOKEN_KEY, value);
-                else sessionStorage.removeItem(CONTROL_TOKEN_KEY);
+                if (isRememberToken()) {
+                    if (value) localStorage.setItem(CONTROL_TOKEN_KEY, value);
+                    else localStorage.removeItem(CONTROL_TOKEN_KEY);
+                    sessionStorage.removeItem(CONTROL_TOKEN_KEY);
+                } else {
+                    if (value) sessionStorage.setItem(CONTROL_TOKEN_KEY, value);
+                    else sessionStorage.removeItem(CONTROL_TOKEN_KEY);
+                    localStorage.removeItem(CONTROL_TOKEN_KEY);
+                }
             } catch (e) { /* storage unavailable (private mode) — input still works */ }
+        }
+
+        function clearControlToken() {
+            try {
+                localStorage.removeItem(CONTROL_TOKEN_KEY);
+                sessionStorage.removeItem(CONTROL_TOKEN_KEY);
+            } catch (e) { /* ignore */ }
         }
 
         function setControlMessage(text, type) {
@@ -3077,6 +3111,12 @@
             if (!el) return;
             el.textContent = text || '';
             el.className = 'control-message' + (type ? ' ' + type : '');
+            el.style.display = text ? '' : 'none';
+        }
+
+        function updateDirtyHint() {
+            const row = document.getElementById('control-save-row');
+            if (row) row.style.display = controlDirty ? '' : 'none';
         }
 
         function updateReserve0Warning() {
@@ -3087,7 +3127,7 @@
             const modeChanged = controlInitial.mode !== null && modeVal !== controlInitial.mode;
             if (Number.isInteger(reserveVal) && reserveVal === 0 && modeChanged) {
                 warn.style.display = '';
-                warn.textContent = 'Note: reserve 0 + mode change is sent as 2 calls (mode with previous reserve first, then reserve 0) — Tesla API quirk, otherwise the mode change may be dropped.';
+                warn.textContent = 'Tip: reserve 0 plus a new mode is saved in two steps, so nothing gets lost.';
             } else {
                 warn.style.display = 'none';
                 warn.textContent = '';
@@ -3137,25 +3177,16 @@
                     if (stale) {
                         const when = op.last_updated ? ' (as of ' + new Date(op.last_updated * 1000).toLocaleString() + ')' : '';
                         staleWarn.style.display = '';
-                        staleWarn.textContent = 'Values may be stale — cloud link down, last known values' + when + '.';
+                        staleWarn.textContent = 'Might be outdated — no cloud connection.' + when + ' Showing last known values.';
                     } else {
                         staleWarn.style.display = 'none';
                         staleWarn.textContent = '';
                     }
                 }
 
-                // Default gateway label (display only, /control/* acts on the default gateway)
-                try {
-                    const ids = Object.keys(gatewayMeta || {});
-                    if (ids.length) {
-                        const defId = ids.includes('default') ? 'default' : ids[0];
-                        const defName = (gatewayMeta[defId] && gatewayMeta[defId].name) || defId;
-                        document.getElementById('control-gateway-label').textContent = ' · Default: ' + defName;
-                    }
-                } catch (e) { /* label optional */ }
-
                 if (isRefresh && controlDirty) {
                     updateReserve0Warning();
+                    updateDirtyHint();
                     return; // Dirty check: do not overwrite user input
                 }
                 if (mode && document.getElementById('control-mode')) {
@@ -3170,6 +3201,7 @@
                 controlInitial = { mode, reserve };
                 controlDirty = false;
                 updateReserve0Warning();
+                updateDirtyHint();
             } catch (e) {
                 console.log('Control values not available:', e.message);
             }
@@ -3191,10 +3223,10 @@
 
         function controlErrorText(status, payload, fallback) {
             if (payload && typeof payload.detail === 'string') return payload.detail;
-            if (status === 401) return 'Invalid token (401).';
-            if (status === 403) return 'Control disabled (403) – PW_CONTROL_SECRET not set.';
-            if (status === 400) return 'Invalid input (400).';
-            if (status === 503) return 'Gateway/cloud unreachable (503).';
+            if (status === 401) return 'Wrong token. Please enter it again.';
+            if (status === 403) return 'Control is off — no token set on the server.';
+            if (status === 400) return 'Please check your input.';
+            if (status === 503) return 'Powerwall unreachable. Please try again.';
             return fallback || ('Error ' + status);
         }
 
@@ -3203,32 +3235,25 @@
             const tokenInput = document.getElementById('control-token');
             const token = (tokenInput?.value || getControlToken() || '').trim();
             if (!token) {
-                setControlMessage('Please enter the control token (PW_CONTROL_SECRET).', 'error');
+                setControlMessage('Enter your control token first.', 'error');
                 return;
             }
             setControlToken(token);
             const modeVal = document.getElementById('control-mode')?.value;
             const reserveVal = parseInt(document.getElementById('control-reserve-number')?.value, 10);
             if (!['self_consumption', 'backup', 'autonomous'].includes(modeVal)) {
-                setControlMessage('Invalid mode.', 'error');
+                setControlMessage('That mode is unknown.', 'error');
                 return;
             }
             if (!Number.isInteger(reserveVal) || reserveVal < 0 || reserveVal > 100) {
-                setControlMessage('Reserve must be an integer 0–100.', 'error');
+                setControlMessage('Reserve must be 0–100.', 'error');
                 return;
             }
-            const modeChanged = controlInitial.mode !== null && modeVal !== controlInitial.mode;
-            const reserveChanged = controlInitial.reserve !== null && reserveVal !== controlInitial.reserve;
-            if (controlInitial.mode === null || controlInitial.reserve === null) {
-                // Initial state unknown yet (e.g. stale null): treat fields as changed
-                // without breaking the auto-split logic below
-            }
-            const bothChanged = (modeVal !== controlInitial.mode) || (reserveVal !== controlInitial.reserve);
-            // Count null initial state as changed
+            // A null initial state (e.g. values not loaded yet) counts as changed
             const mChanged = modeVal !== controlInitial.mode;
             const rChanged = reserveVal !== controlInitial.reserve;
             if (!mChanged && !rChanged) {
-                setControlMessage('No changes.', '');
+                setControlMessage('Nothing to save.', '');
                 return;
             }
 
@@ -3243,24 +3268,24 @@
                     const first = await postControl('mode', { value: modeVal, level: controlInitial.reserve }, token);
                     if (!first.resp.ok) {
                         if (first.resp.status === 401) {
-                            setControlToken('');
+                            clearControlToken();
                             if (tokenInput) tokenInput.value = '';
                         }
-                        throw new Error(controlErrorText(first.resp.status, first.payload, 'Step 1 (mode) failed.'));
+                        throw new Error(controlErrorText(first.resp.status, first.payload, 'Saving the mode failed.'));
                     }
                     const second = await postControl('reserve', { value: 0 }, token);
                     if (!second.resp.ok) {
                         if (second.resp.status === 401) {
-                            setControlToken('');
+                            clearControlToken();
                             if (tokenInput) tokenInput.value = '';
                         }
-                        throw new Error(controlErrorText(second.resp.status, second.payload, 'Step 2 (reserve 0) failed – mode may already be set.'));
+                        throw new Error(controlErrorText(second.resp.status, second.payload, 'Saving reserve 0 failed — the mode may already be saved.'));
                     }
                 } else if (mChanged && rChanged) {
                     const r = await postControl('mode', { value: modeVal, level: reserveVal }, token);
                     if (!r.resp.ok) {
                         if (r.resp.status === 401) {
-                            setControlToken('');
+                            clearControlToken();
                             if (tokenInput) tokenInput.value = '';
                         }
                         throw new Error(controlErrorText(r.resp.status, r.payload, null));
@@ -3269,7 +3294,7 @@
                     const r = await postControl('reserve', { value: reserveVal }, token);
                     if (!r.resp.ok) {
                         if (r.resp.status === 401) {
-                            setControlToken('');
+                            clearControlToken();
                             if (tokenInput) tokenInput.value = '';
                         }
                         throw new Error(controlErrorText(r.resp.status, r.payload, null));
@@ -3278,15 +3303,15 @@
                     const r = await postControl('mode', { value: modeVal }, token);
                     if (!r.resp.ok) {
                         if (r.resp.status === 401) {
-                            setControlToken('');
+                            clearControlToken();
                             if (tokenInput) tokenInput.value = '';
                         }
                         throw new Error(controlErrorText(r.resp.status, r.payload, null));
                     }
                 }
-                void modeChanged; void reserveChanged; void bothChanged;
-                setControlMessage('Saved – takes effect after about one poll interval.', 'success');
+                setControlMessage('Saved. Takes a few seconds to apply.', 'success');
                 controlDirty = false;
+                updateDirtyHint();
                 await loadControlValues(false);
                 await loadStats();
             } catch (e) {
@@ -3299,11 +3324,18 @@
 
         function initControl() {
             const tokenInput = document.getElementById('control-token');
+            const rememberBox = document.getElementById('control-remember');
             const slider = document.getElementById('control-reserve-slider');
             const number = document.getElementById('control-reserve-number');
             const modeSel = document.getElementById('control-mode');
             if (tokenInput) {
-                const saved = getControlToken();
+                let saved = '';
+                try {
+                    saved = localStorage.getItem(CONTROL_TOKEN_KEY) || '';
+                    const remember = !!saved || localStorage.getItem(CONTROL_REMEMBER_KEY) === '1';
+                    if (rememberBox) rememberBox.checked = remember;
+                    if (!saved) saved = sessionStorage.getItem(CONTROL_TOKEN_KEY) || '';
+                } catch (e) { saved = ''; }
                 if (saved) tokenInput.value = saved;
                 tokenInput.addEventListener('input', () => {
                     setControlToken(tokenInput.value.trim());
@@ -3324,8 +3356,19 @@
             if (clearBtn && tokenInput) {
                 clearBtn.addEventListener('click', () => {
                     tokenInput.value = '';
-                    setControlToken('');
+                    clearControlToken();
                     setControlMessage('Token cleared.', '');
+                });
+            }
+            if (rememberBox) {
+                rememberBox.addEventListener('change', () => {
+                    try {
+                        localStorage.setItem(CONTROL_REMEMBER_KEY, rememberBox.checked ? '1' : '0');
+                    } catch (e) { /* ignore */ }
+                    // Move any entered token to the newly selected storage
+                    const cur = tokenInput && tokenInput.value ? tokenInput.value.trim() : '';
+                    if (cur) setControlToken(cur);
+                    else clearControlToken();
                 });
             }
             if (slider && number) {
@@ -3333,22 +3376,26 @@
                     number.value = slider.value;
                     controlDirty = true;
                     updateReserve0Warning();
+                    updateDirtyHint();
                 });
                 number.addEventListener('input', () => {
                     const v = parseInt(number.value, 10);
                     if (Number.isInteger(v) && v >= 0 && v <= 100) slider.value = v;
                     controlDirty = true;
                     updateReserve0Warning();
+                    updateDirtyHint();
                 });
             }
             if (modeSel) {
                 modeSel.addEventListener('change', () => {
                     controlDirty = true;
                     updateReserve0Warning();
+                    updateDirtyHint();
                 });
             }
             const saveBtn = document.getElementById('control-save');
             if (saveBtn) saveBtn.addEventListener('click', saveControl);
+            updateDirtyHint();
         }
 
         // Initialize — load gateway metadata first so multi-gateway panels branch correctly

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -713,6 +713,141 @@
             font-weight: 600;
             font-variant-numeric: tabular-nums;
         }
+
+        /* Powerwall Control Card (visible only when GET /control/status → enabled) */
+        .control-card {
+            grid-column: span 12;
+        }
+        .control-badge {
+            font-size: 0.8em;
+            font-weight: 600;
+            padding: 3px 10px;
+            border-radius: 12px;
+            background: rgba(63, 185, 80, 0.15);
+            color: var(--accent-green);
+        }
+        .control-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 16px;
+            margin-bottom: 16px;
+        }
+        .control-field {
+            background: var(--bg-secondary);
+            border-radius: 8px;
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        .control-label {
+            font-size: 0.75em;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        .control-field select,
+        .control-field input[type="number"],
+        .control-token-row input {
+            background: var(--bg-card);
+            border: 1px solid var(--border-color);
+            border-radius: 6px;
+            color: var(--text-primary);
+            padding: 8px 10px;
+            font-size: 0.95em;
+            width: 100%;
+        }
+        .control-field select:focus,
+        .control-field input:focus,
+        .control-token-row input:focus {
+            outline: none;
+            border-color: var(--accent-blue);
+        }
+        .control-reserve-row {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+        }
+        .control-reserve-row input[type="range"] {
+            flex: 1;
+            accent-color: var(--accent-green);
+        }
+        .control-reserve-row input[type="number"] {
+            width: 90px;
+            flex-shrink: 0;
+        }
+        .control-reserve-value {
+            font-variant-numeric: tabular-nums;
+            font-weight: 600;
+        }
+        .control-token-row {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+        }
+        .control-token-row input {
+            flex: 1;
+        }
+        .control-btn {
+            background: transparent;
+            color: var(--text-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 6px;
+            padding: 8px 12px;
+            cursor: pointer;
+            font-size: 0.9em;
+            white-space: nowrap;
+        }
+        .control-btn:hover:not(:disabled) {
+            border-color: var(--accent-blue);
+            color: var(--text-primary);
+        }
+        .control-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+        .control-icon-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 38px;
+        }
+        .control-icon-btn svg {
+            width: 16px;
+            height: 16px;
+        }
+        .control-btn.primary {
+            background: rgba(63, 185, 80, 0.15);
+            border-color: var(--accent-green);
+            color: var(--accent-green);
+            font-weight: 600;
+        }
+        .control-btn.primary:hover:not(:disabled) {
+            background: rgba(63, 185, 80, 0.25);
+            color: var(--accent-green);
+        }
+        .control-hint {
+            font-size: 0.8em;
+            color: var(--text-secondary);
+        }
+        .control-warning {
+            display: none;
+            font-size: 0.85em;
+            padding: 10px 12px;
+            border-radius: 6px;
+            margin-bottom: 12px;
+            background: rgba(210, 153, 34, 0.12);
+            border-left: 3px solid var(--accent-yellow);
+            color: var(--text-primary);
+        }
+        .control-message {
+            font-size: 0.85em;
+            min-height: 1.4em;
+            margin-top: 12px;
+            color: var(--text-secondary);
+        }
+        .control-message.success { color: var(--accent-green); }
+        .control-message.error { color: var(--accent-red); }
         
         /* Powerwall Health Card */
         .powerwall-card {
@@ -1393,6 +1528,60 @@
                         <div class="health-value" id="server-offline">--</div>
                     </div>
                 </div>
+            </div>
+
+            <!-- Powerwall Control (hidden until GET /control/status → enabled) -->
+            <div class="card control-card" id="control-card" style="display:none">
+                <div class="card-header">
+                    <div class="card-title">
+                        <span class="icon">
+                            <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M12 20h9" fill="none"/>
+                                <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z" fill="none"/>
+                            </svg>
+                        </span>
+                        Powerwall Control
+                    </div>
+                    <div class="control-badge" id="control-badge">Control active</div>
+                </div>
+                <div class="control-hint" style="margin-bottom:12px">
+                    Controls the default gateway · Token from <code>PW_CONTROL_SECRET</code> required
+                    <span id="control-gateway-label"></span>
+                </div>
+                <div class="control-warning" id="control-stale-warning"></div>
+                <div class="control-warning" id="control-reserve0-warning"></div>
+                <div class="control-grid">
+                    <div class="control-field">
+                        <div class="control-label">Operating Mode</div>
+                        <select id="control-mode">
+                            <option value="self_consumption">Self-Consumption</option>
+                            <option value="backup">Backup</option>
+                            <option value="autonomous">Time-Based</option>
+                        </select>
+                        <div class="control-hint">Current: <span id="control-current-mode">--</span></div>
+                    </div>
+                    <div class="control-field">
+                        <div class="control-label">Backup Reserve (%)</div>
+                        <div class="control-reserve-row">
+                            <input type="range" id="control-reserve-slider" min="0" max="100" step="1" value="20">
+                            <input type="number" id="control-reserve-number" min="0" max="100" step="1" value="20">
+                        </div>
+                        <div class="control-hint">Current: <span id="control-current-reserve" class="control-reserve-value">--</span></div>
+                    </div>
+                    <div class="control-field">
+                        <div class="control-label">Control Token</div>
+                        <div class="control-token-row">
+                            <input type="password" id="control-token" placeholder="Paste token (PW_CONTROL_SECRET)" autocomplete="off">
+                            <button type="button" class="control-btn control-icon-btn" id="control-token-toggle" title="Show token" aria-label="Show token"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
+                            <button type="button" class="control-btn control-icon-btn" id="control-token-clear" title="Clear token" aria-label="Clear token">✕</button>
+                        </div>
+                        <div class="control-hint">sessionStorage only, cleared when the tab closes. Header: <code>Authorization: Bearer &lt;token&gt;</code></div>
+                    </div>
+                </div>
+                <div>
+                    <button type="button" class="control-btn primary" id="control-save">Save</button>
+                </div>
+                <div class="control-message" id="control-message"></div>
             </div>
             
             <!-- Powerwall Status -->
@@ -2859,6 +3048,309 @@
             }
         }
         
+        // Powerwall Control (GET /control/status → enabled, writes via POST /control/*)
+        const CONTROL_TOKEN_KEY = 'pw_control_token';
+        const CONTROL_EYE_OPEN = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
+        const CONTROL_EYE_CLOSED = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>';
+        let controlEnabled = false;
+        let controlInitial = { mode: null, reserve: null };
+        let controlDirty = false;
+        let controlSaving = false;
+
+        function getControlToken() {
+            try {
+                return sessionStorage.getItem(CONTROL_TOKEN_KEY) || '';
+            } catch (e) {
+                return document.getElementById('control-token')?.value || '';
+            }
+        }
+
+        function setControlToken(value) {
+            try {
+                if (value) sessionStorage.setItem(CONTROL_TOKEN_KEY, value);
+                else sessionStorage.removeItem(CONTROL_TOKEN_KEY);
+            } catch (e) { /* storage unavailable (private mode) — input still works */ }
+        }
+
+        function setControlMessage(text, type) {
+            const el = document.getElementById('control-message');
+            if (!el) return;
+            el.textContent = text || '';
+            el.className = 'control-message' + (type ? ' ' + type : '');
+        }
+
+        function updateReserve0Warning() {
+            const warn = document.getElementById('control-reserve0-warning');
+            if (!warn) return;
+            const reserveVal = parseInt(document.getElementById('control-reserve-number')?.value, 10);
+            const modeVal = document.getElementById('control-mode')?.value;
+            const modeChanged = controlInitial.mode !== null && modeVal !== controlInitial.mode;
+            if (Number.isInteger(reserveVal) && reserveVal === 0 && modeChanged) {
+                warn.style.display = '';
+                warn.textContent = 'Note: reserve 0 + mode change is sent as 2 calls (mode with previous reserve first, then reserve 0) — Tesla API quirk, otherwise the mode change may be dropped.';
+            } else {
+                warn.style.display = 'none';
+                warn.textContent = '';
+            }
+        }
+
+        async function loadControlStatus() {
+            const card = document.getElementById('control-card');
+            try {
+                const resp = await fetch('/control/status');
+                if (!resp.ok) throw new Error('status ' + resp.status);
+                const data = await resp.json();
+                controlEnabled = data.enabled === true;
+            } catch (e) {
+                console.log('Control status not available:', e.message);
+                controlEnabled = false;
+            }
+            if (card) card.style.display = controlEnabled ? '' : 'none';
+            if (controlEnabled) {
+                await loadControlValues(false);
+            }
+        }
+
+        async function loadControlValues(isRefresh) {
+            if (!controlEnabled) return;
+            try {
+                const resp = await fetch('/api/operation');
+                if (!resp.ok) throw new Error('Failed to load operation');
+                const op = await resp.json();
+                const mode = op.real_mode || null;
+                const reserve = (op.backup_reserve_percent !== null && op.backup_reserve_percent !== undefined)
+                    ? Math.round(Number(op.backup_reserve_percent)) : null;
+                const stale = !!op.stale;
+
+                const modeMap = {
+                    'self_consumption': 'Self-Consumption',
+                    'backup': 'Backup',
+                    'autonomous': 'Time-Based',
+                };
+                document.getElementById('control-current-mode').textContent =
+                    (modeMap[mode] || mode || '--') + (stale && mode ? ' (stale)' : '');
+                document.getElementById('control-current-reserve').textContent =
+                    (reserve !== null ? reserve + '%' : '--') + (stale && reserve !== null ? ' (stale)' : '');
+
+                const staleWarn = document.getElementById('control-stale-warning');
+                if (staleWarn) {
+                    if (stale) {
+                        const when = op.last_updated ? ' (as of ' + new Date(op.last_updated * 1000).toLocaleString() + ')' : '';
+                        staleWarn.style.display = '';
+                        staleWarn.textContent = 'Values may be stale — cloud link down, last known values' + when + '.';
+                    } else {
+                        staleWarn.style.display = 'none';
+                        staleWarn.textContent = '';
+                    }
+                }
+
+                // Default gateway label (display only, /control/* acts on the default gateway)
+                try {
+                    const ids = Object.keys(gatewayMeta || {});
+                    if (ids.length) {
+                        const defId = ids.includes('default') ? 'default' : ids[0];
+                        const defName = (gatewayMeta[defId] && gatewayMeta[defId].name) || defId;
+                        document.getElementById('control-gateway-label').textContent = ' · Default: ' + defName;
+                    }
+                } catch (e) { /* label optional */ }
+
+                if (isRefresh && controlDirty) {
+                    updateReserve0Warning();
+                    return; // Dirty check: do not overwrite user input
+                }
+                if (mode && document.getElementById('control-mode')) {
+                    document.getElementById('control-mode').value = mode;
+                }
+                if (reserve !== null) {
+                    const slider = document.getElementById('control-reserve-slider');
+                    const number = document.getElementById('control-reserve-number');
+                    if (slider) slider.value = reserve;
+                    if (number) number.value = reserve;
+                }
+                controlInitial = { mode, reserve };
+                controlDirty = false;
+                updateReserve0Warning();
+            } catch (e) {
+                console.log('Control values not available:', e.message);
+            }
+        }
+
+        async function postControl(path, body, token) {
+            const resp = await fetch('/control/' + path, {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Bearer ' + token,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(body),
+            });
+            let payload = null;
+            try { payload = await resp.json(); } catch (e) { payload = null; }
+            return { resp, payload };
+        }
+
+        function controlErrorText(status, payload, fallback) {
+            if (payload && typeof payload.detail === 'string') return payload.detail;
+            if (status === 401) return 'Invalid token (401).';
+            if (status === 403) return 'Control disabled (403) – PW_CONTROL_SECRET not set.';
+            if (status === 400) return 'Invalid input (400).';
+            if (status === 503) return 'Gateway/cloud unreachable (503).';
+            return fallback || ('Error ' + status);
+        }
+
+        async function saveControl() {
+            if (controlSaving) return;
+            const tokenInput = document.getElementById('control-token');
+            const token = (tokenInput?.value || getControlToken() || '').trim();
+            if (!token) {
+                setControlMessage('Please enter the control token (PW_CONTROL_SECRET).', 'error');
+                return;
+            }
+            setControlToken(token);
+            const modeVal = document.getElementById('control-mode')?.value;
+            const reserveVal = parseInt(document.getElementById('control-reserve-number')?.value, 10);
+            if (!['self_consumption', 'backup', 'autonomous'].includes(modeVal)) {
+                setControlMessage('Invalid mode.', 'error');
+                return;
+            }
+            if (!Number.isInteger(reserveVal) || reserveVal < 0 || reserveVal > 100) {
+                setControlMessage('Reserve must be an integer 0–100.', 'error');
+                return;
+            }
+            const modeChanged = controlInitial.mode !== null && modeVal !== controlInitial.mode;
+            const reserveChanged = controlInitial.reserve !== null && reserveVal !== controlInitial.reserve;
+            if (controlInitial.mode === null || controlInitial.reserve === null) {
+                // Initial state unknown yet (e.g. stale null): treat fields as changed
+                // without breaking the auto-split logic below
+            }
+            const bothChanged = (modeVal !== controlInitial.mode) || (reserveVal !== controlInitial.reserve);
+            // Count null initial state as changed
+            const mChanged = modeVal !== controlInitial.mode;
+            const rChanged = reserveVal !== controlInitial.reserve;
+            if (!mChanged && !rChanged) {
+                setControlMessage('No changes.', '');
+                return;
+            }
+
+            const saveBtn = document.getElementById('control-save');
+            controlSaving = true;
+            if (saveBtn) saveBtn.disabled = true;
+            setControlMessage('Saving …', '');
+            try {
+                // Auto-split for reserve 0 + mode change (see README):
+                // mode with previous reserve first, then reserve 0 separately.
+                if (mChanged && rChanged && reserveVal === 0 && Number.isInteger(controlInitial.reserve)) {
+                    const first = await postControl('mode', { value: modeVal, level: controlInitial.reserve }, token);
+                    if (!first.resp.ok) {
+                        if (first.resp.status === 401) {
+                            setControlToken('');
+                            if (tokenInput) tokenInput.value = '';
+                        }
+                        throw new Error(controlErrorText(first.resp.status, first.payload, 'Step 1 (mode) failed.'));
+                    }
+                    const second = await postControl('reserve', { value: 0 }, token);
+                    if (!second.resp.ok) {
+                        if (second.resp.status === 401) {
+                            setControlToken('');
+                            if (tokenInput) tokenInput.value = '';
+                        }
+                        throw new Error(controlErrorText(second.resp.status, second.payload, 'Step 2 (reserve 0) failed – mode may already be set.'));
+                    }
+                } else if (mChanged && rChanged) {
+                    const r = await postControl('mode', { value: modeVal, level: reserveVal }, token);
+                    if (!r.resp.ok) {
+                        if (r.resp.status === 401) {
+                            setControlToken('');
+                            if (tokenInput) tokenInput.value = '';
+                        }
+                        throw new Error(controlErrorText(r.resp.status, r.payload, null));
+                    }
+                } else if (rChanged && !mChanged) {
+                    const r = await postControl('reserve', { value: reserveVal }, token);
+                    if (!r.resp.ok) {
+                        if (r.resp.status === 401) {
+                            setControlToken('');
+                            if (tokenInput) tokenInput.value = '';
+                        }
+                        throw new Error(controlErrorText(r.resp.status, r.payload, null));
+                    }
+                } else {
+                    const r = await postControl('mode', { value: modeVal }, token);
+                    if (!r.resp.ok) {
+                        if (r.resp.status === 401) {
+                            setControlToken('');
+                            if (tokenInput) tokenInput.value = '';
+                        }
+                        throw new Error(controlErrorText(r.resp.status, r.payload, null));
+                    }
+                }
+                void modeChanged; void reserveChanged; void bothChanged;
+                setControlMessage('Saved – takes effect after about one poll interval.', 'success');
+                controlDirty = false;
+                await loadControlValues(false);
+                await loadStats();
+            } catch (e) {
+                setControlMessage(e.message || 'Save failed.', 'error');
+            } finally {
+                controlSaving = false;
+                if (saveBtn) saveBtn.disabled = false;
+            }
+        }
+
+        function initControl() {
+            const tokenInput = document.getElementById('control-token');
+            const slider = document.getElementById('control-reserve-slider');
+            const number = document.getElementById('control-reserve-number');
+            const modeSel = document.getElementById('control-mode');
+            if (tokenInput) {
+                const saved = getControlToken();
+                if (saved) tokenInput.value = saved;
+                tokenInput.addEventListener('input', () => {
+                    setControlToken(tokenInput.value.trim());
+                    if (controlEnabled && tokenInput.value.trim()) setControlMessage('', '');
+                });
+            }
+            const toggle = document.getElementById('control-token-toggle');
+            if (toggle && tokenInput) {
+                toggle.addEventListener('click', () => {
+                    const show = tokenInput.type === 'password';
+                    tokenInput.type = show ? 'text' : 'password';
+                    toggle.innerHTML = show ? CONTROL_EYE_CLOSED : CONTROL_EYE_OPEN;
+                    toggle.title = show ? 'Hide token' : 'Show token';
+                    toggle.setAttribute('aria-label', show ? 'Hide token' : 'Show token');
+                });
+            }
+            const clearBtn = document.getElementById('control-token-clear');
+            if (clearBtn && tokenInput) {
+                clearBtn.addEventListener('click', () => {
+                    tokenInput.value = '';
+                    setControlToken('');
+                    setControlMessage('Token cleared.', '');
+                });
+            }
+            if (slider && number) {
+                slider.addEventListener('input', () => {
+                    number.value = slider.value;
+                    controlDirty = true;
+                    updateReserve0Warning();
+                });
+                number.addEventListener('input', () => {
+                    const v = parseInt(number.value, 10);
+                    if (Number.isInteger(v) && v >= 0 && v <= 100) slider.value = v;
+                    controlDirty = true;
+                    updateReserve0Warning();
+                });
+            }
+            if (modeSel) {
+                modeSel.addEventListener('change', () => {
+                    controlDirty = true;
+                    updateReserve0Warning();
+                });
+            }
+            const saveBtn = document.getElementById('control-save');
+            if (saveBtn) saveBtn.addEventListener('click', saveControl);
+        }
+
         // Initialize — load gateway metadata first so multi-gateway panels branch correctly
         async function initGateways() {
             try {
@@ -2892,10 +3384,12 @@
 
         (async () => {
             await initGateways();
+            initControl();
             connectWebSocket();
             loadAlerts();
             loadStrings();
             loadStats();
+            loadControlStatus();
             loadPowerwalls();
             loadGateways();
             loadMqtt();
@@ -2906,6 +3400,7 @@
                 loadAlerts();
                 loadStrings();
                 loadStats();
+                loadControlValues(true);
                 loadPowerwalls();
                 loadGateways();
                 loadMqtt();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -3286,35 +3286,16 @@
                         throw new Error(controlErrorText(second.resp.status, second.payload, 'Saving reserve 0 failed — the mode may already be saved.'));
                     }
                 } else if (mChanged && rChanged) {
-                    if (reserveVal === 0) {
-                        // Reserve 0 + mode change: avoid companion write with level=0 (see README note).
-                        const first = await postControl('mode', { value: modeVal }, token);
-                        if (!first.resp.ok) {
-                            if (first.resp.status === 401) {
-                                clearControlToken();
-                                if (tokenInput) tokenInput.value = '';
-                            }
-                            throw new Error(controlErrorText(first.resp.status, first.payload, 'Saving the mode failed.'));
+                    // reserveVal > 0 here — the branch above splits the reserve-0 case.
+                    const r = await postControl('mode', { value: modeVal, level: reserveVal }, token);
+                    if (!r.resp.ok) {
+                        if (r.resp.status === 401) {
+                            clearControlToken();
+                            if (tokenInput) tokenInput.value = '';
                         }
-                        const second = await postControl('reserve', { value: 0 }, token);
-                        if (!second.resp.ok) {
-                            if (second.resp.status === 401) {
-                                clearControlToken();
-                                if (tokenInput) tokenInput.value = '';
-                            }
-                            throw new Error(controlErrorText(second.resp.status, second.payload, 'Saving reserve 0 failed — the mode may already be saved.'));
-                        }
-                    } else {
-                        const r = await postControl('mode', { value: modeVal, level: reserveVal }, token);
-                        if (!r.resp.ok) {
-                            if (r.resp.status === 401) {
-                                clearControlToken();
-                                if (tokenInput) tokenInput.value = '';
-                            }
-                            throw new Error(controlErrorText(r.resp.status, r.payload, null));
-                        }
+                        throw new Error(controlErrorText(r.resp.status, r.payload, null));
                     }
-                }
+                } else if (rChanged) {
                     const r = await postControl('reserve', { value: reserveVal }, token);
                     if (!r.resp.ok) {
                         if (r.resp.status === 401) {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -3262,10 +3262,14 @@
             if (saveBtn) saveBtn.disabled = true;
             setControlMessage('Saving …', '');
             try {
-                // Auto-split for reserve 0 + mode change (see README):
-                // mode with previous reserve first, then reserve 0 separately.
-                if (mChanged && rChanged && reserveVal === 0 && Number.isInteger(controlInitial.reserve)) {
-                    const first = await postControl('mode', { value: modeVal, level: controlInitial.reserve }, token);
+                // Reserve 0 + mode change: never use the companion write with
+                // level=0 (see README note) — mode first, then reserve 0.
+                // With a known previous reserve, keep it for step 1.
+                if (mChanged && rChanged && reserveVal === 0) {
+                    const firstBody = Number.isInteger(controlInitial.reserve)
+                        ? { value: modeVal, level: controlInitial.reserve }
+                        : { value: modeVal };
+                    const first = await postControl('mode', firstBody, token);
                     if (!first.resp.ok) {
                         if (first.resp.status === 401) {
                             clearControlToken();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -3282,15 +3282,35 @@
                         throw new Error(controlErrorText(second.resp.status, second.payload, 'Saving reserve 0 failed — the mode may already be saved.'));
                     }
                 } else if (mChanged && rChanged) {
-                    const r = await postControl('mode', { value: modeVal, level: reserveVal }, token);
-                    if (!r.resp.ok) {
-                        if (r.resp.status === 401) {
-                            clearControlToken();
-                            if (tokenInput) tokenInput.value = '';
+                    if (reserveVal === 0) {
+                        // Reserve 0 + mode change: avoid companion write with level=0 (see README note).
+                        const first = await postControl('mode', { value: modeVal }, token);
+                        if (!first.resp.ok) {
+                            if (first.resp.status === 401) {
+                                clearControlToken();
+                                if (tokenInput) tokenInput.value = '';
+                            }
+                            throw new Error(controlErrorText(first.resp.status, first.payload, 'Saving the mode failed.'));
                         }
-                        throw new Error(controlErrorText(r.resp.status, r.payload, null));
+                        const second = await postControl('reserve', { value: 0 }, token);
+                        if (!second.resp.ok) {
+                            if (second.resp.status === 401) {
+                                clearControlToken();
+                                if (tokenInput) tokenInput.value = '';
+                            }
+                            throw new Error(controlErrorText(second.resp.status, second.payload, 'Saving reserve 0 failed — the mode may already be saved.'));
+                        }
+                    } else {
+                        const r = await postControl('mode', { value: modeVal, level: reserveVal }, token);
+                        if (!r.resp.ok) {
+                            if (r.resp.status === 401) {
+                                clearControlToken();
+                                if (tokenInput) tokenInput.value = '';
+                            }
+                            throw new Error(controlErrorText(r.resp.status, r.payload, null));
+                        }
                     }
-                } else if (rChanged && !mChanged) {
+                }
                     const r = await postControl('reserve', { value: reserveVal }, token);
                     if (!r.resp.ok) {
                         if (r.resp.status === 401) {

--- a/tests/test_api_legacy.py
+++ b/tests/test_api_legacy.py
@@ -440,6 +440,35 @@ def test_control_rejects_wrong_token(control_client, connected_gateway):
 
 
 # ---------------------------------------------------------------------------
+# GET /control/status tests (Console WebGUI availability check)
+# ---------------------------------------------------------------------------
+
+
+def test_control_status_enabled_when_secret_set(control_client):
+    """GET /control/status returns enabled=true without auth when secret is set."""
+    response = control_client.get("/control/status")
+    assert response.status_code == 200
+    assert response.json() == {"enabled": True}
+
+
+def test_control_status_disabled_without_secret(client):
+    """GET /control/status returns enabled=false when no secret is configured."""
+    from app.config import settings
+
+    assert not settings.control_secret
+    response = client.get("/control/status")
+    assert response.status_code == 200
+    assert response.json() == {"enabled": False}
+
+
+def test_control_status_leaks_no_secret(control_client):
+    """GET /control/status must not expose the secret value."""
+    response = control_client.get("/control/status")
+    assert response.status_code == 200
+    assert _CONTROL_TOKEN not in response.text
+
+
+# ---------------------------------------------------------------------------
 # /control companion parameter tests (ported from pypowerwall PR #308)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### Summary
Adds Reserve + Mode control (`TOKEN=$PW_CONTROL_SECRET` curls from the README) to the web Console. The card is only shown when Control Mode is active and drives the existing `POST /control/*` API.

> **Note:** this PR uses the legacy control API (`POST /control/*`).

### Changes
- Backend — `app/api/legacy.py`: new unauthenticated `GET /control/status` → `{"enabled": bool}` (from `settings.control_enabled`). Exposes no secret; all writes still require `verify_control_token`.
- Frontend — `app/static/index.html` (additive only): new `Powerwall Control` card after System Health, hidden until `enabled == true`. Mode select (Self-Consumption / Backup / Time-Based), reserve slider + number (0–100), token field (`sessionStorage` only, eye/eye-off toggle, clear button, `Authorization: Bearer <token>` per request). One Save button: both changed → single `POST /control/mode {"value", "level"}`; reserve 0 + mode change → auto-split into 2 calls; otherwise single call. Values from `GET /api/operation` (incl. stale handling), warning banners, inline status, 30 s refresh with dirty-check, 401 clears the token. Controls the default gateway.
- Tests — `tests/test_api_legacy.py`: 3 new status-endpoint tests.
- Docs — `README.md`: short Web Console paragraph.

### Testing
- `pytest`: 317 passed. Console JS: `node --check` clean.
- Manual: without `PW_CONTROL_SECRET` no card; with secret set reserve/mode; wrong token → 401.

Maintainers are welcome to modify this PR as needed.

<img width="1576" height="230" alt="Screenshot 2026-09-05 192818" src="https://github.com/user-attachments/assets/1812d63c-1cc2-4c58-b173-28197b60373f" />