### PR TITLE
v0.6.2: Web Console Powerwall Control card (#94)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## Version History
 
-### [0.6.2] - Upcoming
+### [0.6.2] - 2026-09-05
 
 **Added:**
 - **Web Console Powerwall Control card (`PW_CONTROL_SECRET`)** — the Console gains a Powerwall Control card (shown after System Health when a control secret is configured) with mode select (Self-Consumption/Backup/Time-Based), reserve slider + number (0–100), and a token field kept client-side (session-only by default, optional "Remember my token on this device" via `localStorage`). Mode + reserve changes go through the existing `POST /control/*` API with `Authorization: Bearer <token>`; a mode change together with reserve 0 is auto-split into two calls to avoid the Tesla cloud API quirk that can silently drop the mode change. Card availability is exposed by a new unauthenticated `GET /control/status` returning only `{"enabled": bool}`. (#94)

--- a/app/config.py
+++ b/app/config.py
@@ -199,7 +199,7 @@ from pydantic_settings import BaseSettings
 logger = logging.getLogger(__name__)
 
 # Server version
-SERVER_VERSION = "0.6.1"
+SERVER_VERSION = "0.6.2"
 
 
 class GatewayConfig(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypowerwall-server"
-version = "0.6.1"  # Also defined in app/config.py as SERVER_VERSION
+version = "0.6.2"  # Also defined in app/config.py as SERVER_VERSION
 description = "A high-performance FastAPI-based server for monitoring and managing Tesla Powerwall systems"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Cuts the 0.6.2 release per the request in #94.

## Changes
Per the release procedure in `AGENTS.md`:
- `app/config.py`: `SERVER_VERSION = "0.6.2"`
- `pyproject.toml`: `version = "0.6.2"`
- `RELEASE.md`: dated the `[0.6.2]` section `2026-09-05` (section body was already added with the fix commit in #94 — no content changes)

The CI `js-syntax` job from #95 is internal-only, so no release-note entry needed for it.

## Verification
- `pytest`: 317/317 passing at `d5676dd`

Dated 2026-09-05 assuming the container is cut today — happy to adjust if it slips.

— Sam 🔌