### PR TITLE
feat(ui): attach Powerwall 3 expansion rows to leaders

### DIFF
--- a/app/api/legacy.py
+++ b/app/api/legacy.py
@@ -65,6 +65,64 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _device_serial(value: object) -> Optional[str]:
+    """Extract a serial number from a TEDAPI VIN/DIN or plain serial value."""
+    if not isinstance(value, str) or not value:
+        return None
+    return value.rsplit("--", 1)[-1]
+
+
+def _expansion_parent_indexes(
+    system_status: Optional[dict], tedapi_config: Optional[dict]
+) -> dict[int, int]:
+    """Map battery-expansion block indexes to their leader block indexes.
+
+    TEDAPI config stores expansions under their leader while system status exposes
+    each expansion as a separate ``battery_blocks`` entry.  The mapping lets the
+    legacy flat ``/pod`` response retain the parent relationship for the Console.
+    """
+    if not isinstance(system_status, dict) or not isinstance(tedapi_config, dict):
+        return {}
+
+    blocks = system_status.get("battery_blocks") or []
+    if not isinstance(blocks, list):
+        return {}
+
+    serial_to_index = {}
+    for index, block in enumerate(blocks, 1):
+        if not isinstance(block, dict):
+            continue
+        serial = _device_serial(block.get("PackageSerialNumber"))
+        if serial:
+            serial_to_index[serial] = index
+
+    parent_indexes: dict[int, int] = {}
+    config_blocks = tedapi_config.get("battery_blocks") or []
+    if not isinstance(config_blocks, list):
+        return parent_indexes
+
+    for config_block in config_blocks:
+        if not isinstance(config_block, dict):
+            continue
+        leader_serial = _device_serial(
+            config_block.get("vin") or config_block.get("din")
+        )
+        leader_index = serial_to_index.get(leader_serial)
+        if not leader_index:
+            continue
+        for expansion in config_block.get("battery_expansions") or []:
+            if not isinstance(expansion, dict):
+                continue
+            expansion_serial = _device_serial(
+                expansion.get("din") or expansion.get("vin")
+            )
+            expansion_index = serial_to_index.get(expansion_serial)
+            if expansion_index:
+                parent_indexes[expansion_index] = leader_index
+
+    return parent_indexes
+
+
 @router.post("/control/{path:path}")
 async def control_api(
     path: str, data: dict, authorization: Optional[str] = Header(None)
@@ -781,6 +839,9 @@ async def get_pod():
 
     # Get Individual Powerwall Battery Data from cached system_status
     system_status = status.data.system_status
+    expansion_parent_indexes = _expansion_parent_indexes(
+        system_status, status.data.tedapi_config
+    )
     if system_status and "battery_blocks" in system_status:
         idx = 1
         for block in system_status["battery_blocks"]:
@@ -798,6 +859,10 @@ async def get_pod():
             pod[f"PW{idx}_POD_nom_energy_remaining"] = None
             pod[f"PW{idx}_POD_nom_energy_to_be_charged"] = None
             pod[f"PW{idx}_POD_nom_full_pack_energy"] = None
+
+            parent_idx = expansion_parent_indexes.get(idx)
+            if parent_idx:
+                pod[f"PW{idx}_attached_to"] = f"PW{parent_idx}"
 
             # System Status Data
             pod[f"PW{idx}_POD_nom_energy_remaining"] = block.get(
@@ -1804,6 +1869,7 @@ async def pw_version():
     return {"version": version, "vint": vint}
 
 
+
 @router.get("/pw/status")
 async def pw_status():
     """Status summary.
@@ -2168,4 +2234,3 @@ async def get_version():
         pass
 
     return {"version": version, "vint": vint}
-

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -755,6 +755,27 @@
             color: var(--text-primary);
         }
 
+        .powerwall-expansion-row td {
+            color: var(--text-secondary);
+        }
+
+        .powerwall-expansion-row td:first-child {
+            position: relative;
+            padding-left: 32px;
+        }
+
+        .powerwall-expansion-row td:first-child::before {
+            content: "↳";
+            position: absolute;
+            left: 12px;
+            color: var(--accent-blue);
+            font-weight: 600;
+        }
+
+        .powerwall-expansion-name {
+            font-weight: 500;
+        }
+
         .powerwall-model {
             font-size: 1.0em;
             color: var(--text-secondary);
@@ -2489,6 +2510,7 @@
         // isPw3System: gateway-level flag derived from /stats pw3:true (most reliable).
         // Falls back to PackagePartNumber prefix heuristics, then rated capacity.
         function pwModel(partNum, blockType, nomCapWh, isPw3System) {
+            if (blockType === 'BatteryExpansion') return 'Powerwall 3 (Expansion)';
             if (blockType === 'Powerwall3Follower') return 'Powerwall 3 (Follower)';
             if (isPw3System) return 'Powerwall 3';
             if (blockType === 'Powerwall3' || blockType === 'LFPV') return 'Powerwall 3';
@@ -2497,6 +2519,102 @@
             // Powerwall+ part numbers (integrated inverter, ~13.5 kWh)
             if (partNum && /^(1114932|2012170|2849923|3012170-25-)/.test(partNum)) return 'Powerwall +';
             return 'Powerwall 2';
+        }
+
+        function isBatteryExpansion(block, expansionParentBySerial) {
+            return block?.Type === 'BatteryExpansion' ||
+                block?.type === 'BatteryExpansion' ||
+                block?.attached_to != null ||
+                (expansionParentBySerial?.has(deviceSerial(block?.PackageSerialNumber)) ?? false);
+        }
+
+        function deviceSerial(value) {
+            if (typeof value !== 'string' || !value) return null;
+            const parts = value.split('--');
+            return parts[parts.length - 1];
+        }
+
+        // Return rows in the physical hierarchy: each expansion follows its
+        // Powerwall 3 leader, even when system_status lists it later.
+        function arrangePowerwallRows(items, tedapiConfig) {
+            const serialToName = new Map();
+            for (const item of items) {
+                const serial = deviceSerial(item.PackageSerialNumber);
+                if (serial) serialToName.set(serial, item.name);
+            }
+
+            const expansionParentBySerial = new Map();
+            for (const configBlock of (tedapiConfig?.battery_blocks || [])) {
+                const leaderSerial = deviceSerial(configBlock?.vin || configBlock?.din);
+                for (const expansion of (configBlock?.battery_expansions || [])) {
+                    const expansionSerial = deviceSerial(expansion?.din || expansion?.vin);
+                    if (leaderSerial && expansionSerial) {
+                        expansionParentBySerial.set(expansionSerial, leaderSerial);
+                    }
+                }
+            }
+
+            const childrenByParent = new Map();
+            const unmatched = [];
+            for (const item of items) {
+                const configuredParentSerial = expansionParentBySerial.get(
+                    deviceSerial(item.PackageSerialNumber)
+                );
+                const isExpansion = isBatteryExpansion(item, expansionParentBySerial);
+                if (!isExpansion) continue;
+                const parentName = item.attached_to ||
+                    serialToName.get(configuredParentSerial);
+                if (parentName && items.some(candidate =>
+                    candidate.name === parentName &&
+                    !isBatteryExpansion(candidate, expansionParentBySerial))) {
+                    if (!childrenByParent.has(parentName)) childrenByParent.set(parentName, []);
+                    childrenByParent.get(parentName).push(item);
+                } else {
+                    unmatched.push(item);
+                }
+            }
+
+            const rows = [];
+            for (const item of items) {
+                if (isBatteryExpansion(item, expansionParentBySerial)) continue;
+                rows.push({ item, isExpansion: false });
+                for (const child of (childrenByParent.get(item.name) || [])) {
+                    rows.push({ item: child, isExpansion: true });
+                }
+            }
+            for (const item of unmatched) {
+                rows.push({ item, isExpansion: true });
+            }
+            return rows;
+        }
+
+        function powerwallRowHtml(pw, displayName, isExpansion, isPw3System) {
+            const capacity = pw.POD_nom_full_pack_energy || pw.nominal_full_pack_energy;
+            const capacityKwh = capacity ? (capacity / 1000).toFixed(2) : '--';
+            const capacityNum = capacity ? capacity / 1000 : 0;
+            const capacityPct = capacityNum > 0 ? ((capacityNum / 13.5) * 100).toFixed(1) : '--';
+            const capacityClass = capacityNum >= 13.5 ? 'spec-good' : 'spec-warning';
+            const voltage = pw.v_out ? pw.v_out.toFixed(1) : '--';
+            const powerNum = pw.p_out || 0;
+            const power = powerNum !== 0 ? Math.abs(powerNum).toFixed(2) : '--';
+            const powerArrow = powerNum > 0 ? ' ↓' : powerNum < 0 ? ' ↑' : '';
+            const powerArrowClass = powerNum > 0 ? 'arrow-down' : powerNum < 0 ? 'arrow-up' : '';
+            const frequency = pw.f_out ? pw.f_out.toFixed(2) : '--';
+            const model = isExpansion
+                ? 'Powerwall 3 (Expansion)'
+                : pwModel(pw.PackagePartNumber, pw.Type, capacity, isPw3System);
+            const rowClass = isExpansion ? ' class="powerwall-expansion-row"' : '';
+            const nameClass = isExpansion
+                ? 'powerwall-name powerwall-expansion-name'
+                : 'powerwall-name';
+            const name = isExpansion ? 'Expansion' : displayName;
+
+            return `<tr${rowClass}><td class="${nameClass}">${name}</td>` +
+                `<td class="powerwall-model">${model}</td>` +
+                `<td>${capacityKwh} kWh <span class="${capacityClass}">(${capacityPct}%)</span></td>` +
+                `<td>${voltage} V</td>` +
+                `<td>${power} kW<span class="energy-arrow ${powerArrowClass}">${powerArrow}</span></td>` +
+                `<td>${frequency} Hz</td></tr>`;
         }
 
         async function loadPowerwalls() {
@@ -2511,7 +2629,7 @@
                 
                 // Extract Powerwall data
                 const powerwalls = [];
-                const pwRegex = /^(PW\d+)_(POD_nom_full_pack_energy|v_out|p_out|f_out|PackagePartNumber|Type)$/;
+                const pwRegex = /^(PW\d+)_(POD_nom_full_pack_energy|v_out|p_out|f_out|PackagePartNumber|PackageSerialNumber|Type|attached_to)$/;
                 const pwData = {};
                 
                 for (const [key, value] of Object.entries(pod)) {
@@ -2527,6 +2645,7 @@
                 // Convert to array and sort
                 const pwList = Object.entries(pwData).map(([name, data]) => ({ name, ...data }));
                 pwList.sort((a, b) => a.name.localeCompare(b.name));
+                const pwRows = arrangePowerwallRows(pwList);
                 
                 if (pwList.length === 0) {
                     container.innerHTML = '<div class="no-strings">No Powerwall data available</div>';
@@ -2545,29 +2664,13 @@
                 
                 const SPEC_CAPACITY = 13.5; // kWh per Powerwall
                 
-                pwList.forEach(pw => {
-                    const capacity = pw.POD_nom_full_pack_energy ? (pw.POD_nom_full_pack_energy / 1000).toFixed(2) : '--';
-                    const capacityNum = pw.POD_nom_full_pack_energy ? pw.POD_nom_full_pack_energy / 1000 : 0;
-                    const capacityPct = capacityNum > 0 ? ((capacityNum / SPEC_CAPACITY) * 100).toFixed(1) : '--';
-                    const capacityClass = capacityNum >= SPEC_CAPACITY ? 'spec-good' : 'spec-warning';
-                    
-                    const voltage = pw.v_out ? pw.v_out.toFixed(1) : '--';
-                    const powerNum = pw.p_out || 0;
-                    const power = powerNum !== 0 ? Math.abs(powerNum).toFixed(2) : '--';
-                    const powerArrow = powerNum > 0 ? ' ↓' : powerNum < 0 ? ' ↑' : '';
-                    const powerArrowClass = powerNum > 0 ? 'arrow-down' : powerNum < 0 ? 'arrow-up' : '';
-                    const frequency = pw.f_out ? pw.f_out.toFixed(2) : '--';
-                    const model = pwModel(pw.PackagePartNumber, pw.Type, pw.POD_nom_full_pack_energy,
-                        gatewayMeta['default']?.pw3 || window._systemPw3 || false);
-
-                    html += '<tr>';
-                    html += `<td class="powerwall-name">${pw.name}</td>`;
-                    html += `<td class="powerwall-model">${model}</td>`;
-                    html += `<td>${capacity} kWh <span class="${capacityClass}">(${capacityPct}%)</span></td>`;
-                    html += `<td>${voltage} V</td>`;
-                    html += `<td>${power} kW<span class="energy-arrow ${powerArrowClass}">${powerArrow}</span></td>`;
-                    html += `<td>${frequency} Hz</td>`;
-                    html += '</tr>';
+                pwRows.forEach(({ item: pw, isExpansion }) => {
+                    html += powerwallRowHtml(
+                        pw,
+                        pw.name,
+                        isExpansion,
+                        gatewayMeta['default']?.pw3 || window._systemPw3 || false
+                    );
                 });
                 
                 html += '</tbody></table>';
@@ -2761,20 +2864,17 @@
                     if (!blocks.length) { html += '<div class="no-strings">No Powerwall data</div>'; continue; }
                     // Battery table (same columns as single-gateway view)
                     html += '<table class="powerwall-table"><thead><tr><th>Powerwall</th><th>Model</th><th>Capacity</th><th>Voltage</th><th>Power</th><th>Frequency</th></tr></thead><tbody>';
-                    blocks.forEach((block, i) => {
-                        const cap = block.nominal_full_pack_energy;
-                        const capKwh = cap ? (cap / 1000).toFixed(2) : '--';
-                        const capPct = cap ? ((cap / 1000 / SPEC_CAPACITY) * 100).toFixed(1) : '--';
-                        const capClass = cap && cap / 1000 >= SPEC_CAPACITY ? 'spec-good' : 'spec-warning';
-                        const voltage = block.v_out ? block.v_out.toFixed(1) : '--';
-                        const pwr = block.p_out || 0;
-                        const pwrStr = pwr !== 0 ? Math.abs(pwr).toFixed(2) : '--';
-                        const arrow = pwr > 0 ? ' ↓' : pwr < 0 ? ' ↑' : '';
-                        const arrowClass = pwr > 0 ? 'arrow-down' : pwr < 0 ? 'arrow-up' : '';
-                        const freq = block.f_out ? block.f_out.toFixed(2) : '--';
-                        const model = pwModel(block.PackagePartNumber, block.Type, cap,
-                            gatewayMeta[gwId]?.pw3 || false);
-                        html += `<tr><td class="powerwall-name">PW${i + 1}</td><td class="powerwall-model">${model}</td><td>${capKwh} kWh <span class="${capClass}">(${capPct}%)</span></td><td>${voltage} V</td><td>${pwrStr} kW<span class="energy-arrow ${arrowClass}">${arrow}</span></td><td>${freq} Hz</td></tr>`;
+                    const rows = arrangePowerwallRows(
+                        blocks.map((block, i) => ({ ...block, name: `PW${i + 1}` })),
+                        status.data.tedapi_config
+                    );
+                    rows.forEach(({ item: block, isExpansion }) => {
+                        html += powerwallRowHtml(
+                            block,
+                            block.name,
+                            isExpansion,
+                            gatewayMeta[gwId]?.pw3 || false
+                        );
                     });
                     html += '</tbody></table>';
                     // Compact summary row

--- a/tests/test_api_legacy.py
+++ b/tests/test_api_legacy.py
@@ -2,6 +2,7 @@
 import pytest
 from unittest.mock import Mock
 from app.core.scaling import raw_to_tesla_battery_percent
+from app.api.legacy import _expansion_parent_indexes
 
 
 def test_aggregates_endpoint(client, connected_gateway):
@@ -165,6 +166,50 @@ def test_pod_endpoint(client, connected_gateway):
     assert len(data) > 0
     # Should have at least some POD fields from vitals
     assert any(key.startswith("PW1_POD_") for key in data.keys())
+
+
+def test_pod_marks_powerwall_expansion_as_attached_to_leader(
+    client, connected_gateway
+):
+    """Expose the TEDAPI expansion-to-leader relationship in the pod data."""
+    connected_gateway.data.system_status = {
+        "battery_blocks": [
+            {"PackageSerialNumber": "LEADER"},
+            {"PackageSerialNumber": "FOLLOWER"},
+            {"PackageSerialNumber": "EXPANSION", "Type": "BatteryExpansion"},
+        ]
+    }
+    connected_gateway.data.tedapi_config = {
+        "battery_blocks": [
+            {
+                "vin": "1707000-30-L--LEADER",
+                "battery_expansions": [{"din": "1807000-20-B--EXPANSION"}],
+            },
+            {"vin": "1707000-30-L--FOLLOWER"},
+        ]
+    }
+
+    response = client.get("/pod")
+
+    assert response.status_code == 200
+    assert response.json()["PW3_attached_to"] == "PW1"
+
+
+def test_expansion_parent_indexes_ignore_unknown_expansions():
+    """Only expansions present in the current system-status snapshot are mapped."""
+    system_status = {
+        "battery_blocks": [{"PackageSerialNumber": "LEADER"}]
+    }
+    tedapi_config = {
+        "battery_blocks": [
+            {
+                "vin": "1707000-30-L--LEADER",
+                "battery_expansions": [{"din": "1807000-20-B--MISSING"}],
+            }
+        ]
+    }
+
+    assert _expansion_parent_indexes(system_status, tedapi_config) == {}
 
 
 def test_battery_endpoint(client, connected_gateway):


### PR DESCRIPTION
PW3 expansion packs would show up on the "Powerwall Status" as a separate Powerwall. This PR changes the expansion to appear underneath the leader.

Before

<img width="1637" height="422" alt="image" src="https://github.com/user-attachments/assets/2bcd4f70-4380-472b-99e3-c92a263cf393" />


After

<img width="1689" height="423" alt="image" src="https://github.com/user-attachments/assets/530982c5-547c-4927-8e6b-776e8680fc49" />
