### PR TITLE
ci: syntax-check inline JS in static HTML

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,3 +44,26 @@ jobs:
 
       - name: Run pytest
         run: pytest -q
+
+  js-syntax:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check inline JS syntax in static HTML
+        run: |
+          python3 - <<'EOF'
+          import re, subprocess, sys, glob
+          failed = False
+          for path in sorted(glob.glob('app/static/**/*.html', recursive=True)):
+              html = open(path).read()
+              for i, s in enumerate(re.findall(r'<script(?![^>]*src)[^>]*>(.*?)</script>', html, re.S)):
+                  tmp = f'/tmp/{path.replace("/", "_")}.{i}.js'
+                  open(tmp, 'w').write(s)
+                  r = subprocess.run(['node', '--check', tmp], capture_output=True, text=True)
+                  if r.returncode != 0:
+                      print(f'{path} inline script #{i}: SYNTAX ERROR\n{r.stderr}')
+                      failed = True
+          sys.exit(1 if failed else 0)
+          EOF


### PR DESCRIPTION
Follow-up from #94, where a botched merge mangled the Console's single inline `<script>` block (`saveControl()` else-if chain) and `node --check` would have caught it — 317 passing backend tests could not.

## Changes

Adds a `js-syntax` job to `pytest.yml` (snippet from the #94 review, lightly hardened):

- Extracts every inline `<script>` block (skipping `src=` references) from `app/static/**/*.html` and runs `node --check` on each
- Deterministic order (`sorted(glob)`), per-file tmp names so blocks from different files can't collide
- ~30 s, no dependencies beyond preinstalled Node — HTML changes already trigger this workflow since `paths-ignore` only covers `**/*.md` and `docs/**`

## Verification

Ran the exact embedded step locally against the current tree — all 6 inline scripts across 4 HTML files (`index.html`, `example.html`, `powerflow/index.html`, `powerflow/example.html`) parse clean, and the PR #94 head (`853926b`) passes as well. Also negative-tested against a deliberately broken block (fails with file + block index in the message).

— Sam 🔌